### PR TITLE
feat(M1): canonical composition form + semantics + property laws

### DIFF
--- a/crates/noether-engine/src/lagrange/canonical.rs
+++ b/crates/noether-engine/src/lagrange/canonical.rs
@@ -4,7 +4,7 @@
 //! semantically equivalent graphs produce the same byte representation
 //! (and therefore the same composition ID). The rules implemented here
 //! are justified in `docs/architecture/semantics.md`; the property tests
-//! in `crates/noether-core/tests/laws.rs` check every law.
+//! in `crates/noether-engine/tests/laws.rs` check every law.
 //!
 //! Rules (M1):
 //!
@@ -147,13 +147,20 @@ fn canonicalise_node(node: CompositionNode) -> CompositionNode {
             {
                 if inner_delay == delay_ms {
                     let combined = max_attempts.saturating_mul(inner_attempts);
-                    return CompositionNode::Retry {
+                    // Defensive: the combined Retry could itself be subject to
+                    // further node-local collapse (e.g. combined == 1). Re-feed
+                    // through canonicalise_node so one pass is enough
+                    // regardless of input tree shape. Proptest L12 locks
+                    // `canonicalise(canonicalise(g)) == canonicalise(g)`.
+                    return canonicalise_node(CompositionNode::Retry {
                         stage: inner_stage,
                         max_attempts: combined,
                         delay_ms,
-                    };
+                    });
                 }
-                // Different delays: keep the nesting so timing behaviour is preserved.
+                // Different delays: keep the nesting so timing behaviour is
+                // preserved. The inner stage is already canonical because
+                // children were processed bottom-up.
                 return CompositionNode::Retry {
                     stage: Box::new(CompositionNode::Retry {
                         stage: inner_stage,

--- a/crates/noether-engine/src/lagrange/canonical.rs
+++ b/crates/noether-engine/src/lagrange/canonical.rs
@@ -1,0 +1,445 @@
+//! Canonicalisation of composition graphs.
+//!
+//! Rewrites a `CompositionNode` into its canonical form so that
+//! semantically equivalent graphs produce the same byte representation
+//! (and therefore the same composition ID). The rules implemented here
+//! are justified in `docs/architecture/semantics.md`; the property tests
+//! in `crates/noether-core/tests/laws.rs` check every law.
+//!
+//! Rules (M1):
+//!
+//! 1. Flatten nested `Sequential` into a single list, left-to-right.
+//! 2. Collapse singleton `Sequential[s]` to `s`.
+//! 3. `Retry { s, 1, _ }` → `s`.
+//! 4. `Retry { Retry { s, n, d }, m, d }` → `Retry { s, n·m, d }`
+//!    when both delays match.
+//! 5. `Let { {}, body }` → `body`.
+//! 6. `BTreeMap` in `Parallel.branches` and `Let.bindings` already
+//!    guarantees alphabetical ordering in the serialised form; no
+//!    active rewrite needed.
+//!
+//! What is *not* done in M1 (see semantics.md):
+//!
+//! - Stage-level identity detection (needs stage metadata, M2).
+//! - `Const` absorption (`f >> Const` → `Const`) — deferred to M2 so
+//!   this module remains purely structural.
+//! - Dead-branch elimination when `Branch.predicate` is `Const`
+//!   (optimizer territory, M3).
+//!
+//! Canonicalisation is idempotent: `canonicalise(canonicalise(g)) ==
+//! canonicalise(g)`. That's tested as a law.
+
+use crate::lagrange::ast::CompositionNode;
+
+/// Rewrite a node into its canonical form. Recurses through the tree
+/// bottom-up so each parent sees already-canonical children.
+pub fn canonicalise(node: &CompositionNode) -> CompositionNode {
+    // Canonicalise children first (bottom-up), then apply node-local
+    // rewrites. This ordering ensures that e.g. `Sequential
+    // [ Sequential [a, b], c ]` becomes `Sequential [a, b, c]` in a
+    // single pass: the inner Sequential is already flattened when we
+    // look at the outer one.
+    let with_canonical_children = canonicalise_children(node);
+    canonicalise_node(with_canonical_children)
+}
+
+/// Recurse into the structural children of `node`, replacing each with
+/// its canonical form. Leaves atomic nodes (`Stage`, `RemoteStage`,
+/// `Const`) unchanged — they have no structural children.
+fn canonicalise_children(node: &CompositionNode) -> CompositionNode {
+    match node {
+        CompositionNode::Stage { .. }
+        | CompositionNode::RemoteStage { .. }
+        | CompositionNode::Const { .. } => node.clone(),
+
+        CompositionNode::Sequential { stages } => CompositionNode::Sequential {
+            stages: stages.iter().map(canonicalise).collect(),
+        },
+
+        CompositionNode::Parallel { branches } => {
+            // BTreeMap preserves ordering; we just recurse into values.
+            let branches = branches
+                .iter()
+                .map(|(k, v)| (k.clone(), canonicalise(v)))
+                .collect();
+            CompositionNode::Parallel { branches }
+        }
+
+        CompositionNode::Branch {
+            predicate,
+            if_true,
+            if_false,
+        } => CompositionNode::Branch {
+            predicate: Box::new(canonicalise(predicate)),
+            if_true: Box::new(canonicalise(if_true)),
+            if_false: Box::new(canonicalise(if_false)),
+        },
+
+        CompositionNode::Fanout { source, targets } => CompositionNode::Fanout {
+            source: Box::new(canonicalise(source)),
+            targets: targets.iter().map(canonicalise).collect(),
+        },
+
+        CompositionNode::Merge { sources, target } => CompositionNode::Merge {
+            sources: sources.iter().map(canonicalise).collect(),
+            target: Box::new(canonicalise(target)),
+        },
+
+        CompositionNode::Retry {
+            stage,
+            max_attempts,
+            delay_ms,
+        } => CompositionNode::Retry {
+            stage: Box::new(canonicalise(stage)),
+            max_attempts: *max_attempts,
+            delay_ms: *delay_ms,
+        },
+
+        CompositionNode::Let { bindings, body } => {
+            let bindings = bindings
+                .iter()
+                .map(|(k, v)| (k.clone(), canonicalise(v)))
+                .collect();
+            CompositionNode::Let {
+                bindings,
+                body: Box::new(canonicalise(body)),
+            }
+        }
+    }
+}
+
+/// Apply node-local canonicalisation rules, assuming children are
+/// already canonical.
+fn canonicalise_node(node: CompositionNode) -> CompositionNode {
+    match node {
+        // Rule 1 + 2: flatten nested Sequentials and collapse singletons.
+        CompositionNode::Sequential { stages } => {
+            let flattened: Vec<CompositionNode> = stages
+                .into_iter()
+                .flat_map(|s| match s {
+                    CompositionNode::Sequential { stages: inner } => inner,
+                    other => vec![other],
+                })
+                .collect();
+
+            if flattened.len() == 1 {
+                flattened.into_iter().next().unwrap()
+            } else {
+                CompositionNode::Sequential { stages: flattened }
+            }
+        }
+
+        // Rule 3 + 4: single-attempt retry is the inner stage; nested
+        // retries with matching delay multiply attempts.
+        CompositionNode::Retry {
+            stage,
+            max_attempts,
+            delay_ms,
+        } => {
+            if max_attempts <= 1 {
+                return *stage;
+            }
+            if let CompositionNode::Retry {
+                stage: inner_stage,
+                max_attempts: inner_attempts,
+                delay_ms: inner_delay,
+            } = *stage
+            {
+                if inner_delay == delay_ms {
+                    let combined = max_attempts.saturating_mul(inner_attempts);
+                    return CompositionNode::Retry {
+                        stage: inner_stage,
+                        max_attempts: combined,
+                        delay_ms,
+                    };
+                }
+                // Different delays: keep the nesting so timing behaviour is preserved.
+                return CompositionNode::Retry {
+                    stage: Box::new(CompositionNode::Retry {
+                        stage: inner_stage,
+                        max_attempts: inner_attempts,
+                        delay_ms: inner_delay,
+                    }),
+                    max_attempts,
+                    delay_ms,
+                };
+            }
+            CompositionNode::Retry {
+                stage,
+                max_attempts,
+                delay_ms,
+            }
+        }
+
+        // Rule 5: empty Let is the body.
+        CompositionNode::Let { bindings, body } => {
+            if bindings.is_empty() {
+                return *body;
+            }
+            CompositionNode::Let { bindings, body }
+        }
+
+        // Other nodes have no local rewrites in M1.
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noether_core::stage::StageId;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn stage(id: &str) -> CompositionNode {
+        CompositionNode::Stage {
+            id: StageId(id.into()),
+            config: None,
+        }
+    }
+
+    #[test]
+    fn atomic_nodes_unchanged() {
+        assert_eq!(canonicalise(&stage("a")), stage("a"));
+
+        let c = CompositionNode::Const { value: json!(42) };
+        assert_eq!(canonicalise(&c), c);
+    }
+
+    #[test]
+    fn sequential_singleton_collapses() {
+        let g = CompositionNode::Sequential {
+            stages: vec![stage("a")],
+        };
+        assert_eq!(canonicalise(&g), stage("a"));
+    }
+
+    #[test]
+    fn sequential_nested_flattens_left() {
+        // Sequential [ Sequential [a, b], c ]  ->  Sequential [a, b, c]
+        let g = CompositionNode::Sequential {
+            stages: vec![
+                CompositionNode::Sequential {
+                    stages: vec![stage("a"), stage("b")],
+                },
+                stage("c"),
+            ],
+        };
+        let expected = CompositionNode::Sequential {
+            stages: vec![stage("a"), stage("b"), stage("c")],
+        };
+        assert_eq!(canonicalise(&g), expected);
+    }
+
+    #[test]
+    fn sequential_nested_flattens_right() {
+        let g = CompositionNode::Sequential {
+            stages: vec![
+                stage("a"),
+                CompositionNode::Sequential {
+                    stages: vec![stage("b"), stage("c")],
+                },
+            ],
+        };
+        let expected = CompositionNode::Sequential {
+            stages: vec![stage("a"), stage("b"), stage("c")],
+        };
+        assert_eq!(canonicalise(&g), expected);
+    }
+
+    #[test]
+    fn sequential_deeply_nested_flattens() {
+        // Sequential [ Sequential [a, Sequential [b, c]], Sequential [d] ]
+        let g = CompositionNode::Sequential {
+            stages: vec![
+                CompositionNode::Sequential {
+                    stages: vec![
+                        stage("a"),
+                        CompositionNode::Sequential {
+                            stages: vec![stage("b"), stage("c")],
+                        },
+                    ],
+                },
+                CompositionNode::Sequential {
+                    stages: vec![stage("d")],
+                },
+            ],
+        };
+        let expected = CompositionNode::Sequential {
+            stages: vec![stage("a"), stage("b"), stage("c"), stage("d")],
+        };
+        assert_eq!(canonicalise(&g), expected);
+    }
+
+    #[test]
+    fn retry_single_attempt_collapses() {
+        let g = CompositionNode::Retry {
+            stage: Box::new(stage("a")),
+            max_attempts: 1,
+            delay_ms: Some(500),
+        };
+        assert_eq!(canonicalise(&g), stage("a"));
+    }
+
+    #[test]
+    fn retry_zero_attempts_also_collapses() {
+        // Defensive: max_attempts=0 shouldn't wrap at all.
+        let g = CompositionNode::Retry {
+            stage: Box::new(stage("a")),
+            max_attempts: 0,
+            delay_ms: None,
+        };
+        assert_eq!(canonicalise(&g), stage("a"));
+    }
+
+    #[test]
+    fn retry_nested_same_delay_multiplies() {
+        // Retry { Retry { s, 3, 100 }, 4, 100 }  ->  Retry { s, 12, 100 }
+        let g = CompositionNode::Retry {
+            stage: Box::new(CompositionNode::Retry {
+                stage: Box::new(stage("a")),
+                max_attempts: 3,
+                delay_ms: Some(100),
+            }),
+            max_attempts: 4,
+            delay_ms: Some(100),
+        };
+        let expected = CompositionNode::Retry {
+            stage: Box::new(stage("a")),
+            max_attempts: 12,
+            delay_ms: Some(100),
+        };
+        assert_eq!(canonicalise(&g), expected);
+    }
+
+    #[test]
+    fn retry_nested_different_delay_preserved() {
+        let g = CompositionNode::Retry {
+            stage: Box::new(CompositionNode::Retry {
+                stage: Box::new(stage("a")),
+                max_attempts: 3,
+                delay_ms: Some(100),
+            }),
+            max_attempts: 4,
+            delay_ms: Some(200),
+        };
+        // Should stay nested — different delays produce observably
+        // different timing behaviour.
+        let canonical = canonicalise(&g);
+        match canonical {
+            CompositionNode::Retry {
+                stage: outer_stage,
+                max_attempts: 4,
+                delay_ms: Some(200),
+            } => match *outer_stage {
+                CompositionNode::Retry {
+                    max_attempts: 3,
+                    delay_ms: Some(100),
+                    ..
+                } => {}
+                other => panic!("expected inner Retry, got {:?}", other),
+            },
+            other => panic!("expected outer Retry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_let_collapses_to_body() {
+        let g = CompositionNode::Let {
+            bindings: BTreeMap::new(),
+            body: Box::new(stage("body")),
+        };
+        assert_eq!(canonicalise(&g), stage("body"));
+    }
+
+    #[test]
+    fn non_empty_let_preserved() {
+        let mut bindings = BTreeMap::new();
+        bindings.insert("x".into(), stage("compute_x"));
+        let g = CompositionNode::Let {
+            bindings: bindings.clone(),
+            body: Box::new(stage("body")),
+        };
+        assert_eq!(canonicalise(&g), g);
+    }
+
+    #[test]
+    fn canonicalise_is_idempotent() {
+        // Property L12: canonicalise(canonicalise(g)) == canonicalise(g)
+        let g = CompositionNode::Sequential {
+            stages: vec![
+                CompositionNode::Sequential {
+                    stages: vec![stage("a"), stage("b")],
+                },
+                CompositionNode::Retry {
+                    stage: Box::new(stage("c")),
+                    max_attempts: 1,
+                    delay_ms: None,
+                },
+                CompositionNode::Let {
+                    bindings: BTreeMap::new(),
+                    body: Box::new(stage("d")),
+                },
+            ],
+        };
+        let once = canonicalise(&g);
+        let twice = canonicalise(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn parallel_branches_preserved_under_btreemap() {
+        // BTreeMap serialises keys alphabetically, so two Parallels
+        // built from the same {name → branch} set should compare equal
+        // regardless of insertion order.
+        let mut a = BTreeMap::new();
+        a.insert("alpha".into(), stage("x"));
+        a.insert("beta".into(), stage("y"));
+
+        let mut b = BTreeMap::new();
+        b.insert("beta".into(), stage("y"));
+        b.insert("alpha".into(), stage("x"));
+
+        let g1 = CompositionNode::Parallel { branches: a };
+        let g2 = CompositionNode::Parallel { branches: b };
+
+        assert_eq!(canonicalise(&g1), canonicalise(&g2));
+    }
+
+    #[test]
+    fn fanout_target_order_preserved() {
+        // Fanout is ordered; two Fanouts with permuted targets are NOT
+        // semantically equivalent (output is [t1(s), t2(s)] vs
+        // [t2(s), t1(s)]).
+        let g1 = CompositionNode::Fanout {
+            source: Box::new(stage("src")),
+            targets: vec![stage("a"), stage("b")],
+        };
+        let g2 = CompositionNode::Fanout {
+            source: Box::new(stage("src")),
+            targets: vec![stage("b"), stage("a")],
+        };
+        assert_ne!(canonicalise(&g1), canonicalise(&g2));
+    }
+
+    #[test]
+    fn inner_canonicalisation_bubbles_up() {
+        // A Sequential whose child is a collapsible Retry should end up
+        // with the unwrapped stage after one canonicalise call.
+        let g = CompositionNode::Sequential {
+            stages: vec![
+                stage("a"),
+                CompositionNode::Retry {
+                    stage: Box::new(stage("b")),
+                    max_attempts: 1,
+                    delay_ms: Some(50),
+                },
+                stage("c"),
+            ],
+        };
+        let expected = CompositionNode::Sequential {
+            stages: vec![stage("a"), stage("b"), stage("c")],
+        };
+        assert_eq!(canonicalise(&g), expected);
+    }
+}

--- a/crates/noether-engine/src/lagrange/mod.rs
+++ b/crates/noether-engine/src/lagrange/mod.rs
@@ -1,6 +1,8 @@
 mod ast;
+pub mod canonical;
 
 pub use ast::{collect_stage_ids, CompositionGraph, CompositionNode};
+pub use canonical::canonicalise;
 
 use noether_core::stage::{Stage, StageId};
 use noether_store::StageStore;
@@ -206,9 +208,25 @@ pub fn serialize_graph(graph: &CompositionGraph) -> Result<String, serde_json::E
     serde_json::to_string_pretty(graph)
 }
 
-/// Compute a deterministic composition ID (SHA-256 of canonical JSON).
+/// Compute a deterministic composition ID.
+///
+/// The hash is taken over the **canonical form of the graph's root node**,
+/// serialised via JCS (RFC 8785). Metadata fields (`description`,
+/// `version`) do not contribute to the ID: cosmetic edits should not
+/// shift a composition's identity, and equivalent graphs with different
+/// surface syntax (nested Sequentials, permuted Parallel branches,
+/// collapsed Retry layers, etc.) must produce identical IDs.
+///
+/// The canonicalisation rules are documented in
+/// `docs/architecture/semantics.md` and implemented in
+/// `crate::lagrange::canonical`.
+///
+/// **Compatibility note.** This changes composition IDs from the
+/// pre-0.5 byte-of-the-whole-graph hash. Migration guidance lives in
+/// the 0.5.0 release notes.
 pub fn compute_composition_id(graph: &CompositionGraph) -> Result<String, serde_json::Error> {
-    let bytes = serde_json::to_vec(graph)?;
+    let canonical = canonicalise(&graph.root);
+    let bytes = serde_jcs::to_vec(&canonical)?;
     let hash = Sha256::digest(&bytes);
     Ok(hex::encode(hash))
 }

--- a/crates/noether-engine/tests/laws.proptest-regressions
+++ b/crates/noether-engine/tests/laws.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 72e1c8da11669b7895e00d3892a04990ebf6963f8f2e5980d0e03808b4ad248f # shrinks to pairs = [("b", Stage { id: StageId("a"), config: None }), ("b", Stage { id: StageId("b"), config: None })], body = Stage { id: StageId("a"), config: None }
+cc acb09096056496c8c83508ef70a2b1d66f26d93ec40a63a6ffaacb7b5ce9ef45 # shrinks to pairs = [("pe", Stage { id: StageId("a"), config: None }), ("pe", Stage { id: StageId("b"), config: None })]

--- a/crates/noether-engine/tests/laws.rs
+++ b/crates/noether-engine/tests/laws.rs
@@ -1,0 +1,438 @@
+//! Property-based tests for the composition-graph laws stated in
+//! `docs/architecture/semantics.md`.
+//!
+//! Every law in the semantics doc has at least one test here. When the
+//! semantics and the code disagree, one of these fails. When either
+//! changes, both must.
+//!
+//! Strategy: rather than generate arbitrary composition graphs (which
+//! couples test failures to generator quality), we parameterise each
+//! law over a small alphabet of stage IDs, attempt counts, and delays —
+//! enough randomness to catch regressions, specific enough to keep
+//! failures debuggable.
+
+use noether_core::stage::StageId;
+use noether_engine::lagrange::{
+    canonicalise, compute_composition_id, CompositionGraph, CompositionNode,
+};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+// ── generators ──────────────────────────────────────────────────────────────
+
+/// Stage-name alphabet. Short strings are enough; the canonical-form
+/// rewrites never inspect stage IDs beyond equality.
+fn stage_id() -> impl Strategy<Value = StageId> {
+    "[a-z]{1,6}".prop_map(StageId)
+}
+
+fn stage() -> impl Strategy<Value = CompositionNode> {
+    stage_id().prop_map(|id| CompositionNode::Stage { id, config: None })
+}
+
+/// Build a Sequential from a vec of stage IDs.
+fn sequential_of(ids: Vec<&str>) -> CompositionNode {
+    CompositionNode::Sequential {
+        stages: ids
+            .into_iter()
+            .map(|s| CompositionNode::Stage {
+                id: StageId(s.into()),
+                config: None,
+            })
+            .collect(),
+    }
+}
+
+fn st(id: &str) -> CompositionNode {
+    CompositionNode::Stage {
+        id: StageId(id.into()),
+        config: None,
+    }
+}
+
+// ── L1: Sequential associativity (flattening) ───────────────────────────────
+
+proptest! {
+    #[test]
+    fn l1_sequential_associativity_left(
+        a in "[a-z]{1,4}",
+        b in "[a-z]{1,4}",
+        c in "[a-z]{1,4}",
+    ) {
+        // Sequential [ Sequential [a, b], c ]  ≡  Sequential [a, b, c]
+        let left_grouped = CompositionNode::Sequential {
+            stages: vec![sequential_of(vec![&a, &b]), st(&c)],
+        };
+        let flat = sequential_of(vec![&a, &b, &c]);
+        prop_assert_eq!(canonicalise(&left_grouped), flat);
+    }
+
+    #[test]
+    fn l1_sequential_associativity_right(
+        a in "[a-z]{1,4}",
+        b in "[a-z]{1,4}",
+        c in "[a-z]{1,4}",
+    ) {
+        // Sequential [ a, Sequential [b, c] ]  ≡  Sequential [a, b, c]
+        let right_grouped = CompositionNode::Sequential {
+            stages: vec![st(&a), sequential_of(vec![&b, &c])],
+        };
+        let flat = sequential_of(vec![&a, &b, &c]);
+        prop_assert_eq!(canonicalise(&right_grouped), flat);
+    }
+
+    #[test]
+    fn l1_sequential_associativity_both_groupings(
+        ids in prop::collection::vec("[a-z]{1,4}", 2..8),
+    ) {
+        // For any ordered list of stage IDs, both left- and right-grouped
+        // Sequentials canonicalise to the same flat sequence.
+        let ref_ids = ids.iter().map(String::as_str).collect::<Vec<_>>();
+        let flat = sequential_of(ref_ids);
+
+        // Left-grouped: (((a b) c) d) …
+        let mut left = st(&ids[0]);
+        for id in &ids[1..] {
+            left = CompositionNode::Sequential {
+                stages: vec![left, st(id)],
+            };
+        }
+
+        // Right-grouped: (a (b (c d))) …
+        let mut right = st(&ids[ids.len() - 1]);
+        for id in ids[..ids.len() - 1].iter().rev() {
+            right = CompositionNode::Sequential {
+                stages: vec![st(id), right],
+            };
+        }
+
+        prop_assert_eq!(canonicalise(&left), canonicalise(&flat));
+        prop_assert_eq!(canonicalise(&right), canonicalise(&flat));
+    }
+}
+
+// ── L4: Sequential singleton collapse ───────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l4_sequential_singleton_collapses(s in stage()) {
+        let singleton = CompositionNode::Sequential {
+            stages: vec![s.clone()],
+        };
+        prop_assert_eq!(canonicalise(&singleton), s);
+    }
+}
+
+// ── L5: Arbitrary Sequential nesting flattens ───────────────────────────────
+
+proptest! {
+    #[test]
+    fn l5_sequential_deep_nesting_flattens(
+        // 3-7 stages grouped randomly.
+        ids in prop::collection::vec("[a-z]{1,4}", 3..8),
+    ) {
+        let ref_ids = ids.iter().map(String::as_str).collect::<Vec<_>>();
+        let expected = sequential_of(ref_ids);
+
+        // Build a bushy tree by random pairing.
+        let mut nodes: Vec<CompositionNode> = ids.iter().map(|s| st(s)).collect();
+        while nodes.len() > 1 {
+            let right = nodes.pop().unwrap();
+            let left = nodes.pop().unwrap();
+            nodes.push(CompositionNode::Sequential {
+                stages: vec![left, right],
+            });
+        }
+        let bushy = nodes.pop().unwrap();
+
+        prop_assert_eq!(canonicalise(&bushy), expected);
+    }
+}
+
+// ── L6: Parallel branch-name permutation ────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l6_parallel_branch_permutation_stable_id(
+        pairs in prop::collection::vec(
+            ("[a-z]{1,6}", stage()),
+            1..6,
+        ),
+    ) {
+        // Dedupe keys up-front so last-wins ordering does not change the
+        // value under different insertion orders — we want to test that
+        // key-order doesn't matter, not that the last write wins.
+        let canon: BTreeMap<String, CompositionNode> = pairs.into_iter().collect();
+        let entries: Vec<_> = canon.clone().into_iter().collect();
+
+        let mut map_fwd = BTreeMap::new();
+        for (k, v) in &entries {
+            map_fwd.insert(k.clone(), v.clone());
+        }
+        let mut map_rev = BTreeMap::new();
+        for (k, v) in entries.iter().rev() {
+            map_rev.insert(k.clone(), v.clone());
+        }
+
+        let p1 = CompositionNode::Parallel { branches: map_fwd };
+        let p2 = CompositionNode::Parallel { branches: map_rev };
+
+        prop_assert_eq!(canonicalise(&p1), canonicalise(&p2));
+
+        let g1 = CompositionGraph::new("p1", p1);
+        let g2 = CompositionGraph::new("p2", p2);
+        prop_assert_eq!(
+            compute_composition_id(&g1).unwrap(),
+            compute_composition_id(&g2).unwrap()
+        );
+    }
+}
+
+// ── L7: Let binding permutation ─────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l7_let_binding_permutation_stable_id(
+        pairs in prop::collection::vec(
+            ("[a-z]{1,6}", stage()),
+            1..5,
+        ),
+        body in stage(),
+    ) {
+        let canon: BTreeMap<String, CompositionNode> = pairs.into_iter().collect();
+        let entries: Vec<_> = canon.clone().into_iter().collect();
+
+        let mut map_fwd = BTreeMap::new();
+        for (k, v) in &entries {
+            map_fwd.insert(k.clone(), v.clone());
+        }
+        let mut map_rev = BTreeMap::new();
+        for (k, v) in entries.iter().rev() {
+            map_rev.insert(k.clone(), v.clone());
+        }
+
+        let l1 = CompositionNode::Let {
+            bindings: map_fwd,
+            body: Box::new(body.clone()),
+        };
+        let l2 = CompositionNode::Let {
+            bindings: map_rev,
+            body: Box::new(body),
+        };
+
+        prop_assert_eq!(canonicalise(&l1), canonicalise(&l2));
+    }
+}
+
+// ── L9: Retry 1-attempt collapse ────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l9_retry_single_attempt_collapses(
+        s in stage(),
+        delay in prop::option::of(0u64..10_000),
+    ) {
+        let r = CompositionNode::Retry {
+            stage: Box::new(s.clone()),
+            max_attempts: 1,
+            delay_ms: delay,
+        };
+        prop_assert_eq!(canonicalise(&r), s);
+    }
+
+    #[test]
+    fn l9_retry_zero_attempts_also_collapses(
+        s in stage(),
+        delay in prop::option::of(0u64..10_000),
+    ) {
+        // Defensive: zero-attempts Retry is nonsensical; canonicalise
+        // should unwrap rather than leave a never-executing wrapper.
+        let r = CompositionNode::Retry {
+            stage: Box::new(s.clone()),
+            max_attempts: 0,
+            delay_ms: delay,
+        };
+        prop_assert_eq!(canonicalise(&r), s);
+    }
+}
+
+// ── L10: Retry multiplication when delays match ─────────────────────────────
+
+proptest! {
+    #[test]
+    fn l10_retry_nested_same_delay_multiplies(
+        s in stage(),
+        n in 2u32..12,
+        m in 2u32..12,
+        delay in prop::option::of(0u64..1_000),
+    ) {
+        let inner = CompositionNode::Retry {
+            stage: Box::new(s.clone()),
+            max_attempts: n,
+            delay_ms: delay,
+        };
+        let outer = CompositionNode::Retry {
+            stage: Box::new(inner),
+            max_attempts: m,
+            delay_ms: delay,
+        };
+        let expected = CompositionNode::Retry {
+            stage: Box::new(s),
+            max_attempts: n.saturating_mul(m),
+            delay_ms: delay,
+        };
+        prop_assert_eq!(canonicalise(&outer), expected);
+    }
+
+    #[test]
+    fn l10_retry_nested_different_delay_stays_nested(
+        s in stage(),
+        n in 2u32..8,
+        m in 2u32..8,
+        d_inner in prop::option::of(0u64..1_000),
+        d_outer in prop::option::of(0u64..1_000),
+    ) {
+        // Skip the "delays match" case — L10 covers that.
+        prop_assume!(d_inner != d_outer);
+
+        let inner = CompositionNode::Retry {
+            stage: Box::new(s),
+            max_attempts: n,
+            delay_ms: d_inner,
+        };
+        let outer = CompositionNode::Retry {
+            stage: Box::new(inner.clone()),
+            max_attempts: m,
+            delay_ms: d_outer,
+        };
+        let canonical = canonicalise(&outer);
+        // Must remain a Retry wrapping a Retry — timing matters.
+        match canonical {
+            CompositionNode::Retry {
+                stage: outer_stage,
+                max_attempts: outer_attempts,
+                delay_ms: outer_delay,
+            } => {
+                prop_assert_eq!(outer_attempts, m);
+                prop_assert_eq!(outer_delay, d_outer);
+                match *outer_stage {
+                    CompositionNode::Retry {
+                        max_attempts: inner_attempts,
+                        delay_ms: inner_delay,
+                        ..
+                    } => {
+                        prop_assert_eq!(inner_attempts, n);
+                        prop_assert_eq!(inner_delay, d_inner);
+                    }
+                    other => panic!("expected inner Retry, got {:?}", other),
+                }
+            }
+            other => panic!("expected outer Retry, got {:?}", other),
+        }
+    }
+}
+
+// ── L11: Empty Let collapse ─────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l11_empty_let_collapses_to_body(body in stage()) {
+        let l = CompositionNode::Let {
+            bindings: BTreeMap::new(),
+            body: Box::new(body.clone()),
+        };
+        prop_assert_eq!(canonicalise(&l), body);
+    }
+}
+
+// ── L12: Canonicalisation idempotence ───────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn l12_canonicalise_is_idempotent(
+        ids in prop::collection::vec("[a-z]{1,4}", 2..6),
+        retries in prop::collection::vec(0u32..5, 0..4),
+    ) {
+        // Build a tree that exercises several canonical rules at once:
+        // nested Sequentials + a 1-attempt Retry + an empty Let.
+        let mut stages = ids.iter().map(|s| st(s)).collect::<Vec<_>>();
+        if let Some(first_retry) = retries.first() {
+            if !stages.is_empty() {
+                let inner = stages.remove(0);
+                stages.insert(
+                    0,
+                    CompositionNode::Retry {
+                        stage: Box::new(inner),
+                        max_attempts: *first_retry,
+                        delay_ms: None,
+                    },
+                );
+            }
+        }
+        stages.push(CompositionNode::Let {
+            bindings: BTreeMap::new(),
+            body: Box::new(CompositionNode::Sequential {
+                stages: vec![st("inner1"), st("inner2")],
+            }),
+        });
+
+        let g = CompositionNode::Sequential { stages };
+
+        let once = canonicalise(&g);
+        let twice = canonicalise(&once);
+        prop_assert_eq!(once, twice);
+    }
+}
+
+// ── L13: Composition ID stability under equivalent rewrites ─────────────────
+
+proptest! {
+    #[test]
+    fn l13_composition_id_same_for_flattened_vs_nested(
+        ids in prop::collection::vec("[a-z]{1,4}", 2..6),
+    ) {
+        let ref_ids = ids.iter().map(String::as_str).collect::<Vec<_>>();
+        let flat = sequential_of(ref_ids);
+
+        // Left-grouped nested form of the same Sequential.
+        let mut nested = st(&ids[0]);
+        for id in &ids[1..] {
+            nested = CompositionNode::Sequential {
+                stages: vec![nested, st(id)],
+            };
+        }
+
+        let g_flat = CompositionGraph::new("flat", flat);
+        let g_nested = CompositionGraph::new("nested", nested);
+
+        prop_assert_eq!(
+            compute_composition_id(&g_flat).unwrap(),
+            compute_composition_id(&g_nested).unwrap()
+        );
+    }
+
+    #[test]
+    fn l13_composition_id_ignores_description_and_version(
+        s in stage(),
+        desc1 in ".{0,40}",
+        desc2 in ".{0,40}",
+    ) {
+        // Two graphs that differ only in their description or version
+        // must share a composition ID. Cosmetic doc text cannot shift
+        // identity.
+        let g1 = CompositionGraph {
+            description: desc1,
+            root: s.clone(),
+            version: "1.0.0".into(),
+        };
+        let g2 = CompositionGraph {
+            description: desc2,
+            root: s,
+            version: "0.0.1".into(),
+        };
+        prop_assert_eq!(
+            compute_composition_id(&g1).unwrap(),
+            compute_composition_id(&g2).unwrap()
+        );
+    }
+}

