### PR TITLE
feat(M2): declarative properties DSL on stage specs

### DIFF
--- a/.cli/schemas/stage-spec.json
+++ b/.cli/schemas/stage-spec.json
@@ -34,6 +34,30 @@
         "output": { "description": "Expected output value" }
       }
     },
+    "property": {
+      "type": "object",
+      "description": "Declarative property the stage claims to satisfy for every (input, output) pair. See crates/noether-core/src/stage/property.rs for semantics.",
+      "required": ["kind", "field"],
+      "oneOf": [
+        {
+          "properties": {
+            "kind": { "const": "set_member" },
+            "field": { "type": "string", "description": "Dot-separated path rooted at `input.` or `output.`" },
+            "set": { "type": "array", "description": "Allowed JSON values (any type, compared by value equality)" }
+          },
+          "required": ["kind", "field", "set"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "range" },
+            "field": { "type": "string", "description": "Dot-separated path rooted at `input.` or `output.` (must resolve to a number)" },
+            "min": { "type": "number", "description": "Inclusive lower bound. Omit for unbounded." },
+            "max": { "type": "number", "description": "Inclusive upper bound. Omit for unbounded." }
+          },
+          "required": ["kind", "field"]
+        }
+      ]
+    },
     "simple_spec": {
       "type": "object",
       "description": "Simple spec format — recommended for authoring new stages. The CLI computes the content hash, signs the stage, and registers it.",
@@ -94,6 +118,11 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Alternative names for search recall"
+        },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/property" },
+          "description": "Declarative properties — value-level claims checked against examples at registration time. Per STABILITY.md, may grow additively in 1.x but existing entries cannot be removed."
         }
       }
     },
@@ -152,7 +181,12 @@
         "implementation_code": { "type": ["string", "null"] },
         "implementation_language": { "type": ["string", "null"] },
         "tags": { "type": "array", "items": { "type": "string" } },
-        "aliases": { "type": "array", "items": { "type": "string" } }
+        "aliases": { "type": "array", "items": { "type": "string" } },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/property" },
+          "description": "Declarative properties. See property definition and STABILITY.md."
+        }
       }
     }
   }

--- a/crates/noether-core/src/stage/builder.rs
+++ b/crates/noether-core/src/stage/builder.rs
@@ -193,6 +193,7 @@ impl StageBuilder {
             tags: self.tags,
             aliases: self.aliases,
             name: self.name.clone(),
+            properties: Vec::new(),
         })
     }
 
@@ -247,6 +248,7 @@ impl StageBuilder {
             tags: self.tags,
             aliases: self.aliases,
             name: self.name.clone(),
+            properties: Vec::new(),
         })
     }
 
@@ -292,6 +294,7 @@ impl StageBuilder {
             tags: self.tags,
             aliases: self.aliases,
             name: self.name.clone(),
+            properties: Vec::new(),
         })
     }
 }

--- a/crates/noether-core/src/stage/mod.rs
+++ b/crates/noether-core/src/stage/mod.rs
@@ -1,5 +1,6 @@
 mod builder;
 mod hash;
+pub mod property;
 mod schema;
 mod signing;
 pub mod spec;
@@ -9,6 +10,7 @@ pub use builder::{StageBuilder, StageBuilderError};
 #[allow(deprecated)]
 pub use hash::compute_canonical_id;
 pub use hash::{canonical_json, compute_signature_id, compute_stage_id};
