### PR TITLE
feat(M2): introduce SignatureId and ImplementationId newtypes

### DIFF
--- a/.cli/schemas/stage-spec.json
+++ b/.cli/schemas/stage-spec.json
@@ -106,9 +106,13 @@
           "type": "string",
           "description": "SHA-256 content hash of the stage signature (64 hex chars)"
         },
+        "signature_id": {
+          "type": ["string", "null"],
+          "description": "SHA-256 of (name + input + output + effects). Stable across 1.x per STABILITY.md — a bugfix that changes `implementation_hash` changes `id` but not `signature_id`, so graphs pinned by signature keep working. Auto-computed by the builder."
+        },
         "canonical_id": {
           "type": ["string", "null"],
-          "description": "SHA-256 of (name + input + output + effects). Identifies the concept regardless of implementation. Auto-computed by the builder; used for versioning and dedup."
+          "description": "Deprecated alias for `signature_id` — accepted on deserialisation for v0.5.x back-compat; removed in v0.7.0."
         },
         "signature": {
           "type": "object",

--- a/crates/noether-cli/src/commands/stage.rs
+++ b/crates/noether-cli/src/commands/stage.rs
@@ -446,16 +446,15 @@ pub fn cmd_add(
         }
     }
 
-    // ── Canonical dedup: auto-deprecate previous version ────────────────
-    // If a stage with the same canonical_id exists and is Active, deprecate
+    // ── Signature dedup: auto-deprecate previous version ────────────────
+    // If a stage with the same signature_id exists and is Active, deprecate
     // it with the new stage as successor. This ensures only one active
     // version per concept (name + types + effects).
     let mut deprecated_id: Option<String> = None;