--- a/crates/noether-engine/tests/laws.rs
+++ b/crates/noether-engine/tests/laws.rs
@@ -150,77 +150,130 @@ proptest! {
 }
 
 // ── L6: Parallel branch-name permutation ────────────────────────────────────
+//
+// The in-memory `BTreeMap<String, CompositionNode>` already enforces key
+// ordering at construction time — two `Parallel` nodes built from the same
+// pairs with any insertion order compare structurally equal before any
+// canonicalisation runs. That alone would make the test tautological.
+//
+// The real risk is serialisation drift: a JSON reader that doesn't
+// normalise key order could produce different composition IDs for two
+// JSON encodings of the same `Parallel`. These tests construct graphs
+// from JSON with shuffled key order and check that `parse_graph` +
+// `compute_composition_id` produce identical hashes. That validates
+// both `BTreeMap` and the JCS step.
 
 proptest! {
     #[test]
-    fn l6_parallel_branch_permutation_stable_id(
+    fn l6_parallel_json_key_order_is_irrelevant(
         pairs in prop::collection::vec(
-            ("[a-z]{1,6}", stage()),
-            1..6,
+            ("[a-z]{1,6}", "[a-z]{1,6}"),
+            2..6,
         ),
     ) {
-        // Dedupe keys up-front so last-wins ordering does not change the
-        // value under different insertion orders — we want to test that
-        // key-order doesn't matter, not that the last write wins.
-        let canon: BTreeMap<String, CompositionNode> = pairs.into_iter().collect();
-        let entries: Vec<_> = canon.clone().into_iter().collect();
+        // Dedupe to avoid last-wins asymmetry across permutations.
+        let canon: BTreeMap<String, String> = pairs.into_iter().collect();
+        prop_assume!(canon.len() >= 2);
 
-        let mut map_fwd = BTreeMap::new();
-        for (k, v) in &entries {
-            map_fwd.insert(k.clone(), v.clone());
-        }
-        let mut map_rev = BTreeMap::new();
-        for (k, v) in entries.iter().rev() {
-            map_rev.insert(k.clone(), v.clone());
-        }
+        // Build JSON with fwd-ordered keys.
+        let fwd_branches: serde_json::Map<String, serde_json::Value> = canon
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::json!({"op": "Stage", "id": v})))
+            .collect();
+        let fwd_json = serde_json::json!({
+            "description": "fwd",
+            "version": "0.1.0",
+            "root": {"op": "Parallel", "branches": fwd_branches},
+        });
 
-        let p1 = CompositionNode::Parallel { branches: map_fwd };
-        let p2 = CompositionNode::Parallel { branches: map_rev };
+        // Build JSON with reversed key order. Since serde_json::Map
+        // preserves insertion order, this really does produce a
+        // different byte sequence for the unsorted form.
+        let rev_branches: serde_json::Map<String, serde_json::Value> = canon
+            .iter()
+            .rev()
+            .map(|(k, v)| (k.clone(), serde_json::json!({"op": "Stage", "id": v})))
+            .collect();
+        let rev_json = serde_json::json!({
+            "description": "rev",
+            "version": "0.1.0",
+            "root": {"op": "Parallel", "branches": rev_branches},
+        });
 
-        prop_assert_eq!(canonicalise(&p1), canonicalise(&p2));
+        // Pre-normalisation JSON bytes should differ (sanity: otherwise
+        // the test isn't exercising permutation at all).
+        prop_assume!(
+            serde_json::to_string(&fwd_json).unwrap()
+                != serde_json::to_string(&rev_json).unwrap()
+        );
 
-        let g1 = CompositionGraph::new("p1", p1);
-        let g2 = CompositionGraph::new("p2", p2);
+        let g_fwd: CompositionGraph = serde_json::from_value(fwd_json).unwrap();
+        let g_rev: CompositionGraph = serde_json::from_value(rev_json).unwrap();
+
+        // Canonical AST equal.
+        prop_assert_eq!(canonicalise(&g_fwd.root), canonicalise(&g_rev.root));
+
+        // Composition IDs equal (this is the law the claim is about).
         prop_assert_eq!(
-            compute_composition_id(&g1).unwrap(),
-            compute_composition_id(&g2).unwrap()
+            compute_composition_id(&g_fwd).unwrap(),
+            compute_composition_id(&g_rev).unwrap()
         );
     }
 }
 
 // ── L7: Let binding permutation ─────────────────────────────────────────────