+pub use property::{Property, PropertyViolation};
 #[allow(deprecated)]
 pub use schema::CanonicalId;
 pub use schema::{

--- a/crates/noether-core/src/stage/mod.rs
+++ b/crates/noether-core/src/stage/mod.rs
@@ -14,8 +14,8 @@ pub use property::{Property, PropertyViolation};
 #[allow(deprecated)]
 pub use schema::CanonicalId;
 pub use schema::{
-    CostEstimate, Example, ImplementationId, SignatureId, Stage, StageId, StageLifecycle,
-    StageSignature,
+    CheckPropertiesError, CostEstimate, Example, ImplementationId, SignatureId, Stage, StageId,
+    StageLifecycle, StageSignature,
 };
 pub use signing::{sign_stage_id, verify_stage_signature, SigningError};
 pub use spec::{normalize_type, parse_simple_spec};

--- a/crates/noether-core/src/stage/property.rs
+++ b/crates/noether-core/src/stage/property.rs
@@ -38,6 +38,13 @@
 use serde::{Deserialize, Serialize};
 
 /// A declarative property claim on a stage.
+///
+/// The wire format is a tagged union on the `"kind"` field. Unknown
+/// kinds deserialise into [`Property::Unknown`] so a 1.0 reader can
+/// still load a graph written against 1.1 (forward compatibility).
+/// Readers that can't evaluate an unknown property should skip it
+/// with a warning; they must not treat "couldn't parse" as "property
+/// holds".
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Property {
@@ -62,6 +69,17 @@ pub enum Property {
         min: Option<f64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         max: Option<f64>,
+    },
+    /// A property kind this reader doesn't know how to evaluate.
+    /// Produced by the deserialiser for forward compatibility when a
+    /// future minor release adds a new `kind` variant; the original
+    /// `kind` string is preserved so callers can report which kind
+    /// was skipped.
+    #[serde(untagged)]
+    Unknown {
+        /// The raw JSON object for the unknown property.
+        #[serde(flatten)]
+        raw: serde_json::Value,
     },
 }
 
@@ -97,23 +115,179 @@ pub enum PropertyViolation {
     AboveMax { path: String, actual: f64, max: f64 },
 }
 
+/// Why a property failed static validation against a stage's declared
+/// input/output types.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum PropertyTypeError {
+    #[error(
+        "property field `{path}` is malformed: first segment must be \
+         `input` or `output` (got: `{reason}`)"
+    )]
+    BadPath { path: String, reason: String },
+
+    #[error(
+        "property field `{path}` is not reachable in the stage's declared \
+         {side} type `{declared_type}`"
+    )]
+    FieldNotInType {
+        path: String,
+        side: &'static str,
+        declared_type: String,
+    },
+
+    #[error(
+        "property `{path}` requires a numeric field but the declared \
+         type at that path is `{declared_type}`"
+    )]
+    RangeOnNonNumber { path: String, declared_type: String },
+}
+
 impl Property {
     /// The field path this property constrains. Used by callers that
     /// want to group properties by target field for reporting.
+    /// Returns an empty string for [`Property::Unknown`] since the
+    /// reader doesn't know how to interpret it.
     pub fn field(&self) -> &str {
         match self {
             Property::SetMember { field, .. } | Property::Range { field, .. } => field,
+            Property::Unknown { .. } => "",
+        }
+    }
+
+    /// True if this is an `Unknown` variant — the reader doesn't know
+    /// how to evaluate the property. Callers that aggregate results
+    /// should treat these as skips, not passes or failures.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Property::Unknown { .. })
+    }
+
+    /// Validate that this property's field path is reachable in the
+    /// declared `input`/`output` types, and (for `Range`) that the
+    /// target field is numeric.
+    ///
+    /// Called at stage-registration time so bogus property declarations
+    /// (e.g. `Range { field: "output.color" }` on a Text-typed stage)
+    /// fail early, not only on first violating example.
+    ///
+    /// [`Property::Unknown`] short-circuits to `Ok(())` — the reader
+    /// can't validate a kind it doesn't know.
+    pub fn validate_against_types(
+        &self,
+        input_type: &crate::types::NType,
+        output_type: &crate::types::NType,
+    ) -> Result<(), PropertyTypeError> {
+        if self.is_unknown() {
+            return Ok(());
+        }
+        use crate::types::NType;
+        let path = self.field();
+        let mut parts = path.split('.');
+        let (root, side_label) = match parts.next() {
+            Some("input") => (input_type, "input"),
+            Some("output") => (output_type, "output"),
+            Some(other) => {
+                return Err(PropertyTypeError::BadPath {
+                    path: path.to_string(),
+                    reason: format!("first segment must be `input` or `output`, got `{other}`"),
+                });
+            }
+            None => {
+                return Err(PropertyTypeError::BadPath {
+                    path: path.to_string(),
+                    reason: "empty path".into(),
+                });
+            }
+        };
+
+        // Walk into the type. Any field that descends through `Any`
+        // or a Union keeps the claim alive (we can't prove absence),
+        // so we short-circuit. For Record / Map / List, descend; for
+        // primitives, the remaining path must be empty.
+        let mut cursor: &NType = root;
+        for segment in parts {
+            cursor = match cursor {
+                NType::Any => {
+                    // Can't prove the field is absent under Any; accept.
+                    return self.validate_terminal(path, &NType::Any);
+                }
+                NType::Record(fields) => match fields.get(segment) {
+                    Some(t) => t,
+                    None => {
+                        return Err(PropertyTypeError::FieldNotInType {
+                            path: path.to_string(),
+                            side: side_label,
+                            declared_type: format!("{root:?}"),
+                        });
+                    }
+                },
+                _ => {
+                    // Can't descend into a non-record type.
+                    return Err(PropertyTypeError::FieldNotInType {
+                        path: path.to_string(),
+                        side: side_label,
+                        declared_type: format!("{root:?}"),
+                    });
+                }
+            };
+        }
+
+        self.validate_terminal(path, cursor)
+    }
+
+    fn validate_terminal(
+        &self,
+        path: &str,
+        terminal: &crate::types::NType,
+    ) -> Result<(), PropertyTypeError> {
+        use crate::types::NType;
+        match self {
+            // Unknown: the reader can't validate a property kind it
+            // doesn't recognise. Skip rather than error — the property
+            // may be fine under a future reader.
+            Property::Unknown { .. } => Ok(()),
+            // SetMember accepts anything — JSON-value equality is type-blind.
+            Property::SetMember { .. } => Ok(()),
+            // Range needs a Number (or Any / Union containing Number —
+            // we're permissive here).
+            Property::Range { .. } => match terminal {
+                NType::Number | NType::Any => Ok(()),
+                NType::Union(variants) => {
+                    if variants
+                        .iter()
+                        .any(|v| matches!(v, NType::Number | NType::Any))
+                    {
+                        Ok(())
+                    } else {
+                        Err(PropertyTypeError::RangeOnNonNumber {
+                            path: path.to_string(),
+                            declared_type: format!("{terminal:?}"),
+                        })
+                    }
+                }
+                other => Err(PropertyTypeError::RangeOnNonNumber {
+                    path: path.to_string(),
+                    declared_type: format!("{other:?}"),
+                }),
+            },
         }
     }
 
     /// Check whether the property holds for the given `input` /
     /// `output` pair. Returns `Ok(())` on success, a
     /// [`PropertyViolation`] describing exactly what broke on failure.