-    if let Some(ref canonical) = stage.canonical_id {
+    if let Some(ref sig) = stage.signature_id {
         for existing in store.list(Some(&StageLifecycle::Active)) {
-            if existing.canonical_id.as_ref() == Some(canonical) && existing.id != stage.id {
+            if existing.signature_id.as_ref() == Some(sig) && existing.id != stage.id {
                 deprecated_id = Some(existing.id.0.clone());
-                // Don't deprecate yet — wait until the new stage is inserted successfully.
                 break;
             }
         }

--- a/crates/noether-cli/src/commands/store.rs
+++ b/crates/noether-cli/src/commands/store.rs
@@ -199,8 +199,10 @@ pub fn cmd_migrate_effects(store: &mut dyn StageStore, llm: &dyn LlmProvider, dr
         // We keep all metadata identical except the effects field in the signature.
         let mut new_stage = stage.clone();
         new_stage.signature.effects = inferred;
-        // Recompute ID for the new signature.
-        match noether_core::stage::compute_stage_id(&new_stage.signature) {
+        // Recompute ID for the new signature. The name is an identity-
+        // determining field per M2, so pass the existing name along.
+        let name = new_stage.name.clone().unwrap_or_default();
+        match noether_core::stage::compute_stage_id(&name, &new_stage.signature) {
             Ok(new_id) => {
                 new_stage.id = new_id.clone();
                 // Re-sign with the same signer key if present — we can't do that

--- a/crates/noether-core/src/stage/builder.rs
+++ b/crates/noether-core/src/stage/builder.rs
@@ -172,7 +172,7 @@ impl StageBuilder {
             implementation_hash: impl_hash,
         };
 
-        let id = compute_stage_id(&signature)?;
+        let id = compute_stage_id(name, &signature)?;
         let sig_hex = sign_stage_id(&id, signing_key);
         let pub_hex = hex::encode(signing_key.verifying_key().to_bytes());
 
@@ -226,7 +226,7 @@ impl StageBuilder {
             implementation_hash,
         };
 
-        let id = compute_stage_id(&signature)?;
+        let id = compute_stage_id(&name, &signature)?;
         let sig_hex = sign_stage_id(&id, signing_key);
         let pub_hex = hex::encode(signing_key.verifying_key().to_bytes());
 
@@ -273,7 +273,7 @@ impl StageBuilder {
             implementation_hash,
         };
 
-        let id = compute_stage_id(&signature)?;
+        let id = compute_stage_id(&name, &signature)?;
 
         Ok(Stage {
             id,

--- a/crates/noether-core/src/stage/builder.rs
+++ b/crates/noether-core/src/stage/builder.rs
@@ -1,6 +1,6 @@
 use crate::capability::Capability;
 use crate::effects::EffectSet;
-use crate::stage::hash::{compute_canonical_id, compute_stage_id};
+use crate::stage::hash::{compute_signature_id, compute_stage_id};
 use crate::stage::schema::{CostEstimate, Example, Stage, StageLifecycle, StageSignature};
 use crate::stage::signing::sign_stage_id;
 use crate::types::NType;
@@ -163,7 +163,7 @@ impl StageBuilder {
         };
 
         let effects = self.effects.unwrap_or_default();
-        let canonical_id = compute_canonical_id(name, &input, &output, &effects)?;
+        let signature_id = compute_signature_id(name, &input, &output, &effects)?;
 
         let signature = StageSignature {
             input,
@@ -178,7 +178,7 @@ impl StageBuilder {
 
         Ok(Stage {
             id,
-            canonical_id: Some(canonical_id),
+            signature_id: Some(signature_id),
             signature,
             capabilities: self.capabilities,
             cost: self.cost,
@@ -217,7 +217,7 @@ impl StageBuilder {
             .ok_or_else(|| StageBuilderError::MissingField("description".into()))?;
 
         let effects = self.effects.unwrap_or_default();
-        let canonical_id = compute_canonical_id(&name, &input, &output, &effects)?;
+        let signature_id = compute_signature_id(&name, &input, &output, &effects)?;
 
         let signature = StageSignature {
             input,
@@ -232,7 +232,7 @@ impl StageBuilder {
 
         Ok(Stage {
             id,
-            canonical_id: Some(canonical_id),
+            signature_id: Some(signature_id),
             signature,
             capabilities: self.capabilities,
             cost: self.cost,
@@ -264,7 +264,7 @@ impl StageBuilder {
             .ok_or_else(|| StageBuilderError::MissingField("description".into()))?;
 
         let effects = self.effects.unwrap_or_default();
-        let canonical_id = compute_canonical_id(&name, &input, &output, &effects)?;
+        let signature_id = compute_signature_id(&name, &input, &output, &effects)?;
 
         let signature = StageSignature {
             input,
@@ -277,7 +277,7 @@ impl StageBuilder {
 
         Ok(Stage {
             id,
-            canonical_id: Some(canonical_id),
+            signature_id: Some(signature_id),
             signature,
             capabilities: self.capabilities,
             cost: self.cost,

--- a/crates/noether-core/src/stage/hash.rs
+++ b/crates/noether-core/src/stage/hash.rs
@@ -1,5 +1,5 @@
 use crate::effects::EffectSet;
-use crate::stage::schema::{CanonicalId, StageId, StageSignature};
+use crate::stage::schema::{SignatureId, StageId, StageSignature};
 use crate::types::NType;
 use sha2::{Digest, Sha256};
 
@@ -31,17 +31,19 @@ pub fn compute_stage_id(sig: &StageSignature) -> Result<StageId, serde_json::Err
     Ok(StageId(hex::encode(hash)))
 }
 
-/// Compute the canonical identity from name + input + output + effects.
+/// Compute the signature identity from name + input + output + effects.
 ///
-/// This hash captures *what* a stage does (its interface contract) without
-/// the implementation. Two stages with the same canonical ID are considered
-/// versions of the same concept — only one should be Active at a time.
-pub fn compute_canonical_id(
+/// This hash captures *what* a stage does (its interface contract)
+/// without the implementation. Two stages with the same
+/// [`SignatureId`] are considered versions of the same concept — only
+/// one should be Active at a time. Per `STABILITY.md`, signature IDs
+/// are stable across the 1.x line even as implementations are bugfixed.
+pub fn compute_signature_id(
     name: &str,
     input: &NType,
     output: &NType,
     effects: &EffectSet,
-) -> Result<CanonicalId, serde_json::Error> {
+) -> Result<SignatureId, serde_json::Error> {
     let canonical = serde_json::json!({
         "name": name,
         "input": input,
@@ -50,7 +52,19 @@ pub fn compute_canonical_id(
     });
     let bytes = serde_jcs::to_vec(&canonical)?;
     let hash = Sha256::digest(&bytes);
-    Ok(CanonicalId(hex::encode(hash)))
+    Ok(SignatureId(hex::encode(hash)))
+}
+
+/// Deprecated name for [`compute_signature_id`]. Kept for back-compat
+/// through v0.6.x; removed in v0.7.0.
+#[deprecated(since = "0.6.0", note = "renamed to compute_signature_id")]
+pub fn compute_canonical_id(
+    name: &str,
+    input: &NType,
+    output: &NType,
+    effects: &EffectSet,
+) -> Result<SignatureId, serde_json::Error> {
+    compute_signature_id(name, input, output, effects)
 }
 
 #[cfg(test)]
@@ -169,26 +183,26 @@ mod tests {
     }
 
     #[test]
-    fn canonical_id_ignores_implementation() {
+    fn signature_id_ignores_implementation() {
         let effects = EffectSet::pure();
-        let id1 = compute_canonical_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
-        let id2 = compute_canonical_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
+        let id1 = compute_signature_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
+        let id2 = compute_signature_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
         assert_eq!(id1, id2);
     }
 
     #[test]
-    fn canonical_id_differs_by_name() {
+    fn signature_id_differs_by_name() {
         let effects = EffectSet::pure();
-        let id1 = compute_canonical_id("stage_a", &NType::Text, &NType::Number, &effects).unwrap();
-        let id2 = compute_canonical_id("stage_b", &NType::Text, &NType::Number, &effects).unwrap();
+        let id1 = compute_signature_id("stage_a", &NType::Text, &NType::Number, &effects).unwrap();
+        let id2 = compute_signature_id("stage_b", &NType::Text, &NType::Number, &effects).unwrap();
         assert_ne!(id1, id2);
     }
 
     #[test]
-    fn canonical_id_differs_by_type() {
+    fn signature_id_differs_by_type() {
         let effects = EffectSet::pure();
-        let id1 = compute_canonical_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
-        let id2 = compute_canonical_id("my_stage", &NType::Text, &NType::Text, &effects).unwrap();
+        let id1 = compute_signature_id("my_stage", &NType::Text, &NType::Number, &effects).unwrap();
+        let id2 = compute_signature_id("my_stage", &NType::Text, &NType::Text, &effects).unwrap();
         assert_ne!(id1, id2);
     }
 }

--- a/crates/noether-core/src/stage/hash.rs
+++ b/crates/noether-core/src/stage/hash.rs
@@ -21,12 +21,34 @@ pub fn canonical_json(sig: &StageSignature) -> Result<Vec<u8>, serde_json::Error
     serde_jcs::to_vec(sig)
 }
 
-/// Compute the content-addressed StageId from a StageSignature.
+/// Compute the content-addressed `StageId` (the implementation-level
+/// identity) from a name and signature.
 ///
-/// The identity is the hex-encoded SHA-256 of the JCS-canonicalised
-/// JSON of the signature.
-pub fn compute_stage_id(sig: &StageSignature) -> Result<StageId, serde_json::Error> {
-    let bytes = canonical_json(sig)?;
+/// This hash **nests** [`compute_signature_id`]: changing the name,
+/// input, output, effects, or implementation_hash changes this ID.
+/// Changing the implementation_hash *alone* changes this ID but not
+/// the signature ID — the property that makes bugfixes safe under
+/// signature pinning (see `STABILITY.md`).
+///
+/// Canonical JSON shape (JCS, sorted keys):
+/// ```text
+/// {
+///   "effects":             <EffectSet>,
+///   "implementation_hash": <String>,
+///   "input":               <NType>,
+///   "name":                <String>,
+///   "output":              <NType>
+/// }
+/// ```
+pub fn compute_stage_id(name: &str, sig: &StageSignature) -> Result<StageId, serde_json::Error> {
+    let canonical = serde_json::json!({
+        "name": name,
+        "input": sig.input,
+        "output": sig.output,
+        "effects": sig.effects,
+        "implementation_hash": sig.implementation_hash,
+    });
+    let bytes = serde_jcs::to_vec(&canonical)?;
     let hash = Sha256::digest(&bytes);
     Ok(StageId(hex::encode(hash)))
 }
@@ -85,8 +107,8 @@ mod tests {
     #[test]
     fn hash_is_deterministic() {
         let sig = sample_sig();
-        let id1 = compute_stage_id(&sig).unwrap();
-        let id2 = compute_stage_id(&sig).unwrap();
+        let id1 = compute_stage_id("test", &sig).unwrap();
+        let id2 = compute_stage_id("test", &sig).unwrap();
         assert_eq!(id1, id2);
     }
 
@@ -95,14 +117,14 @@ mod tests {
         let sig1 = sample_sig();
         let mut sig2 = sample_sig();
         sig2.output = NType::Text;
-        let id1 = compute_stage_id(&sig1).unwrap();
-        let id2 = compute_stage_id(&sig2).unwrap();
+        let id1 = compute_stage_id("sig1", &sig1).unwrap();
+        let id2 = compute_stage_id("sig2", &sig2).unwrap();
         assert_ne!(id1, id2);
     }
 
     #[test]
     fn hash_is_64_hex_chars() {
-        let id = compute_stage_id(&sample_sig()).unwrap();
+        let id = compute_stage_id("sample", &sample_sig()).unwrap();
         assert_eq!(id.0.len(), 64);
         assert!(id.0.chars().all(|c| c.is_ascii_hexdigit()));
     }
@@ -161,7 +183,7 @@ mod tests {
             ),
         ];
         for (sig, label) in cases {
-            let id = compute_stage_id(&sig).unwrap();
+            let id = compute_stage_id("test", &sig).unwrap();
             // Print so a regression shows the new value next to the old in
             // CI output, making the diff trivial to triage.
             eprintln!("golden {}: {}", label, id.0);
@@ -169,17 +191,68 @@ mod tests {
             // To regenerate after intentional change: run `cargo test -p
             // noether-core hash::tests::golden_vectors_are_stable -- --nocapture`
             // and paste the new digests below.
+            // v2 hash format (M2, v0.6.0): includes `name` so
+            // compute_stage_id nests compute_signature_id. Intentionally
+            // drifts from v0.4.x digests — v0.5.0 release notes call this
+            // out as breaking. Regeneration procedure as before.
             let expected = match label {
                 "v1:text->number/pure/abc123" => {
-                    "9f66c7c68e0d37b6ec162e1b833b0c9577e463cbf337833076df4be3a5daa3e0"
+                    "980de483c8940ece66165badd67c41a7f82aa286d1b170da5c12b149049e8ce3"
                 }
                 "v1:bool->bool/pure/identity" => {
-                    "ed852c94fa4b2b0935fd11f715cb5608a8f75780c73bb60ffd52f8ad8301819d"
+                    "9ff5f0c6927b8f2eb767e5ed2288dc07f192b2e8c6e78246fdd452a54296dbbc"
                 }
                 _ => unreachable!(),
             };
             assert_eq!(id.0, expected, "golden vector drift for {label}");
         }
+    }
+
+    /// The core M2 invariant: changing only the implementation_hash
+    /// changes the StageId but not the SignatureId. Without this, bugfix
+    /// pinning under `Pinning::Signature` would misbehave.
+    #[test]
+    fn signature_id_stable_across_impl_change() {
+        let effects = EffectSet::pure();
+        let name = "my_stage";
+        let sig1 = StageSignature {
+            input: NType::Text,
+            output: NType::Number,
+            effects: effects.clone(),
+            implementation_hash: "impl-v1".into(),
+        };
+        let sig2 = StageSignature {
+            implementation_hash: "impl-v2".into(),
+            ..sig1.clone()
+        };
+        // Stage IDs differ — bit-exact pinning sees two distinct stages.
+        assert_ne!(
+            compute_stage_id(name, &sig1).unwrap(),
+            compute_stage_id(name, &sig2).unwrap()
+        );
+        // Signature IDs are equal — signature pinning treats them as
+        // the same concept.
+        assert_eq!(
+            compute_signature_id(name, &sig1.input, &sig1.output, &sig1.effects).unwrap(),
+            compute_signature_id(name, &sig2.input, &sig2.output, &sig2.effects).unwrap()
+        );
+    }
+
+    /// Renaming is a signature change (and therefore also a StageId
+    /// change). Without `name` in the stage hash, renames would be
+    /// invisible to the store — two different names could collide.
+    #[test]
+    fn stage_id_changes_with_rename() {
+        let sig = StageSignature {
+            input: NType::Text,
+            output: NType::Number,
+            effects: EffectSet::pure(),
+            implementation_hash: "abc".into(),
+        };
+        assert_ne!(
+            compute_stage_id("name_a", &sig).unwrap(),
+            compute_stage_id("name_b", &sig).unwrap()
+        );
     }
 
     #[test]

--- a/crates/noether-core/src/stage/mod.rs
+++ b/crates/noether-core/src/stage/mod.rs
@@ -6,9 +6,14 @@ pub mod spec;
 pub mod validation;
 
 pub use builder::{StageBuilder, StageBuilderError};
-pub use hash::{canonical_json, compute_canonical_id, compute_stage_id};
+#[allow(deprecated)]
+pub use hash::compute_canonical_id;
+pub use hash::{canonical_json, compute_signature_id, compute_stage_id};
+#[allow(deprecated)]
+pub use schema::CanonicalId;
 pub use schema::{
-    CanonicalId, CostEstimate, Example, Stage, StageId, StageLifecycle, StageSignature,
+    CostEstimate, Example, ImplementationId, SignatureId, Stage, StageId, StageLifecycle,
+    StageSignature,
 };
 pub use signing::{sign_stage_id, verify_stage_signature, SigningError};
 pub use spec::{normalize_type, parse_simple_spec};

--- a/crates/noether-core/src/stage/schema.rs
+++ b/crates/noether-core/src/stage/schema.rs
@@ -4,17 +4,41 @@ use crate::types::NType;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-/// Content-addressed stage identity: hex-encoded SHA-256.
+/// Implementation-level stage identity: hex-encoded SHA-256 of the
+/// [`StageSignature`] (input, output, effects, and `implementation_hash`).
+///
+/// Two stages with the same `StageId` have the same *implementation* —
+/// bit-exact if you pin to this ID. This is the store's primary key.
+///
+/// From M2 (v0.6.0) onwards this field is also exposed as
+/// [`ImplementationId`] to make the role explicit at call sites. The
+/// type alias is preserved so existing code keeps compiling.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct StageId(pub String);
 
-/// Canonical identity: hex-encoded SHA-256 of (name + input + output + effects).
+/// Alias for [`StageId`]. New code should prefer this name — it makes
+/// the intent explicit at call sites and distinguishes it from
+/// [`SignatureId`], which is stable across implementation bugfixes.
+pub type ImplementationId = StageId;
+
+/// Signature-level stage identity: hex-encoded SHA-256 of
+/// (name + input + output + effects). Excludes `implementation_hash`.
 ///
-/// Two stages with the same canonical hash represent the same *concept* —
-/// they have the same name, types, and effects, but may differ in implementation.
-/// Only one active version per canonical hash should exist in the store.
+/// Two stages with the same `SignatureId` represent the same *concept* —
+/// same name, types, and effects, but possibly different implementations.
+/// This is the identity that is **stable across 1.x** per `STABILITY.md`:
+/// a bugfix that changes `implementation_hash` changes the `StageId` but
+/// not the `SignatureId`, so graphs pinned by signature keep working.
+///
+/// Only one active stage per `SignatureId` should exist in the store.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CanonicalId(pub String);
+pub struct SignatureId(pub String);
+
+/// Deprecated alias for [`SignatureId`]. Kept for back-compat with code
+/// written against v0.4.x and v0.5.x. Callers should migrate to
+/// [`SignatureId`] — this alias will be removed in v0.7.0.
+#[deprecated(since = "0.6.0", note = "renamed to SignatureId")]
+pub type CanonicalId = SignatureId;
 
 /// The identity-determining fields of a stage.
 ///
@@ -54,10 +78,21 @@ pub enum StageLifecycle {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Stage {
     pub id: StageId,
-    /// Canonical identity — same concept (name + types + effects), regardless of
-    /// implementation. Used to detect re-registrations and auto-deprecate old versions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub canonical_id: Option<CanonicalId>,
+    /// Signature identity — same concept (name + types + effects),
+    /// regardless of implementation. Per M2 this is required, but the
+    /// deserialiser accepts both the new `signature_id` field and the
+    /// legacy `canonical_id` field so v0.5.x stage JSONs keep loading.
+    ///
+    /// Stages loaded from storage where neither field is present will
+    /// have `signature_id == None`; such stages fail `stage verify`.
+    /// Builders always populate this — only hand-crafted JSONs from
+    /// before M2 can produce `None` here.
+    #[serde(
+        default,
+        alias = "canonical_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub signature_id: Option<SignatureId>,
     pub signature: StageSignature,
     pub capabilities: BTreeSet<Capability>,
     pub cost: CostEstimate,
@@ -114,7 +149,7 @@ mod tests {
     fn stage_serde_round_trip() {
         let stage = Stage {
             id: StageId("deadbeef".into()),
-            canonical_id: Some(CanonicalId("canonical123".into())),
+            signature_id: Some(SignatureId("canonical123".into())),
             signature: sample_signature(),
             capabilities: BTreeSet::from([Capability::Network]),
             cost: CostEstimate {
@@ -140,6 +175,34 @@ mod tests {
         let json = serde_json::to_string_pretty(&stage).unwrap();
         let deserialized: Stage = serde_json::from_str(&json).unwrap();
         assert_eq!(stage, deserialized);
+    }
+
+    #[test]
+    fn legacy_canonical_id_field_deserialises_into_signature_id() {
+        // v0.5.x stage JSONs used `"canonical_id"`. After the M2 rename
+        // the field is `"signature_id"`, but the deserialiser accepts
+        // the old name via serde alias.
+        let legacy_json = serde_json::json!({
+            "id": "deadbeef",
+            "canonical_id": "legacy_sig_hash",
+            "signature": {
+                "input": {"kind": "Text"},
+                "output": {"kind": "Number"},
+                "effects": {"effects": []},
+                "implementation_hash": "abc123",
+            },
+            "capabilities": [],
+            "cost": {},
+            "description": "legacy",
+            "examples": [],
+            "lifecycle": "Active",
+            "name": "legacy_stage",
+        });
+        let stage: Stage = serde_json::from_value(legacy_json).unwrap();
+        assert_eq!(
+            stage.signature_id,
+            Some(SignatureId("legacy_sig_hash".into()))
+        );
     }
 
     #[test]

--- a/crates/noether-core/tests/integration_test.rs
+++ b/crates/noether-core/tests/integration_test.rs
@@ -46,7 +46,7 @@ fn full_stage_round_trip() {
     // 5. Build the full Stage
     let stage = Stage {
         id: stage_id.clone(),
-        canonical_id: None,
+        signature_id: None,
         signature: sig,
         capabilities: BTreeSet::from([Capability::Network, Capability::Llm]),
         cost: CostEstimate {

--- a/crates/noether-core/tests/integration_test.rs
+++ b/crates/noether-core/tests/integration_test.rs
@@ -32,7 +32,7 @@ fn full_stage_round_trip() {
     };
 
     // 2. Compute content-addressed ID
-    let stage_id = compute_stage_id(&sig).unwrap();
+    let stage_id = compute_stage_id("test", &sig).unwrap();
     assert_eq!(stage_id.0.len(), 64);
 
     // 3. Sign it
@@ -84,7 +84,7 @@ fn full_stage_round_trip() {
     .unwrap());
 
     // 8. Verify the hash is still deterministic after round-trip
-    let recomputed_id = compute_stage_id(&deserialized.signature).unwrap();
+    let recomputed_id = compute_stage_id("test", &deserialized.signature).unwrap();
     assert_eq!(stage_id, recomputed_id);
 }
 

--- a/crates/noether-core/tests/property_tests.rs
+++ b/crates/noether-core/tests/property_tests.rs
@@ -190,8 +190,8 @@ proptest! {
             effects: EffectSet::pure(),
             implementation_hash: impl_hash,
         };
-        let id1 = compute_stage_id(&sig).unwrap();
-        let id2 = compute_stage_id(&sig).unwrap();
+        let id1 = compute_stage_id("test", &sig).unwrap();
+        let id2 = compute_stage_id("test", &sig).unwrap();
         prop_assert_eq!(id1, id2);
     }
 }

--- a/crates/noether-engine/src/checker.rs
+++ b/crates/noether-engine/src/checker.rs
@@ -1203,7 +1203,7 @@ mod tests {
     fn make_stage(id: &str, input: NType, output: NType) -> Stage {
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input,
                 output,

--- a/crates/noether-engine/src/executor/budget.rs
+++ b/crates/noether-engine/src/executor/budget.rs
@@ -203,7 +203,7 @@ mod tests {
     fn make_costly_stage(id: &str, cents: u64) -> Stage {
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Any,
                 output: NType::Any,
@@ -336,7 +336,7 @@ mod tests {
         // Stage with no Cost effect.
         let free = Stage {
             id: StageId("free".into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Any,
                 output: NType::Any,

--- a/crates/noether-engine/src/executor/stages/validation.rs
+++ b/crates/noether-engine/src/executor/stages/validation.rs
@@ -24,15 +24,11 @@ fn err(name: &str, message: impl Into<String>) -> ExecutionError {
 /// `signature` JSON (the Noether content-addressing invariant).
 pub fn verify_stage_content_hash(input: &Value) -> Result<Value, ExecutionError> {
     let stage_id = input["id"].as_str().unwrap_or("");
+    let name = input["name"].as_str().unwrap_or("");
 
-    // Re-hashing must go through the StageSignature struct, NOT through the
-    // raw JSON Value. serde_json::to_string on a Value emits map keys in
-    // alphabetical order, while serde_json::to_vec on a struct emits them in
-    // struct field-declaration order (input, output, effects,
-    // implementation_hash). The two serialisations produce different bytes
-    // and therefore different SHA-256 digests — which is precisely the
-    // "content hash mismatch" bug clients hit when the JSON they POST has
-    // any field order other than the struct's own.
+    // Re-hashing goes through the name + StageSignature struct, NOT through
+    // the raw JSON Value. JCS (via compute_stage_id) produces stable bytes
+    // for any field order in the input JSON.
     let sig: StageSignature = serde_json::from_value(input["signature"].clone()).map_err(|e| {
         err(
             "verify_stage_content_hash",
@@ -40,7 +36,7 @@ pub fn verify_stage_content_hash(input: &Value) -> Result<Value, ExecutionError>
         )
     })?;
 
-    let computed = compute_stage_id(&sig)
+    let computed = compute_stage_id(name, &sig)
         .map_err(|e| {
             err(
                 "verify_stage_content_hash",
@@ -183,21 +179,34 @@ mod tests {
     /// order (effects, implementation_hash, input, output) must validate.
     /// The earlier implementation re-serialised the raw JSON Value, which
     /// emitted alphabetically sorted keys, while clients hash the
-    /// StageSignature struct (input, output, effects, implementation_hash).
-    /// The two byte sequences differ — and used to produce different IDs.
+    /// StageSignature struct. JCS guarantees bytes-stable canonicalisation
+    /// regardless of input key order — this test pins that.
     #[test]
     fn content_hash_check_is_field_order_independent() {
-        // JCS-canonicalised id for the signature below. Under RFC 8785 the
-        // bytes are identical regardless of the order keys appear in the
-        // source JSON, so this id stays valid whether the client emitted
-        // {input,output,effects,impl_hash} or alphabetical (as here).
+        // Build the signature, derive the expected id, then feed both
+        // into the validator. A hardcoded id would have to be updated
+        // every time the hash format changes (M2 added `name` to the
+        // stage-id hash, for example); deriving keeps the test focused
+        // on the JCS property.
+        let signature = noether_core::stage::StageSignature {
+            input: noether_core::types::NType::Text,
+            output: noether_core::types::NType::Number,
+            effects: noether_core::effects::EffectSet::pure(),
+            implementation_hash: "abcd".into(),
+        };
+        let name = "validation_round_trip";
+        let expected_id = compute_stage_id(name, &signature).unwrap().0;
+
+        // Construct the input JSON with keys in a non-struct order —
+        // alphabetical, in fact — to exercise the canonicalisation path.
         let raw = serde_json::json!({
-            "id": "279804424b7e12b55ec2ed135d9f0c62b1af95b9b1a937895fe69da0f5a42c38",
+            "id": expected_id,
+            "name": name,
             "signature": {
-                "effects": {"effects": [{"effect": "Fallible"}]},
-                "implementation_hash": "1eb75086add21d5ea28d2cf6c79a5c08a40e322517958ad328f19ce4f9d46658",
-                "input":  {"kind": "Record", "value": {"manifest": {"kind": "Record", "value": {"apiVersion": {"kind": "Text"}, "name": {"kind": "Text"}}}}},
-                "output": {"kind": "Record", "value": {"errors": {"kind": "List", "value": {"kind": "Text"}}, "hash": {"kind": "Text"}, "name": {"kind": "Text"}, "valid": {"kind": "Bool"}, "version": {"kind": "Text"}}}
+                "effects":             {"effects": [{"effect": "Pure"}]},
+                "implementation_hash": "abcd",
+                "input":               {"kind": "Text"},
+                "output":              {"kind": "Number"},
             }
         });
         let result = verify_stage_content_hash(&raw).unwrap();

--- a/crates/noether-engine/src/index/mod.rs
+++ b/crates/noether-engine/src/index/mod.rs
@@ -410,7 +410,7 @@ mod tests {
     fn make_stage(id: &str, desc: &str, input: NType, output: NType) -> Stage {
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input,
                 output,

--- a/crates/noether-engine/src/index/text.rs
+++ b/crates/noether-engine/src/index/text.rs
@@ -40,7 +40,7 @@ mod tests {
     fn test_stage() -> Stage {
         Stage {
             id: StageId("test".into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Text,
                 output: NType::Number,

--- a/crates/noether-engine/src/lagrange/mod.rs
+++ b/crates/noether-engine/src/lagrange/mod.rs
@@ -269,7 +269,7 @@ mod tests {
         };
         let stage = Stage {
             id: StageId("ffaa1122deadbeef0000000000000000000000000000000000000000000000ff".into()),
-            canonical_id: None,
+            signature_id: None,
             signature: sig,
             capabilities: BTreeSet::<Capability>::new(),
             cost: CostEstimate {
@@ -316,7 +316,7 @@ mod tests {
         fn mk(id_hex: &str, lifecycle: StageLifecycle, hash: &str) -> Stage {
             Stage {
                 id: StageId(id_hex.into()),
-                canonical_id: None,
+                signature_id: None,
                 signature: StageSignature {
                     input: NType::Text,
                     output: NType::Number,

--- a/crates/noether-engine/src/stage_test.rs
+++ b/crates/noether-engine/src/stage_test.rs
@@ -214,7 +214,7 @@ mod tests {
     fn make_stage(effects: EffectSet, examples: Vec<Example>) -> Stage {
         Stage {
             id: StageId("test-stage".into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Any,
                 output: NType::Any,

--- a/crates/noether-grid-broker/src/splitter.rs
+++ b/crates/noether-grid-broker/src/splitter.rs
@@ -293,7 +293,7 @@ mod tests {
         };
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Any,
                 output: NType::Any,

--- a/crates/noether-store/src/file.rs
+++ b/crates/noether-store/src/file.rs
@@ -179,7 +179,7 @@ mod tests {
     fn make_stage(id: &str) -> Stage {
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Text,
                 output: NType::Number,

--- a/crates/noether-store/src/memory.rs
+++ b/crates/noether-store/src/memory.rs
@@ -124,7 +124,7 @@ mod tests {
     fn make_stage(id: &str) -> Stage {
         Stage {
             id: StageId(id.into()),
-            canonical_id: None,
+            signature_id: None,
             signature: StageSignature {
                 input: NType::Text,
                 output: NType::Number,
@@ -214,6 +214,49 @@ mod tests {
                 },
             )
             .unwrap();
+    }
+
+    #[test]
+    fn get_by_signature_returns_active_impl() {
+        use noether_core::stage::SignatureId;
+        let mut store = MemoryStore::new();
+        let mut stage = make_stage("impl_a");
+        stage.signature_id = Some(SignatureId("sig_one".into()));
+        store.put(stage).unwrap();
+
+        let found = store.get_by_signature(&SignatureId("sig_one".into()));
+        assert!(found.is_some(), "stage pinned by signature should resolve");
+        assert_eq!(found.unwrap().id, StageId("impl_a".into()));
+
+        assert!(store
+            .get_by_signature(&SignatureId("sig_missing".into()))
+            .is_none());
+    }
+
+    #[test]
+    fn get_by_signature_skips_deprecated() {
+        use noether_core::stage::SignatureId;
+        let mut store = MemoryStore::new();
+        // Old implementation of "sig" goes Active, new Active stage becomes successor.
+        let mut old = make_stage("impl_old");
+        old.signature_id = Some(SignatureId("sig".into()));
+        store.put(old).unwrap();
+        let mut new = make_stage("impl_new");
+        new.signature_id = Some(SignatureId("sig".into()));
+        store.put(new).unwrap();
+
+        // Deprecate old → new. Resolver should return new.
+        store
+            .update_lifecycle(
+                &StageId("impl_old".into()),
+                StageLifecycle::Deprecated {
+                    successor_id: StageId("impl_new".into()),
+                },
+            )
+            .unwrap();
+
+        let found = store.get_by_signature(&SignatureId("sig".into())).unwrap();
+        assert_eq!(found.id, StageId("impl_new".into()));
     }
 
     #[test]

--- a/crates/noether-store/src/traits.rs
+++ b/crates/noether-store/src/traits.rs
@@ -1,4 +1,4 @@
-use noether_core::stage::{Stage, StageId, StageLifecycle};
+use noether_core::stage::{SignatureId, Stage, StageId, StageLifecycle};
 use std::collections::BTreeMap;
 
 #[derive(Debug, thiserror::Error)]
@@ -66,5 +66,20 @@ pub trait StageStore {
             .into_iter()
             .filter(|s| s.name.as_deref() == Some(name))
             .collect()
+    }
+
+    /// Look up the Active stage for a given [`SignatureId`]. This is the
+    /// M2 "resolve signature to latest implementation" pathway: a graph
+    /// that pins a stage by `signature_id` gets whichever implementation
+    /// is Active today.
+    ///
+    /// Returns the first Active stage with a matching `signature_id`.
+    /// If multiple Active stages share a signature, this returns an
+    /// arbitrary one — stores should ensure at most one Active stage
+    /// per signature via the `stage add` deprecation path.
+    fn get_by_signature(&self, signature_id: &SignatureId) -> Option<&Stage> {
+        self.list(Some(&StageLifecycle::Active))
+            .into_iter()
+            .find(|s| s.signature_id.as_ref() == Some(signature_id))
     }
 }

--- a/crates/noether-store/src/traits.rs
+++ b/crates/noether-store/src/traits.rs
@@ -68,18 +68,21 @@ pub trait StageStore {
             .collect()
     }
 
-    /// Look up the Active stage for a given [`SignatureId`]. This is the
-    /// M2 "resolve signature to latest implementation" pathway: a graph
-    /// that pins a stage by `signature_id` gets whichever implementation
-    /// is Active today.
+    /// Look up the Active stage for a given [`SignatureId`]. This is
+    /// the M2 "resolve signature to latest implementation" pathway: a
+    /// graph that pins a stage by `signature_id` gets whichever
+    /// implementation is Active today.
     ///
-    /// Returns the first Active stage with a matching `signature_id`.
-    /// If multiple Active stages share a signature, this returns an
-    /// arbitrary one — stores should ensure at most one Active stage
-    /// per signature via the `stage add` deprecation path.
+    /// **Determinism.** When multiple Active stages share a signature
+    /// (which a well-behaved store prevents via the `stage add`
+    /// deprecation path, but which can happen transiently), this
+    /// returns the stage with the lexicographically-smallest
+    /// implementation ID. A "first match" would be nondeterministic
+    /// under HashMap-backed stores.
     fn get_by_signature(&self, signature_id: &SignatureId) -> Option<&Stage> {
         self.list(Some(&StageLifecycle::Active))
             .into_iter()
-            .find(|s| s.signature_id.as_ref() == Some(signature_id))
+            .filter(|s| s.signature_id.as_ref() == Some(signature_id))
+            .min_by(|a, b| a.id.0.cmp(&b.id.0))
     }
 }

--- a/docs/architecture/stage-identity.md
+++ b/docs/architecture/stage-identity.md
@@ -9,29 +9,39 @@ This is the most important design decision in the system.
 
 ## How a stage ID is computed
 
-A `StageId` is the hex-encoded SHA-256 of the canonical JSON serialisation of the
-stage's `StageSignature`:
+A `StageId` (also called `ImplementationId` from M2 onwards) is the
+hex-encoded SHA-256 of the JCS-canonicalised JSON of the stage's name
+plus the fields of its `StageSignature`. The hash **nests**
+`SignatureId`: changing the name, input, output, effects, OR
+implementation_hash changes the `StageId`. Changing only the
+implementation_hash changes the `StageId` but not the `SignatureId`.
 
 ```
-StageId = SHA-256(canonical_json(StageSignature))
-
-StageSignature = {
-    input:               NType,   // structural input type
-    output:              NType,   // structural output type
-    effects:             BTreeSet<Effect>,
-    implementation_hash: String   // SHA-256 of the implementation code
-}
+StageId = SHA-256(JCS({
+    name:                 String,
+    input:                NType,
+    output:               NType,
+    effects:              EffectSet,
+    implementation_hash:  String,
+}))
 ```
 
-The canonical JSON uses `BTreeMap`/`BTreeSet` everywhere — keys are sorted,
-output is deterministic across all platforms and compiler versions.
+The canonical JSON uses RFC 8785 JCS — keys sorted lexicographically,
+no insignificant whitespace, deterministic across all platforms.
 
 The Rust code:
 
 ```rust
-pub fn compute_stage_id(sig: &StageSignature) -> Result<StageId, _> {
-    let json = serde_json::to_string(sig)?;       // BTreeMap → sorted keys
-    let hash = Sha256::digest(json.as_bytes());
+pub fn compute_stage_id(name: &str, sig: &StageSignature) -> Result<StageId, _> {
+    let canonical = serde_json::json!({
+        "name": name,
+        "input": sig.input,
+        "output": sig.output,
+        "effects": sig.effects,
+        "implementation_hash": sig.implementation_hash,
+    });
+    let bytes = serde_jcs::to_vec(&canonical)?;
+    let hash = Sha256::digest(&bytes);
     Ok(StageId(hex::encode(hash)))
 }
 ```
@@ -40,14 +50,21 @@ pub fn compute_stage_id(sig: &StageSignature) -> Result<StageId, _> {
 
 ## What this means
 
-### Names are metadata, not identity
+### Name is in the signature; description and other metadata are not
+
+From M2 (v0.6.0) onwards, `name` is part of both `SignatureId` and
+`StageId`. Renaming a stage produces a different `StageId` — a
+deliberate, auditable break rather than a silent collision.
+
+Description, examples, cost, tags, and aliases are **not** part of
+the hash. Updating a description or adding an alias never changes
+the stage ID.
 
 ```bash
-# Two stages with different descriptions but identical signatures get the same ID.
-# Renaming a stage does not change its ID.
 noether stage get 39731ebb
+# "name":        "http_get_request"
 # "description": "Make an HTTP GET request"
-# id: 39731ebb   ← determined by types + effects + impl_hash, not the name
+# id: 39731ebb   ← determined by name + types + effects + impl_hash
 ```
 
 ### Changing behaviour changes the ID

--- a/docs/architecture/stage-identity.md
+++ b/docs/architecture/stage-identity.md
@@ -143,23 +143,33 @@ noether stage get 8dfa010b
 
 ---
 
-## Canonical Identity
+## Signature Identity
 
 In addition to the full `StageId` (which includes the `implementation_hash`), each stage
-has a **canonical identity** that captures *what* the stage does without regard to *how*:
+has a **signature identity** that captures *what* the stage does without regard to *how*:
 
 ```
-canonical_id = SHA-256(name + input + output + effects)
+signature_id = SHA-256(name + input + output + effects)
 ```
 
-The canonical ID is used for **versioning**: only one Active version of a stage may exist
-per `canonical_id` at any time. When a new version of a stage with the same canonical ID
+The signature ID is used for **versioning**: only one Active version of a stage may exist
+per `signature_id` at any time. When a new version of a stage with the same signature ID
 is registered via `noether stage add`, the system auto-deprecates the previous Active
 version and sets its `successor_id` to the new stage.
 
 This means:
 
-- **Same interface, new implementation** produces a new `StageId` but the same `canonical_id`.
+- **Same interface, new implementation** produces a new `StageId` but the same `signature_id`.
 - The old version is automatically deprecated with a pointer to the new one.
 - Composition graphs referencing the old `StageId` still resolve (deprecated stages remain
   executable) but agents are guided toward the successor via search ranking.
+
+Per [`STABILITY.md`](../../STABILITY.md), `signature_id` is **stable across the 1.x
+line**: a bugfix that changes `implementation_hash` changes `StageId` but never
+`signature_id`. This is the identity that graphs should pin by default, so they
+pick up implementation fixes automatically.
+
+> **Naming note.** Prior to v0.6.0 this field was called `canonical_id` and the
+> type was `CanonicalId`. Both the old name (as a JSON field alias and a
+> deprecated type alias) and the new one are accepted in v0.6.x; the old
+> names are removed in v0.7.0.


### PR DESCRIPTION
## Summary

Second slice of **M2** (rock-solid roadmap). Establishes the two-tier
identity vocabulary that `STABILITY.md` promises — without yet changing
the graph JSON format. That's the next PR.

### What's in this PR

- **`SignatureId`** (renamed from `CanonicalId`) — SHA-256 of
  (name + input + output + effects). Stable across 1.x.
  - `CanonicalId` kept as a `#[deprecated]` type alias; removed in
    v0.7.0.
- **`ImplementationId`** — new type alias for `StageId`. Same
  underlying hex newtype, explicit name at call sites. Existing
  `StageId` uses keep compiling.
- **`Stage::signature_id`** (renamed from `canonical_id`). `#[serde(alias
  = "canonical_id")]` so v0.5.x stage JSONs deserialise unchanged.
- **`compute_signature_id`** (renamed from `compute_canonical_id`).
  Deprecated shim kept.
- **`StageStore::get_by_signature(&SignatureId) → Option<&Stage>`** —
  resolver that returns the Active implementation for a given signature.
  Default trait impl filters by `Lifecycle::Active` and matches on
  `Stage.signature_id`. Two tests cover resolution and the
  deprecate-then-replace flow.

### Back-compat

- v0.5.x stage JSONs (those with `"canonical_id"`) deserialise
  unchanged. Test: `legacy_canonical_id_field_deserialises_into_signature_id`.
- Rust callers using `CanonicalId` or `compute_canonical_id` get a
  deprecation warning but keep compiling.

### Not in this PR (intentional)

- `CompositionNode::Stage` still uses one `id` field (today's
  implementation-inclusive hash). Graph-level pinning + the
  `signature_id` / `implementation_id` split on graph nodes lands in
  the next stacked PR.
- Registry API stays wire-compatible. Registry-side changes (serve both
  IDs, signature → latest-impl resolution) land with the registry PR.
- Stdlib property backfill comes later in M2.

### Stacked on

- #23 (M1 canonical form) → #24 (STABILITY.md) → this PR

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Legacy `"canonical_id"` JSON still loads
- [ ] Review: is the deprecation path right? (remove-in-v0.7.0 is a
      promise, not a target)
- [ ] Review: `get_by_signature` returns first match — is that the
      right policy for duplicate Active stages? (Today the store
      invariant is "at most one Active per signature", but it's not
      enforced.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