+//
+// Same rationale as L6 — enforce permutation invariance end-to-end
+// through JSON rather than trivially via BTreeMap.
 
 proptest! {
     #[test]
-    fn l7_let_binding_permutation_stable_id(
+    fn l7_let_json_binding_order_is_irrelevant(
         pairs in prop::collection::vec(
-            ("[a-z]{1,6}", stage()),
-            1..5,
+            ("[a-z]{1,6}", "[a-z]{1,6}"),
+            2..5,
         ),
-        body in stage(),
+        body_id in "[a-z]{1,6}",
     ) {
-        let canon: BTreeMap<String, CompositionNode> = pairs.into_iter().collect();
-        let entries: Vec<_> = canon.clone().into_iter().collect();
+        let canon: BTreeMap<String, String> = pairs.into_iter().collect();
+        prop_assume!(canon.len() >= 2);
 
-        let mut map_fwd = BTreeMap::new();
-        for (k, v) in &entries {
-            map_fwd.insert(k.clone(), v.clone());
-        }
-        let mut map_rev = BTreeMap::new();
-        for (k, v) in entries.iter().rev() {
-            map_rev.insert(k.clone(), v.clone());
-        }
-
-        let l1 = CompositionNode::Let {
-            bindings: map_fwd,
-            body: Box::new(body.clone()),
-        };
-        let l2 = CompositionNode::Let {
-            bindings: map_rev,
-            body: Box::new(body),
+        let mk_bindings = |iter: Box<dyn Iterator<Item = (&String, &String)>>|
+            -> serde_json::Map<String, serde_json::Value>
+        {
+            iter.map(|(k, v)| (k.clone(), serde_json::json!({"op": "Stage", "id": v})))
+                .collect()
         };
 
-        prop_assert_eq!(canonicalise(&l1), canonicalise(&l2));
+        let fwd_bindings = mk_bindings(Box::new(canon.iter()));
+        let rev_bindings = mk_bindings(Box::new(canon.iter().rev()));
+
+        let body = serde_json::json!({"op": "Stage", "id": body_id});
+
+        let fwd_json = serde_json::json!({
+            "description": "fwd",
+            "version": "0.1.0",
+            "root": {"op": "Let", "bindings": fwd_bindings, "body": body.clone()},
+        });
+        let rev_json = serde_json::json!({
+            "description": "rev",
+            "version": "0.1.0",
+            "root": {"op": "Let", "bindings": rev_bindings, "body": body},
+        });
+
+        prop_assume!(
+            serde_json::to_string(&fwd_json).unwrap()
+                != serde_json::to_string(&rev_json).unwrap()
+        );
+
+        let g_fwd: CompositionGraph = serde_json::from_value(fwd_json).unwrap();
+        let g_rev: CompositionGraph = serde_json::from_value(rev_json).unwrap();
+
+        prop_assert_eq!(canonicalise(&g_fwd.root), canonicalise(&g_rev.root));
+        prop_assert_eq!(
+            compute_composition_id(&g_fwd).unwrap(),
+            compute_composition_id(&g_rev).unwrap()
+        );
     }
 }
 
@@ -329,6 +382,35 @@ proptest! {
             }
             other => panic!("expected outer Retry, got {:?}", other),
         }
+    }
+}
+
+// L10 (deep): deeper-than-2 nested Retries with matching delays collapse in
+// one canonicalise pass.
+proptest! {
+    #[test]
+    fn l10_retry_deep_nesting_collapses_fully(
+        s in stage(),
+        attempts in prop::collection::vec(2u32..8, 3..6),
+        delay in prop::option::of(0u64..1_000),
+    ) {
+        // Build k-level nested Retry with the same delay_ms at every level.
+        let mut node = s.clone();
+        let mut product: u32 = 1;
+        for &n in &attempts {
+            product = product.saturating_mul(n);
+            node = CompositionNode::Retry {
+                stage: Box::new(node),
+                max_attempts: n,
+                delay_ms: delay,
+            };
+        }
+        let expected = CompositionNode::Retry {
+            stage: Box::new(s),
+            max_attempts: product,
+            delay_ms: delay,
+        };
+        prop_assert_eq!(canonicalise(&node), expected);
     }
 }
 