+    ///
+    /// [`Property::Unknown`] variants return `Ok(())` — a reader that
+    /// doesn't know how to evaluate a property must not treat that
+    /// as a failure. Callers that want to surface "X skipped because
+    /// unknown kind" should check [`Property::is_unknown`] separately.
     pub fn check(
         &self,
         input: &serde_json::Value,
         output: &serde_json::Value,
     ) -> Result<(), PropertyViolation> {
+        if let Property::Unknown { .. } = self {
+            return Ok(());
+        }
         let path = self.field();
         let value = resolve_path(path, input, output)?;
         match self {
@@ -128,6 +302,7 @@ impl Property {
                     })
                 }
             }
+            Property::Unknown { .. } => unreachable!("handled above"),
             Property::Range { min, max, .. } => {
                 let n = value
                     .as_f64()
@@ -350,6 +525,26 @@ mod tests {
     }
 
     #[test]
+    fn unknown_kind_deserialises_into_unknown_variant() {
+        // Forward-compat: a 1.0 reader must not choke on a 1.1 property
+        // kind it doesn't recognise.
+        let future_json = json!({
+            "kind": "regex_match",
+            "field": "output.id",
+            "pattern": "^[A-Z0-9]+$"
+        });
+        let p: Property = serde_json::from_value(future_json.clone()).unwrap();
+        assert!(p.is_unknown(), "expected Unknown, got {p:?}");
+        // Evaluation: skip, not fail.
+        let result = p.check(&json!({}), &json!({"id": "ABC123"}));
+        assert!(result.is_ok());
+        // Type validation: skip, not fail.
+        let vresult =
+            p.validate_against_types(&crate::types::NType::Any, &crate::types::NType::Any);
+        assert!(vresult.is_ok());
+    }
+
+    #[test]
     fn property_json_shape_is_tagged_snake_case() {
         let p = severity_prop();
         let v: serde_json::Value = serde_json::to_value(&p).unwrap();
@@ -358,5 +553,113 @@ mod tests {
         let r = percent_prop();
         let v: serde_json::Value = serde_json::to_value(&r).unwrap();
         assert_eq!(v["kind"], json!("range"));
+    }
+
+    // ── validate_against_types tests ────────────────────────────────
+
+    use crate::types::NType;
+    use std::collections::BTreeMap as BMap;
+
+    fn record(fields: Vec<(&str, NType)>) -> NType {
+        NType::Record(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect::<BMap<_, _>>(),
+        )
+    }
+
+    #[test]
+    fn range_on_numeric_output_field_validates() {
+        let p = Property::Range {
+            field: "output.soc".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        };
+        let out = record(vec![("soc", NType::Number)]);
+        assert!(p.validate_against_types(&NType::Any, &out).is_ok());
+    }
+
+    #[test]
+    fn range_on_text_field_rejected() {
+        // The motivating case from the review: Range on a Text field
+        // must not silently pass.
+        let p = Property::Range {
+            field: "output.severity".into(),
+            min: Some(0.0),
+            max: Some(1.0),
+        };
+        let out = record(vec![("severity", NType::Text)]);
+        let err = p.validate_against_types(&NType::Any, &out).unwrap_err();
+        assert!(matches!(err, PropertyTypeError::RangeOnNonNumber { .. }));
+    }
+
+    #[test]
+    fn set_member_accepts_any_terminal_type() {
+        let p = Property::SetMember {
+            field: "output.severity".into(),
+            set: vec![json!("HIGH"), json!("LOW")],
+        };
+        let out = record(vec![("severity", NType::Text)]);
+        assert!(p.validate_against_types(&NType::Any, &out).is_ok());
+    }
+
+    #[test]
+    fn missing_field_rejected() {
+        let p = Property::SetMember {
+            field: "output.missing".into(),
+            set: vec![json!(1)],
+        };
+        let out = record(vec![("present", NType::Number)]);
+        let err = p.validate_against_types(&NType::Any, &out).unwrap_err();
+        assert!(matches!(err, PropertyTypeError::FieldNotInType { .. }));
+    }
+
+    #[test]
+    fn bad_root_segment_rejected() {
+        let p = Property::SetMember {
+            field: "neither.foo".into(),
+            set: vec![json!(1)],
+        };
+        let err = p
+            .validate_against_types(&NType::Any, &NType::Any)
+            .unwrap_err();
+        assert!(matches!(err, PropertyTypeError::BadPath { .. }));
+    }
+
+    #[test]
+    fn any_field_accepts_arbitrary_path() {
+        // Can't prove absence under Any — we defer to runtime.
+        let p = Property::Range {
+            field: "output.deeply.nested.thing".into(),
+            min: Some(0.0),
+            max: None,
+        };
+        assert!(p.validate_against_types(&NType::Any, &NType::Any).is_ok());
+    }
+
+    #[test]
+    fn range_on_number_union_accepts() {
+        // output type is Number | Null — Range is still valid because
+        // at runtime a non-null value must be numeric.
+        let p = Property::Range {
+            field: "output".into(),
+            min: Some(0.0),
+            max: None,
+        };
+        let union = NType::union(vec![NType::Number, NType::Null]);
+        assert!(p.validate_against_types(&NType::Any, &union).is_ok());
+    }
+
+    #[test]
+    fn nested_path_walks_into_records() {
+        let p = Property::Range {
+            field: "output.battery.soc".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        };
+        let battery = record(vec![("soc", NType::Number)]);
+        let out = record(vec![("battery", battery)]);
+        assert!(p.validate_against_types(&NType::Any, &out).is_ok());
     }
 }

--- a/crates/noether-core/src/stage/property.rs
+++ b/crates/noether-core/src/stage/property.rs
@@ -1,0 +1,362 @@
+//! Declarative properties that a stage claims to satisfy for every
+//! `(input, output)` pair it accepts. Properties are the M2 answer to
+//! the question *"what does this stage actually guarantee, beyond its
+//! type signature?"*. Types say `output: Number`; properties say
+//! `output >= 0 and output <= 100`.
+//!
+//! ## Scope
+//!
+//! Per the M2 roadmap, the DSL is deliberately tiny:
+//!
+//! - [`Property::SetMember`] — a named field is one of a fixed set of
+//!   JSON values.
+//! - [`Property::Range`] — a named numeric field is within `[min, max]`
+//!   (either bound optional).
+//!
+//! Higher-order predicates (implications over examples, quantifiers,
+//! type-class predicates) are explicit non-goals for 1.0.
+//!
+//! ## Wire format
+//!
+//! Properties live on the Stage spec as a JSON array:
+//!
+//! ```json
+//! "properties": [
+//!   { "kind": "set_member",
+//!     "field": "output.severity",
+//!     "set": ["CRITICAL", "HIGH", "WARNING"] },
+//!   { "kind": "range",
+//!     "field": "output.soc_percent",
+//!     "min": 0.0, "max": 100.0 }
+//! ]
+//! ```
+//!
+//! The field path is dot-separated. The first segment must be either
+//! `input` or `output`; the rest navigate into whichever side's JSON.
+//! A path that doesn't resolve produces a [`PropertyViolation::FieldMissing`].
+
+use serde::{Deserialize, Serialize};
+
+/// A declarative property claim on a stage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Property {
+    /// The value at `field` must equal one of the entries in `set`.
+    /// Comparison is JSON-value equality (strings compare as strings,
+    /// numbers as numbers, etc.).
+    SetMember {
+        /// Dot-separated path, e.g. `"output.severity"` or
+        /// `"input.battery.soc"`.
+        field: String,
+        /// Allowed JSON values. Order does not matter.
+        set: Vec<serde_json::Value>,
+    },
+    /// The numeric value at `field` must lie within `[min, max]`. Either
+    /// bound may be omitted; an omitted bound means "unbounded on that
+    /// side". A non-numeric value at the field path fails with
+    /// [`PropertyViolation::NotNumber`].
+    Range {
+        /// Dot-separated path to a numeric field.
+        field: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<f64>,
+    },
+}
+
+/// A specific way a property failed to hold. Each variant carries
+/// enough context to make the failure actionable without a stack trace.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum PropertyViolation {
+    #[error(
+        "field path `{path}` is malformed: must start with `input.` or `output.` (got: `{reason}`)"
+    )]
+    BadPath { path: String, reason: String },
+
+    #[error("field `{path}` is missing or unreachable in the {side} JSON")]
+    FieldMissing { path: String, side: &'static str },
+
+    #[error("field `{path}` is `{actual}`; expected one of: {expected:?}")]
+    NotInSet {
+        path: String,
+        actual: serde_json::Value,
+        expected: Vec<serde_json::Value>,
+    },
+
+    #[error("field `{path}` is {actual}; expected a number for range check")]
+    NotNumber {
+        path: String,
+        actual: serde_json::Value,
+    },
+
+    #[error("field `{path}` is {actual}; expected >= {min}")]
+    BelowMin { path: String, actual: f64, min: f64 },
+
+    #[error("field `{path}` is {actual}; expected <= {max}")]
+    AboveMax { path: String, actual: f64, max: f64 },
+}
+
+impl Property {
+    /// The field path this property constrains. Used by callers that
+    /// want to group properties by target field for reporting.
+    pub fn field(&self) -> &str {
+        match self {
+            Property::SetMember { field, .. } | Property::Range { field, .. } => field,
+        }
+    }
+
+    /// Check whether the property holds for the given `input` /
+    /// `output` pair. Returns `Ok(())` on success, a
+    /// [`PropertyViolation`] describing exactly what broke on failure.
+    pub fn check(
+        &self,
+        input: &serde_json::Value,
+        output: &serde_json::Value,
+    ) -> Result<(), PropertyViolation> {
+        let path = self.field();
+        let value = resolve_path(path, input, output)?;
+        match self {
+            Property::SetMember { set, .. } => {
+                if set.iter().any(|allowed| allowed == value) {
+                    Ok(())
+                } else {
+                    Err(PropertyViolation::NotInSet {
+                        path: path.to_string(),
+                        actual: value.clone(),
+                        expected: set.clone(),
+                    })
+                }
+            }
+            Property::Range { min, max, .. } => {
+                let n = value
+                    .as_f64()
+                    .or_else(|| value.as_i64().map(|i| i as f64))
+                    .or_else(|| value.as_u64().map(|u| u as f64))
+                    .ok_or_else(|| PropertyViolation::NotNumber {
+                        path: path.to_string(),
+                        actual: value.clone(),
+                    })?;
+                if let Some(lo) = min {
+                    if n < *lo {
+                        return Err(PropertyViolation::BelowMin {
+                            path: path.to_string(),
+                            actual: n,
+                            min: *lo,
+                        });
+                    }
+                }
+                if let Some(hi) = max {
+                    if n > *hi {
+                        return Err(PropertyViolation::AboveMax {
+                            path: path.to_string(),
+                            actual: n,
+                            max: *hi,
+                        });
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Navigate a dot-separated path into either the input or the output
+/// JSON value. Returns a reference into the chosen side, or a
+/// [`PropertyViolation`] describing why the path didn't resolve.
+fn resolve_path<'a>(
+    path: &str,
+    input: &'a serde_json::Value,
+    output: &'a serde_json::Value,
+) -> Result<&'a serde_json::Value, PropertyViolation> {
+    let mut parts = path.split('.');
+    let side = parts.next().ok_or_else(|| PropertyViolation::BadPath {
+        path: path.to_string(),
+        reason: "empty path".into(),
+    })?;
+    let (root, side_label): (&serde_json::Value, &'static str) = match side {
+        "input" => (input, "input"),
+        "output" => (output, "output"),
+        other => {
+            return Err(PropertyViolation::BadPath {
+                path: path.to_string(),
+                reason: format!("first segment must be `input` or `output`, got `{other}`"),
+            });
+        }
+    };
+    let mut cursor = root;
+    for segment in parts {
+        cursor = match cursor {
+            serde_json::Value::Object(map) => {
+                map.get(segment)
+                    .ok_or_else(|| PropertyViolation::FieldMissing {
+                        path: path.to_string(),
+                        side: side_label,
+                    })?
+            }
+            // Array indexing is deliberately out of scope for M2.
+            _ => {
+                return Err(PropertyViolation::FieldMissing {
+                    path: path.to_string(),
+                    side: side_label,
+                });
+            }
+        };
+    }
+    Ok(cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn severity_prop() -> Property {
+        Property::SetMember {
+            field: "output.severity".into(),
+            set: vec![json!("CRITICAL"), json!("HIGH"), json!("WARNING")],
+        }
+    }
+
+    fn percent_prop() -> Property {
+        Property::Range {
+            field: "output.soc_percent".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        }
+    }
+
+    #[test]
+    fn set_member_passes_on_allowed_value() {
+        let p = severity_prop();
+        assert!(p.check(&json!(null), &json!({"severity": "HIGH"})).is_ok());
+    }
+
+    #[test]
+    fn set_member_fails_on_disallowed_value() {
+        let p = severity_prop();
+        let err = p
+            .check(&json!(null), &json!({"severity": "INFO"}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::NotInSet { .. }));
+    }
+
+    #[test]
+    fn range_passes_in_bounds() {
+        let p = percent_prop();
+        assert!(p.check(&json!(null), &json!({"soc_percent": 42.0})).is_ok());
+    }
+
+    #[test]
+    fn range_fails_below_min() {
+        let p = percent_prop();
+        let err = p
+            .check(&json!(null), &json!({"soc_percent": -1.0}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::BelowMin { .. }));
+    }
+
+    #[test]
+    fn range_fails_above_max() {
+        let p = percent_prop();
+        let err = p
+            .check(&json!(null), &json!({"soc_percent": 101.0}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::AboveMax { .. }));
+    }
+
+    #[test]
+    fn range_accepts_integer_representation() {
+        let p = percent_prop();
+        // JSON `42` (i64) must be treated as 42.0 for range checks.
+        assert!(p.check(&json!(null), &json!({"soc_percent": 42})).is_ok());
+    }
+
+    #[test]
+    fn range_unbounded_min_only() {
+        let p = Property::Range {
+            field: "output.x".into(),
+            min: None,
+            max: Some(10.0),
+        };
+        assert!(p.check(&json!(null), &json!({"x": -100})).is_ok());
+        assert!(p.check(&json!(null), &json!({"x": 11})).is_err());
+    }
+
+    #[test]
+    fn path_resolves_into_input() {
+        let p = Property::SetMember {
+            field: "input.mode".into(),
+            set: vec![json!("fast"), json!("slow")],
+        };
+        assert!(p.check(&json!({"mode": "fast"}), &json!(null)).is_ok());
+    }
+
+    #[test]
+    fn path_resolves_nested() {
+        let p = Property::Range {
+            field: "output.battery.soc".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        };
+        assert!(p
+            .check(&json!(null), &json!({"battery": {"soc": 42}}))
+            .is_ok());
+    }
+
+    #[test]
+    fn missing_field_errors_descriptively() {
+        let p = severity_prop();
+        let err = p.check(&json!(null), &json!({})).unwrap_err();
+        assert!(
+            matches!(err, PropertyViolation::FieldMissing { side: "output", .. }),
+            "expected FieldMissing(output), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn non_numeric_range_check_errors() {
+        let p = percent_prop();
+        let err = p
+            .check(&json!(null), &json!({"soc_percent": "oops"}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::NotNumber { .. }));
+    }
+
+    #[test]
+    fn bad_root_segment_errors() {
+        let p = Property::SetMember {
+            field: "neither.foo".into(),
+            set: vec![json!(1)],
+        };
+        let err = p.check(&json!({}), &json!({})).unwrap_err();
+        assert!(matches!(err, PropertyViolation::BadPath { .. }));
+    }
+
+    #[test]
+    fn property_serde_round_trip_set_member() {
+        let p = severity_prop();
+        let json_str = serde_json::to_string(&p).unwrap();
+        let parsed: Property = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn property_serde_round_trip_range() {
+        let p = percent_prop();
+        let json_str = serde_json::to_string(&p).unwrap();
+        let parsed: Property = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn property_json_shape_is_tagged_snake_case() {
+        let p = severity_prop();
+        let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["kind"], json!("set_member"));
+
+        let r = percent_prop();
+        let v: serde_json::Value = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["kind"], json!("range"));
+    }
+}

--- a/crates/noether-core/src/stage/schema.rs
+++ b/crates/noether-core/src/stage/schema.rs
@@ -130,6 +130,51 @@ pub struct Stage {
     /// identities).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    /// Declarative properties the stage claims to satisfy for every
+    /// `(input, output)` pair. Checked against examples at registration
+    /// time (`noether stage verify --with-properties`) and optionally
+    /// at runtime. Types say *what shape* the output has; properties
+    /// say *which values* it may actually take. See
+    /// [`crate::stage::property`] for the DSL.
+    ///
+    /// Not part of the content hash — a stage's properties can be
+    /// strengthened in a follow-up release without forcing a new
+    /// `StageId`. They **can** only grow within 1.x per
+    /// `STABILITY.md`: existing entries cannot be removed or
+    /// weakened.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub properties: Vec<crate::stage::property::Property>,
+}
+
+impl Stage {
+    /// Check every declared property against every declared example.
+    /// Returns `Ok(())` if all `(example, property)` pairs pass, or
+    /// the list of violations if any fail. Empty `properties` vacuously
+    /// passes.
+    ///
+    /// This is the CI-time check the M2 roadmap promises. `noether
+    /// stage verify --with-properties` wraps this with CLI reporting.
+    pub fn check_properties(
+        &self,
+    ) -> Result<(), Vec<(usize, crate::stage::property::PropertyViolation)>> {
+        if self.properties.is_empty() {
+            return Ok(());
+        }
+        let mut violations = Vec::new();
+        for (example_idx, example) in self.examples.iter().enumerate() {
+            for property in &self.properties {
+                if let Err(violation) = property.check(&example.input, &example.output) {
+                    violations.push((example_idx, violation));
+                }
+            }
+        }
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            Err(violations)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -171,6 +216,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: Some("text_to_number".into()),
+            properties: vec![],
         };
         let json = serde_json::to_string_pretty(&stage).unwrap();
         let deserialized: Stage = serde_json::from_str(&json).unwrap();
@@ -203,6 +249,71 @@ mod tests {
             stage.signature_id,
             Some(SignatureId("legacy_sig_hash".into()))
         );
+    }
+
+    #[test]
+    fn check_properties_empty_passes_vacuously() {
+        let mut stage = sample_stage();
+        stage.properties = vec![];
+        assert!(stage.check_properties().is_ok());
+    }
+
+    #[test]
+    fn check_properties_flags_all_violations_across_examples() {
+        use crate::stage::property::{Property, PropertyViolation};
+        let mut stage = sample_stage();
+        // Two examples: one passes, one fails the range property.
+        stage.examples = vec![
+            Example {
+                input: serde_json::json!(null),
+                output: serde_json::json!({"soc": 50.0}),
+            },
+            Example {
+                input: serde_json::json!(null),
+                output: serde_json::json!({"soc": 150.0}),
+            },
+        ];
+        stage.properties = vec![Property::Range {
+            field: "output.soc".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        }];
+
+        let result = stage.check_properties();
+        let violations = result.unwrap_err();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].0, 1);
+        assert!(matches!(
+            violations[0].1,
+            PropertyViolation::AboveMax { .. }
+        ));
+    }
+
+    // Helper used only by the check_properties tests.
+    fn sample_stage() -> Stage {
+        Stage {
+            id: StageId("deadbeef".into()),
+            signature_id: Some(SignatureId("sig".into())),
+            signature: sample_signature(),
+            capabilities: BTreeSet::new(),
+            cost: CostEstimate {
+                time_ms_p50: None,
+                tokens_est: None,
+                memory_mb: None,
+            },
+            description: "sample".into(),
+            examples: vec![],
+            lifecycle: StageLifecycle::Active,
+            ed25519_signature: None,
+            signer_public_key: None,
+            implementation_code: None,
+            implementation_language: None,
+            ui_style: None,
+            tags: vec![],
+            aliases: vec![],
+            name: Some("sample".into()),
+            properties: vec![],
+        }
     }
 
     #[test]

--- a/crates/noether-core/src/stage/schema.rs
+++ b/crates/noether-core/src/stage/schema.rs
@@ -147,19 +147,45 @@ pub struct Stage {
     pub properties: Vec<crate::stage::property::Property>,
 }
 
+/// Failure mode for [`Stage::check_properties`].
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum CheckPropertiesError {
+    /// The stage declares properties but has no examples to check
+    /// them against. Previously this returned Ok vacuously — now it's
+    /// an error so bogus properties can't hide behind a missing
+    /// example set.
+    #[error(
+        "stage declares {count} properties but has no examples to \
+         verify them against — add at least one example"
+    )]
+    NoExamples { count: usize },
+
+    /// One or more (example, property) pairs failed. Each entry is
+    /// `(example_index, violation)`.
+    #[error("{} property violation(s) across examples", .0.len())]
+    Violations(Vec<(usize, crate::stage::property::PropertyViolation)>),
+}
+
 impl Stage {
     /// Check every declared property against every declared example.
-    /// Returns `Ok(())` if all `(example, property)` pairs pass, or
-    /// the list of violations if any fail. Empty `properties` vacuously
-    /// passes.
+    /// Returns `Ok(())` if all `(example, property)` pairs pass, or a
+    /// [`CheckPropertiesError`] describing the failure.
+    ///
+    /// A stage with no properties vacuously passes. A stage with
+    /// properties but no examples is an error ([`CheckPropertiesError::NoExamples`]) —
+    /// previously a vacuous pass, which let property bugs slip
+    /// through on under-specified stages.
     ///
     /// This is the CI-time check the M2 roadmap promises. `noether
     /// stage verify --with-properties` wraps this with CLI reporting.
-    pub fn check_properties(
-        &self,
-    ) -> Result<(), Vec<(usize, crate::stage::property::PropertyViolation)>> {
+    pub fn check_properties(&self) -> Result<(), CheckPropertiesError> {
         if self.properties.is_empty() {
             return Ok(());
+        }
+        if self.examples.is_empty() {
+            return Err(CheckPropertiesError::NoExamples {
+                count: self.properties.len(),
+            });
         }
         let mut violations = Vec::new();
         for (example_idx, example) in self.examples.iter().enumerate() {
@@ -172,7 +198,7 @@ impl Stage {
         if violations.is_empty() {
             Ok(())
         } else {
-            Err(violations)
+            Err(CheckPropertiesError::Violations(violations))
         }
     }
 }
@@ -259,6 +285,86 @@ mod tests {
     }
 
     #[test]
+    fn check_properties_with_no_examples_errors() {
+        // The fix for the "vacuous pass" review finding: a stage that
+        // declares properties but has no examples MUST error, not pass.
+        // Otherwise under-specified stages would hide property bugs.
+        use crate::stage::property::Property;
+        let mut stage = sample_stage();
+        stage.examples = vec![]; // deliberately empty
+        stage.properties = vec![Property::Range {
+            field: "output.x".into(),
+            min: Some(0.0),
+            max: None,
+        }];
+        match stage.check_properties().unwrap_err() {
+            CheckPropertiesError::NoExamples { count } => assert_eq!(count, 1),
+            other => panic!("expected NoExamples, got {other:?}"),
+        }
+    }
+
+    /// Properties are documented as "not part of the content hash".
+    /// This test pins that contract: two stages identical except for
+    /// `properties` produce identical `id` and `signature_id`, and
+    /// the hashes computed from their signatures match.
+    #[test]
+    fn properties_do_not_affect_stage_identity() {
+        use crate::stage::property::Property;
+        use crate::stage::{compute_signature_id, compute_stage_id};
+
+        let name = "sample";
+        let sig = sample_signature();
+
+        // Compute both IDs from the signature directly — this is the
+        // invariant we actually want to pin.
+        let expected_stage_id = compute_stage_id(name, &sig).unwrap();
+        let expected_sig_id =
+            compute_signature_id(name, &sig.input, &sig.output, &sig.effects).unwrap();
+
+        // Build two Stage values, one with properties and one without,
+        // that are otherwise identical.
+        let base = Stage {
+            id: expected_stage_id.clone(),
+            signature_id: Some(expected_sig_id.clone()),
+            signature: sig,
+            capabilities: BTreeSet::new(),
+            cost: CostEstimate {
+                time_ms_p50: None,
+                tokens_est: None,
+                memory_mb: None,
+            },
+            description: "sample".into(),
+            examples: vec![],
+            lifecycle: StageLifecycle::Active,
+            ed25519_signature: None,
+            signer_public_key: None,
+            implementation_code: None,
+            implementation_language: None,
+            ui_style: None,
+            tags: vec![],
+            aliases: vec![],
+            name: Some(name.into()),
+            properties: vec![],
+        };
+        let mut with_properties = base.clone();
+        with_properties.properties = vec![Property::Range {
+            field: "output.x".into(),
+            min: Some(0.0),
+            max: Some(100.0),
+        }];
+
+        // StageId is unaffected by adding properties.
+        assert_eq!(base.id, with_properties.id);
+        // SignatureId is unaffected.
+        assert_eq!(base.signature_id, with_properties.signature_id);
+
+        // Both hashes computed from signature alone match the stored
+        // values (the "not part of the hash" guarantee).
+        assert_eq!(base.id, expected_stage_id);
+        assert_eq!(base.signature_id.as_ref().unwrap(), &expected_sig_id);
+    }
+
+    #[test]
     fn check_properties_flags_all_violations_across_examples() {
         use crate::stage::property::{Property, PropertyViolation};
         let mut stage = sample_stage();
@@ -280,13 +386,17 @@ mod tests {
         }];
 
         let result = stage.check_properties();
-        let violations = result.unwrap_err();
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].0, 1);
-        assert!(matches!(
-            violations[0].1,
-            PropertyViolation::AboveMax { .. }
-        ));
+        match result.unwrap_err() {
+            CheckPropertiesError::Violations(violations) => {
+                assert_eq!(violations.len(), 1);
+                assert_eq!(violations[0].0, 1);
+                assert!(matches!(
+                    violations[0].1,
+                    PropertyViolation::AboveMax { .. }
+                ));
+            }
+            other => panic!("expected Violations, got {other:?}"),
+        }
     }
 
     // Helper used only by the check_properties tests.

--- a/crates/noether-core/tests/integration_test.rs
+++ b/crates/noether-core/tests/integration_test.rs
@@ -68,6 +68,7 @@ fn full_stage_round_trip() {
         tags: vec![],
         aliases: vec![],
         name: None,
+        properties: Vec::new(),
     };
 
     // 6. Serialize to JSON and back

--- a/crates/noether-engine/src/checker.rs
+++ b/crates/noether-engine/src/checker.rs
@@ -1232,6 +1232,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-engine/src/executor/budget.rs
+++ b/crates/noether-engine/src/executor/budget.rs
@@ -232,6 +232,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 
@@ -362,6 +363,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         };
         store.put(free).unwrap();
 

--- a/crates/noether-engine/src/index/mod.rs
+++ b/crates/noether-engine/src/index/mod.rs
@@ -434,6 +434,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-engine/src/index/text.rs
+++ b/crates/noether-engine/src/index/text.rs
@@ -73,6 +73,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-engine/src/lagrange/mod.rs
+++ b/crates/noether-engine/src/lagrange/mod.rs
@@ -289,6 +289,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: Some("volvo_map".into()),
+            properties: Vec::new(),
         };
         let mut store = MemoryStore::new();
         store.put(stage.clone()).unwrap();
