### PR TITLE
fix: P2 batch — find_nix PATH walk, CLAUDE.md phase table, quickstart CI (closes #14 #17 #19)

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,55 @@
+name: Fresh-machine quickstart
+
+# Walks the README quickstart on a clean ubuntu-latest to catch drift
+# between docs and code: missing deps, broken install instructions,
+# stale examples. Runs weekly and on PRs touching README or examples.
+#
+# This exercises the offline subset — `cargo install noether-cli` from
+# crates.io is exercised by the release workflow; here we build from
+# source so the README's "Source" install option stays honest.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'docs/getting-started/**'
+      - 'examples/**'
+      - '.github/workflows/quickstart.yml'
+  workflow_dispatch:
+
+jobs:
+  source-install-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build from source (README "Source" option)
+        run: cargo build --release -p noether-cli -p noether-scheduler
+
+      - name: noether version
+        run: ./target/release/noether version
+
+      - name: noether introspect has the expected top-level commands
+        run: |
+          out=$(./target/release/noether introspect)
+          for cmd in stage store run build compose trace; do
+            if ! echo "$out" | grep -q "\"$cmd\""; then
+              echo "::error::\`$cmd\` missing from \`noether introspect\` — README contract drift"
+              exit 1
+            fi
+          done
+
+      - name: Stdlib loads and stage list works
+        run: ./target/release/noether stage list > /tmp/stage-list.json
+
+      - name: Stage list produces valid JSON
+        run: python3 -c 'import json,sys; json.load(open("/tmp/stage-list.json"))'
+
+      - name: Dry-run the built-in example composition
+        if: hashFiles('examples/count-rows.json') != ''
+        run: ./target/release/noether run --dry-run examples/count-rows.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Noether has completed **Phases 0–3** (Foundation, Store + Stdlib, Composition Engine, Agent Interface). The full design spec is in `docs/roadmap.md`.
+Noether has completed **Phases 0–9** per `docs/roadmap.md`, covering
+foundation, stdlib, composition engine, agent interface, hardening,
+effects v2, NixExecutor hardening, cloud-registry hardening, runtime
+budget enforcement, and distributed execution (`noether-grid-*`).
+Treat that file as the source of truth — this summary is prone to
+drifting, `docs/roadmap.md` isn't.
 
 ## Build & Test Commands
 
@@ -102,7 +107,7 @@ Scalar, Collections, Control, I/O, LLM primitives, Data, Noether internal, Text 
 
 ## Architecture (4 Layers)
 
-- **L1 — Nix Execution Layer**: Hermetic sandboxed execution via Nix store (CAS), binary cache, runtime management.
+- **L1 — Nix Execution Layer**: Reproducible Nix-pinned runtime for Python/JS/Bash stages (CAS, binary cache). **Not an isolation boundary** — subprocess inherits host-user privileges. See SECURITY.md.
 - **L2 — Stage Store**: Immutable versioned registry of stages identified by SHA-256 content hash (not name). Lifecycle: draft → active → deprecated → tombstone.
 - **L3 — Composition Engine**: Type checking, DAG verification, execution planning, structured trace output.
 - **L4 — Agent Interface**: ACLI-compliant CLI (the only public API), Composition Agent (LLM-powered), semantic search index.
@@ -125,13 +130,17 @@ Caloron decides **what** to do (sprint planning, task decomposition). Noether de
 | Phase | Focus | Status |
 |---|---|---|
 | 0 | Foundation — type system, hashing, stage schema | **Done** |
-| 1 | Store + Stdlib — 50 stdlib stages, test harness | **Done** |
+| 1 | Store + Stdlib — 76 stdlib stages, test harness | **Done** |
 | 2 | Composition Engine — DAG executor, trace output | **Done** |
 | 3 | Agent Interface — Composition Agent, semantic index | **Done** |
-| 4 | Hardening — deduplication, store health, CI, docs site | **Done** |
-| 5 | noether-cloud foundation — registry API, scheduler, library API | **Done** |
-| 6 | Effects enforcement — Nix sandbox resource limits, effect mismatch errors | Planned |
-| 7 | Public cloud registry — multi-tenant, billing, dashboard | Planned |
+| 4 | Hardening — `noether build`, store dedup, browser target | **Done** |
+| 5 | Effects v2 — `EffectPolicy`, `infer_effects`, `--allow-effects` | **Done** |
+| 6 | NixExecutor hardening — `NixConfig`, error classification, `warmup()` | **Done** |
+| 7 | Cloud Registry hardening — `DELETE /stages/:id`, paginated refresh | **Done** |
+| 8 | Runtime budget enforcement — `BudgetedExecutor`, `--budget-cents` | **Done** |
+| 9 | Grid — subscription pooling — `noether-grid-broker`/`worker` | **Done (v0.4.0)** |
+
+`docs/roadmap.md` is the source of truth; this table will drift otherwise.
 
 ## noether-cloud Architecture
 

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -122,14 +122,15 @@ impl NixExecutor {
         if determinate.exists() {
             return Some(determinate);
         }
-        // Fallback: check PATH
-        if let Ok(output) = Command::new("which").arg("nix").output() {
-            let p = std::str::from_utf8(&output.stdout)
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            if !p.is_empty() {
-                return Some(PathBuf::from(p));
+
+        // Walk $PATH directly rather than spawning `which`. Avoids a
+        // subprocess + the risk that `which` is missing or shadowed on
+        // minimal systems (e.g. some container base images).
+        let path_env = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path_env) {
+            let candidate = dir.join("nix");
+            if candidate.is_file() {
+                return Some(candidate);
             }
         }
         None


### PR DESCRIPTION
## Summary

Three P2 items:

**#17 — find_nix** — walks \`\$PATH\` directly via \`std::env::split_paths\`. Drops the subprocess to \`which\`, which is missing on minimal container images (e.g. \`debian:stable-slim\`, distroless).

**#14 — roadmap vs reality in CLAUDE.md** — project-status line said "Phases 0–3" but the phase table listed up to 5; \`docs/roadmap.md\` is at phase 9. Summary and table rebuilt from the canonical source. Also softened L1 description to match the sandbox-claim downgrade from PR #20.

**#19 — fresh-machine quickstart CI** — new workflow that builds from source (matching the README's "Source" install option), asserts \`noether introspect\` exposes the six advertised top-level commands, and dry-runs an example composition if one ships. Runs weekly + on PRs that touch README / examples.

## Test plan
- [x] \`cargo test --workspace\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Local smoke: \`noether introspect\` returns stage / store / run / build / compose / trace as expected.
- [ ] Workflow dispatch after merge.

Closes #14
Closes #17
Closes #19