--- a/docs/architecture/semantics.md
+++ b/docs/architecture/semantics.md
@@ -2,7 +2,7 @@
 
 The denotational meaning of each composition operator in the Lagrange
 graph language. This document is the **contract**: every property test in
-`crates/noether-core/tests/laws.rs` checks a law stated here, and every
+`crates/noether-engine/tests/laws.rs` checks a law stated here, and every
 canonicalisation rule in `crates/noether-engine/src/lagrange/canonical.rs`
 is justified by one of these equivalences.
 
@@ -229,8 +229,10 @@ A graph is in **canonical form** when all of the following hold:
 4. **Let bindings sorted alphabetically** by name (same).
 5. **Retry collapse.** `Retry { _, 1, _ }` → inner stage. `Retry { Retry
    { s, n, d }, m, d }` → `Retry { s, n·m, d }`.
-6. **Empty Let collapse.** `Let { {}, body }` → `body` if body is
-   independent of shadowed fields (conservative: always).
+6. **Empty Let collapse.** `Let { {}, body }` → `body`. With no bindings
+   there are no shadowed fields, so the rewrite is always safe — the
+   "body must be independent of shadowed fields" qualifier of the general
+   semantics is vacuous.
 
 The canonical form is what the composition ID hashes. Two graphs with
 the same canonical form are semantically equivalent; two graphs with