@@ -342,6 +343,7 @@ mod tests {
                 tags: vec![],
                 aliases: vec![],
                 name: Some("shared".into()),
+                properties: Vec::new(),
             }
         }
 

--- a/crates/noether-engine/src/stage_test.rs
+++ b/crates/noether-engine/src/stage_test.rs
@@ -238,6 +238,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-grid-broker/src/splitter.rs
+++ b/crates/noether-grid-broker/src/splitter.rs
@@ -317,6 +317,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-store/src/file.rs
+++ b/crates/noether-store/src/file.rs
@@ -203,6 +203,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 

--- a/crates/noether-store/src/memory.rs
+++ b/crates/noether-store/src/memory.rs
@@ -148,6 +148,7 @@ mod tests {
             tags: vec![],
             aliases: vec![],
             name: None,
+            properties: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Fourth slice of M2. Stages can now declare **value-level invariants**
alongside their type signature. Types say *what shape* the output has;
properties say *which values* it may take.

### Scope (deliberately small per M2 roadmap)

- **`Property::SetMember { field, set }`** — the value at `field` (a
  dot-separated path rooted at `input.` or `output.`) must equal one
  of the JSON values in `set`.
- **`Property::Range { field, min, max }`** — the numeric value at
  `field` must be within `[min, max]`. Either bound optional.

### Wire format

Structured JSON (tagged `"kind"`), not a string DSL:

```json
"properties": [
  { "kind": "set_member",
    "field": "output.severity",
    "set": ["CRITICAL", "HIGH", "WARNING"] },
  { "kind": "range",
    "field": "output.soc_percent",
    "min": 0.0, "max": 100.0 }
]
```

A future minor release can add a string-syntax parser if useful; the
structured form is the normative storage shape either way.

### Evaluator

- `Property::check(&input, &output) -> Result<(), PropertyViolation>` —
  variant-typed violation (`BadPath`, `FieldMissing`, `NotInSet`,
  `NotNumber`, `BelowMin`, `AboveMax`) with path + value context. Good
  for CLI reporting.
- `Stage::check_properties() -> Result<(), Vec<(usize, PropertyViolation)>>` —
  runs every property against every declared example, returns the list
  of `(example_idx, violation)` pairs on failure.

### New tests (17 total)

- Unit checks for every violation variant.
- Serde round-trips for both property kinds.
- Nested path resolution (`output.battery.soc`).
- Integer → f64 coercion in range checks.
- End-to-end `Stage::check_properties` across multiple examples.

### Not in this PR (intentional)

- `noether stage verify --with-properties` CLI — next slice.
- Stdlib property backfill (the ≥3-per-stage M2 exit criterion) —
  final slice.
- Higher-order predicates (implications over examples, quantifiers) —
  explicit non-goal for 1.0.

### Stacked on

- #23 (M1) → #24 (STABILITY.md) → #25 (StageId split) → #26 (pinning) →
  this PR

## Test plan

- [x] `cargo test --workspace` green (91 noether-core tests, +17 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Review: is structured JSON the right storage shape long-term, or
      do we want a string-DSL layer before 1.0?
- [ ] Review: `PropertyViolation` variants — is `FieldMissing`
      aggressive enough, or should we treat missing fields as vacuously
      true on the assumption the path wasn't emitted in that example?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