@@ -251,26 +253,33 @@ cost of keeping M1's canonicalisation fast and bug-unlikely.
 
 ## Equivalence claims testable in `laws.rs`
 
-Every item below is one proptest.
+### Tested in M1
+
+Every item below has at least one proptest in `laws.rs`:
 
 | Law | Statement |
 |-----|-----------|
 | `L1` Sequential associativity | `flatten(Sequential[Sequential[a,b], c]) == Sequential[a,b,c]` |
-| `L2` Sequential left identity | `canonicalise(Sequential[id_stage, f]) ≡ f` |
-| `L3` Sequential right identity | `canonicalise(Sequential[f, id_stage]) ≡ f` |
 | `L4` Sequential singleton | `canonicalise(Sequential[a]) == a` |
 | `L5` Sequential nested flatten | any nesting of Sequentials produces a flat equivalent |
-| `L6` Parallel permutation | two Parallels with permuted branch sets produce equal canonical forms |
-| `L7` Let binding permutation | two Lets with permuted bindings produce equal canonical forms |
-| `L8` Const absorption | `canonicalise(Sequential[f, Const{v}]) ≡ Const{v}` (M2; skipped in M1) |
+| `L6` Parallel permutation | permuting branch-key insertion order yields an equal composition ID (JSON-level test — BTreeMap in-memory already enforces this; the test catches serialisation drift) |
+| `L7` Let binding permutation | permuting binding-key insertion order yields an equal composition ID (same rationale as L6) |
 | `L9` Retry 1-attempt collapse | `canonicalise(Retry{s, 1, _}) == s` |
 | `L10` Retry multiplication | `canonicalise(Retry{Retry{s, n, d}, m, d}) == Retry{s, n·m, d}` |
 | `L11` Empty Let collapse | `canonicalise(Let{{}, body}) == body` |
 | `L12` Canonicalisation is idempotent | `canonicalise(canonicalise(g)) == canonicalise(g)` |
 | `L13` Composition ID stability | `compute_composition_id(g) == compute_composition_id(permuted_but_equivalent(g))` |
 
-Laws `L8`, `L9`, `L10` depend on canonical rules that materialise in M1
-(`L9`, `L10`, `L11`) vs M2+ (`L8`).
+### Deferred — claims stand but tests ship in a later milestone
+
+These laws are true by the semantics above; proptests land alongside the
+canonical-form rules that realise them.
+
+| Law | Statement | Ships with |
+|-----|-----------|------------|
+| `L2` Sequential left identity | `canonicalise(Sequential[id_stage, f]) ≡ f` | M2 (stage-level identity detection needs stage metadata) |
+| `L3` Sequential right identity | `canonicalise(Sequential[f, id_stage]) ≡ f` | M2 (same) |
+| `L8` Const absorption | `canonicalise(Sequential[f, Const{v}]) ≡ Const{v}` | M2 (rewrite is semantics-preserving but deferred to M2 optimiser) |
 
 ---
 

--- a/docs/architecture/semantics.md
+++ b/docs/architecture/semantics.md
@@ -1,0 +1,299 @@
+# Composition Semantics
+
+The denotational meaning of each composition operator in the Lagrange
+graph language. This document is the **contract**: every property test in
+`crates/noether-core/tests/laws.rs` checks a law stated here, and every
+canonicalisation rule in `crates/noether-engine/src/lagrange/canonical.rs`
+is justified by one of these equivalences.
+
+When the code and this doc disagree, fix the code. When a new operator
+or property ships without a corresponding entry here, the review blocks.
+
+---
+
+## Notation
+
+We write stage/graph execution as a function:
+
+```
+⟦g⟧ : Input → Output
+```
+
+For composition:
+
+```
+⟦f >> g⟧(x) = ⟦g⟧(⟦f⟧(x))
+```
+
+Two graphs `g₁` and `g₂` are **semantically equivalent** when
+`⟦g₁⟧(x) = ⟦g₂⟧(x)` for all inputs `x` in their common input type.
+Canonicalisation rewrites any graph to a representative of its semantic
+equivalence class; the composition ID hashes the representative, so
+equivalent graphs share an ID.
+
+---
+
+## Operators
+
+### `Stage { id, config }` — reference to a stored stage
+
+```
+⟦Stage { id, config }⟧(x) = stage_impl(id)(merge(config, x))
+```
+
+When `config` is `None`, the stage receives `x` unchanged. When `config`
+is present, `config` fields are merged into `x` before the stage runs —
+fields in `x` override fields in `config`.
+
+**Identity.** `Stage { id = "id/any", config = None }` is the identity
+for any input type it supports, modulo the stdlib `id` stage being
+present. This gives:
+
+```
+id >> f ≡ f
+f >> id ≡ f
+```
+
+### `RemoteStage { url, input, output }` — call a remote Noether
+
+```
+⟦RemoteStage { url, input, output }⟧(x) = http_post(url, x)
+```
+
+The type checker uses the declared `input` and `output` types; actual
+execution dispatches to a remote composition. Equivalence with a local
+Stage is *not* enforced: a remote implementation may differ. Two
+`RemoteStage`s are equivalent iff their `url`, `input`, and `output` are
+identical.
+
+### `Const { value }` — ignore input, emit constant
+
+```
+⟦Const { value }⟧(x) = value
+```
+
+**Absorption.** Const absorbs any prefix:
+
+```
+f >> Const { v } ≡ Const { v }         for any f
+```
+
+### `Sequential { stages }` — left-to-right pipeline
+
+```
+⟦Sequential { [s₁, s₂, …, sₙ] }⟧(x) = ⟦sₙ⟧(⟦sₙ₋₁⟧(…⟦s₁⟧(x)…))
+```
+
+**Associativity.** Nested Sequentials flatten:
+
+```
+Sequential [ Sequential [a, b], c ]   ≡  Sequential [a, b, c]
+Sequential [ a, Sequential [b, c] ]   ≡  Sequential [a, b, c]
+Sequential [ Sequential [a, b], Sequential [c, d] ]  ≡  Sequential [a, b, c, d]
+```
+
+**Identity collapse.** A singleton Sequential is the stage itself:
+
+```
+Sequential [a]  ≡  a
+```
+
+The empty Sequential is rejected at construction time; it has no
+well-defined input/output types.
+
+### `Parallel { branches }` — fan-in then per-branch dispatch
+
+```
+⟦Parallel { {k₁ → b₁, k₂ → b₂, …} }⟧(x) = { k₁: ⟦b₁⟧(x[k₁] or x),
+                                              k₂: ⟦b₂⟧(x[k₂] or x),
+                                              … }
+```
+
+Each branch receives `x[kᵢ]` when `x` is a Record with a key matching the
+branch name; otherwise it receives the full `x`. The output is a Record
+keyed by branch names.
+
+**Branch-name commutativity.** Parallel with branches `{a → X, b → Y}`
+is semantically equivalent to `{b → Y, a → X}` — the branch map is a
+set of name→graph pairs, not an ordered list. The JSON representation is
+normalised by sorting keys alphabetically (the `BTreeMap` in
+`ast.rs` already enforces this in-memory).
+
+### `Fanout { source, targets }` — same source to many targets
+
+```
+⟦Fanout { source, targets = [t₁, …, tₙ] }⟧(x) =
+  let s = ⟦source⟧(x) in
+  [⟦t₁⟧(s), ⟦t₂⟧(s), …, ⟦tₙ⟧(s)]
+```
+
+**Target order matters.** Unlike `Parallel`, Fanout's output is a list
+indexed by position; swapping targets changes the output. Canonicalisation
+does NOT reorder `Fanout` targets.
+
+**Equivalence with Parallel.** `Fanout { source, [t₁, t₂] }` is
+semantically equivalent to `source >> Parallel { { "0": t₁, "1": t₂ } }`
+only up to output shape (list vs record). Not an identity; don't rewrite.
+
+### `Branch { predicate, if_true, if_false }` — conditional routing
+
+```
+⟦Branch { p, t, f }⟧(x) =
+  if ⟦p⟧(x) then ⟦t⟧(x) else ⟦f⟧(x)
+```
+
+The predicate stage must produce a Bool; this is a type-checker
+requirement, not a runtime one.
+
+**Dead-branch elimination.** When the predicate is `Const { true }`:
+
+```
+Branch { Const true, t, f }  ≡  t
+Branch { Const false, t, f }  ≡  f
+```
+
+Canonicalisation applies this rewrite in M3 (the optimizer milestone),
+not in M1 — M1 treats Branch as opaque.
+
+### `Merge { sources, target }` — fan-in to one target
+
+```
+⟦Merge { [s₁, …, sₙ], target }⟧(x) =
+  let outputs = [⟦s₁⟧(x), …, ⟦sₙ⟧(x)] in
+  ⟦target⟧(outputs)
+```
+
+The target receives a list of source outputs in source-order.
+
+**Source ordering.** Source order is semantically significant — the list
+passed to `target` is ordered by the input list. Canonicalisation does
+NOT reorder sources. If the target is commutative (e.g., `sum`), the
+*user* should write a Parallel-plus-reduce pattern instead.
+
+### `Retry { stage, max_attempts, delay_ms }` — retry on failure
+
+```
+⟦Retry { s, n, d }⟧(x) =
+  try ⟦s⟧(x)
+  catch error-that-is-retryable:
+    sleep d ms
+    retry up to n-1 more times
+```
+
+**Fixed-point when max_attempts = 1.** `Retry { s, 1, _ }` is
+semantically equivalent to `s`. Canonicalisation applies this.
+
+**Nested retry collapse.** Two nested `Retry`s with the same `delay_ms`
+multiply their attempt counts:
+
+```
+Retry { Retry { s, n, d }, m, d }  ≡  Retry { s, n·m, d }
+```
+
+Canonicalisation applies this only when `delay_ms` matches (different
+delays produce observably different timing and are NOT equivalent).
+
+### `Let { bindings, body }` — let-bindings with shared outer input
+
+```
+⟦Let { {k₁ → b₁, …}, body }⟧(x) =
+  let bs = { k₁: ⟦b₁⟧(x), k₂: ⟦b₂⟧(x), … } in
+  ⟦body⟧({ ...x, ...bs })
+```
+
+All bindings receive the *outer* input `x` — there is no inter-binding
+dependency ordering. The body receives a Record that is `x` extended
+with the binding outputs; binding names that collide with fields in `x`
+shadow them.
+
+**Binding name commutativity.** Like Parallel, the binding map is a set
+of name→graph pairs; ordering is not semantic. BTreeMap enforces
+alphabetical key order in the serialised form.
+
+**Empty-binding collapse.** `Let { {}, body }` is semantically equivalent
+to `body` when body doesn't reference any shadowed fields. Canonicalisation
+applies this.
+
+---
+
+## Canonical form
+
+A graph is in **canonical form** when all of the following hold:
+
+1. **No nested Sequentials.** Every `Sequential { stages }` has no child
+   that is itself `Sequential`. Flattened in left-to-right order.
+2. **No singleton Sequentials.** `Sequential { [s] }` is rewritten to
+   `s`.
+3. **Parallel branches sorted alphabetically** by name (BTreeMap already
+   guarantees this in serialisation; we verify on deserialisation).
+4. **Let bindings sorted alphabetically** by name (same).
+5. **Retry collapse.** `Retry { _, 1, _ }` → inner stage. `Retry { Retry
+   { s, n, d }, m, d }` → `Retry { s, n·m, d }`.
+6. **Empty Let collapse.** `Let { {}, body }` → `body` if body is
+   independent of shadowed fields (conservative: always).
+
+The canonical form is what the composition ID hashes. Two graphs with
+the same canonical form are semantically equivalent; two graphs with
+different canonical forms *may* still be semantically equivalent (e.g.,
+M3 will add more rewrites), but we accept that false-negative as the
+cost of keeping M1's canonicalisation fast and bug-unlikely.
+
+**What canonicalisation does NOT do in M1:**
+
+- Stage-level identity detection ("is this stage definitionally
+  identity?") — needs stage metadata, deferred to M2.
+- Dead-branch elimination with Const predicate — deferred to M3.
+- Parallel/Fanout cross-conversion — not equivalent (output shape).
+- Cross-node fusion — optimizer territory, deferred to M3.
+- Type-aware rewrites — canonicalisation is syntactic in M1.
+
+---
+
+## Equivalence claims testable in `laws.rs`
+
+Every item below is one proptest.
+
+| Law | Statement |
+|-----|-----------|
+| `L1` Sequential associativity | `flatten(Sequential[Sequential[a,b], c]) == Sequential[a,b,c]` |
+| `L2` Sequential left identity | `canonicalise(Sequential[id_stage, f]) ≡ f` |
+| `L3` Sequential right identity | `canonicalise(Sequential[f, id_stage]) ≡ f` |
+| `L4` Sequential singleton | `canonicalise(Sequential[a]) == a` |
+| `L5` Sequential nested flatten | any nesting of Sequentials produces a flat equivalent |
+| `L6` Parallel permutation | two Parallels with permuted branch sets produce equal canonical forms |
+| `L7` Let binding permutation | two Lets with permuted bindings produce equal canonical forms |
+| `L8` Const absorption | `canonicalise(Sequential[f, Const{v}]) ≡ Const{v}` (M2; skipped in M1) |
+| `L9` Retry 1-attempt collapse | `canonicalise(Retry{s, 1, _}) == s` |
+| `L10` Retry multiplication | `canonicalise(Retry{Retry{s, n, d}, m, d}) == Retry{s, n·m, d}` |
+| `L11` Empty Let collapse | `canonicalise(Let{{}, body}) == body` |
+| `L12` Canonicalisation is idempotent | `canonicalise(canonicalise(g)) == canonicalise(g)` |
+| `L13` Composition ID stability | `compute_composition_id(g) == compute_composition_id(permuted_but_equivalent(g))` |
+
+Laws `L8`, `L9`, `L10` depend on canonical rules that materialise in M1
+(`L9`, `L10`, `L11`) vs M2+ (`L8`).
+
+---
+
+## Notes on future milestones
+
+- **M2 adds property predicates to stages** — not new operators. Semantics
+  above stand.
+- **M3 adds type-system additions** (parametric polymorphism, row
+  polymorphism, refinement types) — may require new equivalences, e.g.,
+  `sort<Number>` and `sort<Text>` canonicalise to the same
+  signature-polymorphic stage. Those rewrites join canonical.rs in M3.
+- **M3 optimizer rewrites** (Pure-fusion, invariant hoisting) are
+  semantically preserving but not part of canonical form — they happen on
+  an already-canonical graph and produce an optimised execution plan.
+  Composition ID is computed from the canonical form *before*
+  optimisation, so optimiser work doesn't change the ID.
+
+---
+
+## Why this matters
+
+Without a written semantics doc, every canonicalisation rule and every
+property test is a judgement call. With one, they are either consistent
+with this doc or they're bugs. That's the entire value of doing this
+work before implementing the laws — the contract exists first, the code
+proves it later.

--- a/docs/roadmap/2026-04-18-rock-solid-plan.md
+++ b/docs/roadmap/2026-04-18-rock-solid-plan.md
@@ -47,7 +47,7 @@ identically.
   `Retry`, `Const`, `Let`, `Merge`, `Stage`). Input/output relation,
   associativity, identity laws. English + sketched equations. Not
   category-theory notation; prose that an engineer understands.
-- `crates/noether-core/tests/laws.rs` — proptest suite with one test per
+- `crates/noether-engine/tests/laws.rs` — proptest suite with one test per
   claimed law:
   - `Sequential` associativity: `(a >> b) >> c ≡ a >> (b >> c)`
   - Left/right identity: `id >> f ≡ f ≡ f >> id`

--- a/docs/roadmap/2026-04-18-rock-solid-plan.md
+++ b/docs/roadmap/2026-04-18-rock-solid-plan.md
@@ -1,0 +1,299 @@
+# Noether 1.0 — Rock-Solid Roadmap
+
+**Status:** Draft · 2026-04-18
+**Scope:** 12-month plan, 4 milestones, target end-state = Noether 1.0 with a
+written stability contract, property-tested semantics, canonical content
+addressing, one curated vertical, one external user.
+
+---
+
+## Premise
+
+Today Noether is v0.4.1. The composition engine works. The type checker
+works. `noether compose` works for narrow problems. What's missing before
+1.0 is the set of properties that let someone build a multi-year project
+on top without being bitten.
+
+"Rock-solid" operationally means five things:
+
+1. **Content addressing is canonical.** Two syntactically different but
+   semantically equivalent graphs produce identical composition IDs. Today
+   they don't.
+2. **Stage semantics are enforceable.** Property predicates are first-class
+   alongside examples. Reuse is safe beyond types.
+3. **Stability contract is in writing.** Stage signature IDs stable across
+   1.x. Implementation fixes don't break pinning. Operator semantics
+   frozen. Stdlib semantics frozen.
+4. **Stdlib is curated, not accreted.** Admission criteria, deprecation
+   path, naming convention. Unix stdlib discipline, not npm sprawl.
+5. **One real external user.** Not Alfonso. Published case study.
+
+Everything below is in service of those five.
+
+---
+
+## Milestones
+
+### M1 — Semantics + Canonical Form (Months 0–3, ship as v0.5.0)
+
+**Goal.** Every claim Noether makes about composition is either
+property-tested or explicitly marked informal. Equivalent graphs hash
+identically.
+
+**Deliverables.**
+
+- `docs/architecture/semantics.md` — two-page formal-ish semantics for
+  each composition operator (`Sequential`, `Parallel`, `Fanout`, `Branch`,
+  `Retry`, `Const`, `Let`, `Merge`, `Stage`). Input/output relation,
+  associativity, identity laws. English + sketched equations. Not
+  category-theory notation; prose that an engineer understands.
+- `crates/noether-core/tests/laws.rs` — proptest suite with one test per
+  claimed law:
+  - `Sequential` associativity: `(a >> b) >> c ≡ a >> (b >> c)`
+  - Left/right identity: `id >> f ≡ f ≡ f >> id`
+  - `Fanout` = Diagonal ∘ Parallel
+  - `Parallel` branch-name permutation invariance
+  - `Const` absorbs input
+  - `Let` is compositional
+  1000 cases per law.
+- `crates/noether-engine/src/lagrange/canonical.rs` — canonicalisation
+  pass:
+  - Flatten nested `Sequential`s into a single N-ary Sequential
+  - Sort `Parallel` branches by name
+  - Drop identity stages
+  - Normalise `Let` binding order
+  - Normalise `Merge` source order (alphabetical by subgraph composition ID)
+- `compute_composition_id` runs canonicalisation before hashing. This is
+  breaking for composition IDs persisted in v0.4.x — that's expected.
+- `noether-engine::agent::CompositionAgent` emits canonical form by default.
+
+**Exit criteria.**
+
+- All `laws.rs` proptest cases pass with 1000 iterations each
+- Two syntactically different semantically equivalent graphs produce
+  identical composition IDs (new integration test)
+- v0.5.0 tagged and released with explicit breaking-change note about
+  composition ID stability
+
+**Risks.**
+
+- Canonical ordering surfaces existing operator bugs → budget fix time
+- Users who pinned v0.4.x composition IDs need a one-time migration →
+  ship a `noether trace migrate-ids` script
+
+**Rough size.** ~1500 new LOC + ~300 modified.
+
+---
+
+### M2 — Stability + Versioning + Property Predicates (Months 3–6, ship as v0.6.0)
+
+**Goal.** Stages can evolve without breaking downstream graphs. Stage
+semantics are expressible, testable claims — not docstring prose.
+
+**Deliverables.**
+
+- `STABILITY.md` — signed, public contract:
+  - Stage **signature IDs** are stable across 1.x minor and patch releases
+  - Stage **implementation IDs** may change on bugfixes
+  - Composition operator semantics are frozen at 1.0
+  - Graph JSON schema is additive-only within 1.x
+  - Stdlib stage semantics are frozen; new behaviour ships as a new stage
+- `StageId` split into two fields in the serialised Stage format:
+  ```json
+  { "signature_id": "sha256-of-canonical-signature",
+    "implementation_id": "sha256-of-impl-source" }
+  ```
+  Backwards-compat: until v0.7.0, legacy single-field `"id"` still accepted.
+- Graph `pinning` field (per-node, optional):
+  - `"pinning": "signature"` (default) — latest implementation for this signature
+  - `"pinning": "both"` — bit-reproducible, refuses implementation drift
+- `properties` array on stage specs — minimal DSL:
+  - Set membership: `output.severity in {"CRITICAL","HIGH","WARNING"}`
+  - Arithmetic: `output.soc_percent >= 0 and output.soc_percent <= 100`
+  - Universally-quantified implications over examples:
+    `for all examples, if input.battery.soc_percent is null then output is null`
+  - No higher-order quantification, no type-class predicates in M2
+- `noether stage verify --with-properties` — runs stage against
+  property-based inputs plus the declared predicates
+- Registry stores both IDs; clients resolve `signature → latest
+  implementation` by default
+
+**Exit criteria.**
+
+- A deliberately buggy stage fix that changes implementation hash but not
+  signature hash leaves all existing graphs operational (integration test)
+- Every stdlib stage ships with ≥3 properties
+- `STABILITY.md` committed, linked from README
+- v0.6.0 released
+
+**Risks.**
+
+- Property DSL scope creep — keep the M2 version tiny, push
+  higher-order features to post-1.0
+- Splitting StageId breaks external tooling using the registry API → one
+  minor version backward-compat window
+
+**Rough size.** ~2000 new LOC + ~500 modified.
+
+---
+
+### M3 — Optimizer + Richer Types (Months 6–9, ship as v0.7.0)
+
+**Goal.** Composition is not just correct but measurably faster than the
+equivalent hand-written code. Types are expressive enough that common
+patterns don't need `Any → Any` escape hatches.
+
+**Deliverables.**
+
+- `crates/noether-engine/src/optimizer/`:
+  - `fuse_pure_sequential.rs` — fold N consecutive Pure stages into one
+    compiled Rust closure
+  - `hoist_invariant.rs` — move stages whose output doesn't depend on the
+    flowing input out of hot loops
+  - `dead_branch.rs` — compile-time elimination of `Branch` whose
+    predicate is Const
+  - `memoize_pure.rs` — opt-in per-composition memoisation for Pure stages
+- Type system additions (each independently small):
+  - Parametric polymorphism on stage signatures (`sort<T: Orderable>` —
+    one stage instead of one per T)
+  - Row polymorphism on records (`{name: Text, ...}` matches any record
+    with a `name` field)
+  - Refinement types with runtime check (`Number where x >= 0`)
+- Benchmarks in `crates/noether-engine/benches/`:
+  - 5-stage Pure pipeline — naive vs fused
+  - 10-vehicle fleet summary — unoptimised vs optimised
+  - Expect 2–5× speedups on realistic graphs
+- `noether run --no-optimize` escape hatch so debugging stays possible
+- Property-based comparison in CI: `optimized(graph).run(input) ==
+  unoptimized(graph).run(input)` for 1000 random inputs
+
+**Exit criteria.**
+
+- Benchmark suite shows ≥2× speedup on at least three canonical graph
+  shapes
+- Optimizer preserves composition IDs (optimised and unoptimised graphs
+  hash identically)
+- At least one stdlib stage uses parametric polymorphism in its signature
+- v0.7.0 released
+
+**Risks.**
+
+- Type system additions interact with canonical form from M1 — re-verify
+  `laws.rs` passes after every type change
+- Optimizer bugs are subtle and silent — property-based equivalence
+  testing is the only defense
+
+**Rough size.** ~3500 new LOC.
+
+---
+
+### M4 — Stdlib Curation + Vertical Depth + 1.0 (Months 9–12, ship as 1.0.0)
+
+**Goal.** One vertical has dense, curated stdlib coverage. One real
+external user runs real workloads. Stability contract enforced.
+
+**Deliverables.**
+
+- `docs/stdlib/curation.md` — public admission + deprecation doctrine:
+  - **Admission.** New stage needs: examples ≥ 5, properties ≥ 3, a
+    "does this generalise?" review by one maintainer other than the author
+  - **Deprecation.** 6-month notice, successor pointer, deprecated badge.
+    Deprecated stages keep executing but emit a warning.
+  - **Naming.** `{domain}_{verb}_{noun}` — `csv_parse_rows`,
+    `geo_haversine_distance`, `etl_batch_upsert`. Agents find stages via
+    name-prefix search; chaotic naming kills discoverability.
+- **One vertical deeply.** Candidate: typed ETL / analytics pipelines —
+  broad addressable market, existing material (noether-telemetry
+  templates), and the real gap in the ecosystem. Target: 500 curated
+  stages in that vertical.
+- **One external reference user.** Begin recruitment at M2; target an
+  introduction by M3; a signed case-study ready for the 1.0 announcement.
+  Candidates: a small data team at a friendly company, an academic group,
+  a solo-open-source project that needs a pipeline.
+- **1.0 release**: stability contract active, CI enforces it:
+  - `scripts/check_breaking_change.sh` diffs stage signatures against
+    the last tagged release; refuses to merge if any stdlib signature
+    changed
+  - Graph JSON schema diffs are additive-only
+- **Long-form post on alpibru.com** — the quarterly content hit from the
+  audit recommendation. "Building a telemetry pipeline in Noether" walks
+  an end-to-end feature with real numbers.
+
+**Exit criteria.**
+
+- 500 stdlib stages in one vertical, each with examples + properties
+- External user in production with a published testimonial
+- CI refuses any commit that breaks stability contract
+- 1.0.0 tag pushed; release notes signed by maintainer
+
+**Risks.**
+
+- Finding an external user as a solo maintainer is the hardest part of
+  the plan — begin outreach at M2, not M4
+- 500 stages is ambitious; fall back to 200 core + 300 extensions if
+  time-pressed
+
+**Rough size.** ~500 stage JSONs + ~1000 doc LOC + CI plumbing.
+
+---
+
+## Quarterly content cadence
+
+| Month | Post |
+|-------|------|
+| 2 | "Canonical composition hashing — what changed in 0.5" |
+| 4 | "The Noether stability contract — what we're promising for 1.x" |
+| 7 | "Pure-stage fusion — why Noether pipelines now run 3× faster" |
+| 10 | "Building X with Noether" (external user case study) |
+| 12 | 1.0 release post |
+
+---
+
+## Open decisions
+
+These need answers before the milestone that depends on them. None block
+M1.
+
+1. **Which vertical for M4?** Typed ETL is the widest market; `electromobility`
+   has existing momentum via noether-telemetry. Decide before M3 begins.
+2. **Does `noether-grid-*` stay in workspace, move to `noether-research`,
+   or ship with 1.0?** Today it's `publish = false` — ambiguous. Decide
+   before M2.
+3. **Scope of property DSL.** Start minimal in M2; revisit if users demand
+   more.
+4. **Runtime enforcement of properties, or CI only?** Default CI only;
+   `--enforce-properties` runtime flag for paranoid environments.
+5. **WASM target — drop or land.** Roadmap mentions it as research. Decide
+   by M2: either ship a worked browser example or remove from pitch.
+
+---
+
+## Explicit non-goals
+
+Writing these down so the scope stays honest.
+
+- Dependent types, proof-carrying code, or refinement types beyond
+  the simple arithmetic/set predicates in M2
+- Distributed execution beyond `noether-grid-*` as an experimental crate
+- A general-purpose programming language — Noether is a composition
+  language; the actual computation lives in Python/Rust stages
+- Compatibility with any specific workflow engine (Airflow, Prefect,
+  Dagster) — Noether complements them, doesn't replace them
+- A UI — agents and scripts are the intended interface
+
+---
+
+## What happens if we don't do this
+
+The failure mode isn't dramatic. Noether keeps working, keeps shipping
+features, and slowly drifts from "a language for agents" into "Alfonso's
+workflow engine that other people sometimes use." Stages don't get
+properties. IDs drift as implementations change. Stdlib accretes. Every
+new adopter writes the same type-checking ad hoc, because they can't trust
+the checks the existing checks make. A fork or a competitor with a
+narrower scope and a clean contract eventually appears and takes the
+mindshare.
+
+The plan above is the minimum set of decisions that prevent that drift
+from being invisible. Each milestone leaves Noether more useful as a
+tool and harder to replace with a me-too.


### PR DESCRIPTION
## Summary

Implements milestone **M1** of the Noether 1.0 rock-solid roadmap
(`docs/roadmap/2026-04-18-rock-solid-plan.md`). This is the first
foundational milestone: nail down what composition *means* and make
the composition ID stable under semantically-irrelevant rewrites.

- **Formal semantics** (`docs/architecture/semantics.md`) — denotational
  meaning for every composition operator, 13 laws stated, each tied to
  a proptest in `laws.rs`.
- **Canonical form** (`crates/noether-engine/src/lagrange/canonical.rs`)
  — bottom-up rewrite pass implementing 5 structural rules:
  1. Flatten nested `Sequential`.
  2. Collapse singleton `Sequential[s] → s`.
  3. `Retry { max_attempts ≤ 1 } → inner stage`.
  4. `Retry { Retry { s, n, d }, m, d } → Retry { s, n·m, d }` (only
     when `delay_ms` matches — different delays are observable).
  5. Empty `Let { {}, body } → body`.
- **Property-based laws** (`crates/noether-engine/tests/laws.rs`) —
  15 proptest properties covering laws L1, L4-L7, L9-L13.
- **compute_composition_id** now canonicalises the root before hashing,
  uses `serde_jcs` (RFC 8785), and hashes the root only — not the
  description or version.

## Breaking change

Composition IDs change from v0.4.x. Old IDs will not match new IDs
even for semantically-identical graphs. This is a v0.5.0-gated break;
migration guidance lands with the v0.5.0 release notes.

## What is *not* in M1

Deliberately deferred to later milestones:

- Const absorption (`f >> Const{v} ≡ Const{v}`) → M2 (needs stage
  metadata).
- Dead-branch elimination with `Const` predicate → M3 (optimizer).
- Stage-level identity detection (`id >> f ≡ f`) → M2.
- Type-aware rewrites → M3.

## Test plan

- [x] `cargo test` (workspace) — all green
- [x] `cargo test -p noether-engine --test laws` — 15/15 proptest laws pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Review the semantics doc — is the contract complete and correct?
- [ ] Review the canonicalisation rules — any rule that's wrong or missing?
- [ ] Review the M1 roadmap doc itself — is the scope right?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
