### PR TITLE
feat(M2.2): wire resolve_pinning into every graph-parse entry point

### DIFF
--- a/crates/noether-cli/src/commands/build.rs
+++ b/crates/noether-cli/src/commands/build.rs
@@ -14,7 +14,7 @@
 use noether_core::stage::{Stage, StageId};
 use noether_core::stdlib::load_stdlib;
 use noether_engine::checker::{check_graph, verify_signatures};
-use noether_engine::lagrange::{collect_stage_ids, parse_graph};
+use noether_engine::lagrange::{collect_stage_ids, parse_graph, resolve_pinning};
 use noether_store::StageStore;
 use std::collections::HashSet;
 use std::path::Path;
@@ -60,13 +60,43 @@ pub fn cmd_build(store: &dyn StageStore, opts: BuildOptions<'_>) {
             std::process::exit(1);
         }
     };
-    let graph = match parse_graph(&graph_json) {
+    let mut graph = match parse_graph(&graph_json) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("{}", acli_error(&format!("Invalid graph JSON: {e}")));
             std::process::exit(1);
         }
     };
+
+    // ── 1a. Resolve pinning ──────────────────────────────────────────────────
+    // Rewrite signature-pinned refs to concrete implementation IDs so every
+    // downstream pass (type-check, signature verify, planner, cost map) sees
+    // impl hashes and can use `store.get` directly. Without this, a graph
+    // that declares `pinning: "signature"` would type-check but fail at
+    // subsequent passes. Same logic as `noether run`.
+    let resolution = match resolve_pinning(&mut graph.root, store) {
+        Ok(rep) => rep,
+        Err(e) => {
+            eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+            std::process::exit(1);
+        }
+    };
+    for rw in &resolution.rewrites {
+        eprintln!(
+            "Info: {:?}-pinned stage {} resolved to {}",
+            rw.pinning,
+            &rw.before[..8.min(rw.before.len())],
+            &rw.after[..8.min(rw.after.len())]
+        );
+    }
+    for w in &resolution.warnings {
+        eprintln!(
+            "Warning: signature {} has {} Active implementations — deterministically picked {}",
+            &w.signature_id[..8.min(w.signature_id.len())],
+            w.active_implementation_ids.len(),
+            &w.chosen[..8.min(w.chosen.len())],
+        );
+    }
 
     // ── 2. Type-check ─────────────────────────────────────────────────────────
     match check_graph(&graph.root, store) {

--- a/crates/noether-cli/src/commands/build_browser.rs
+++ b/crates/noether-cli/src/commands/build_browser.rs
@@ -26,7 +26,7 @@ use crate::output::{acli_error, acli_error_hints, acli_ok};
 use noether_core::stage::{Stage, StageId};
 use noether_core::stdlib::load_stdlib;
 use noether_engine::checker::{check_graph, verify_signatures};
-use noether_engine::lagrange::{collect_stage_ids, parse_graph};
+use noether_engine::lagrange::{collect_stage_ids, parse_graph, resolve_pinning};
 use noether_store::StageStore;
 use std::collections::HashSet;
 use std::path::Path;
@@ -47,13 +47,21 @@ pub fn cmd_build_browser(store: &dyn StageStore, opts: BuildOptions<'_>) {
             std::process::exit(1);
         }
     };
-    let graph = match parse_graph(&graph_json) {
+    let mut graph = match parse_graph(&graph_json) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("{}", acli_error(&format!("Invalid graph JSON: {e}")));
             std::process::exit(1);
         }
     };
+
+    // ── 1a. Resolve pinning ──────────────────────────────────────────────────
+    // Same rationale as `noether run`: rewrite signature-pinned refs so
+    // downstream passes see concrete impl IDs.
+    if let Err(e) = resolve_pinning(&mut graph.root, store) {
+        eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+        std::process::exit(1);
+    }
 
     // ── 2. Type-check ─────────────────────────────────────────────────────────
     match check_graph(&graph.root, store) {

--- a/crates/noether-cli/src/commands/compose.rs
+++ b/crates/noether-cli/src/commands/compose.rs
@@ -7,7 +7,9 @@ use noether_engine::checker::{
 use noether_engine::composition_cache::CompositionCache;
 use noether_engine::executor::runner::run_composition;
 use noether_engine::index::SemanticIndex;
-use noether_engine::lagrange::{compute_composition_id, serialize_graph, CompositionGraph};
+use noether_engine::lagrange::{
+    compute_composition_id, resolve_pinning, serialize_graph, CompositionGraph,
+};
 use noether_engine::llm::{LlmConfig, LlmProvider};
 use noether_engine::planner::plan_graph;
 use noether_store::StageStore;
@@ -46,6 +48,15 @@ pub fn cmd_compose(
                 "Cache hit (model: {}, composed: {}s ago). Use --force to recompose.",
                 cached.model, age_secs,
             );
+            // Resolve pinning on a local clone so downstream passes see
+            // concrete impl IDs. composition_id is computed from the
+            // pre-resolution graph (inside emit_result), so rewrites
+            // don't affect the hashed identity.
+            let mut cached_graph = cached.graph.clone();
+            if let Err(e) = resolve_pinning(&mut cached_graph.root, store) {
+                eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+                std::process::exit(1);
+            }
             emit_result(
                 store,
                 EmitCtx {
@@ -56,7 +67,7 @@ pub fn cmd_compose(
                     cache_age_secs: age_secs,
                     attempts: 0,
                     synthesized: &[],
-                    graph: &cached.graph.clone(),
+                    graph: &cached_graph,
                     policy: opts.policy,
                     budget_cents: opts.budget_cents,
                 },
@@ -86,7 +97,12 @@ pub fn cmd_compose(
         cache.insert(problem, result.graph.clone(), opts.model);
     }
 
-    let (graph, synthesized, attempts) = (result.graph, result.synthesized, result.attempts);
+    let (mut graph, synthesized, attempts) = (result.graph, result.synthesized, result.attempts);
+    // Resolve pinning on the fresh graph before downstream passes run.
+    if let Err(e) = resolve_pinning(&mut graph.root, store) {
+        eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+        std::process::exit(1);
+    }
     emit_result(
         store,
         EmitCtx {

--- a/crates/noether-cli/src/commands/compose.rs
+++ b/crates/noether-cli/src/commands/compose.rs
@@ -1,3 +1,4 @@
+use super::resolver_utils::resolve_and_emit_diagnostics;
 use crate::output::{acli_error, acli_error_hints, acli_ok, acli_ok_cached};
 use acli::output::CacheMeta;
 use noether_engine::agent::SynthesisResult;
@@ -7,9 +8,7 @@ use noether_engine::checker::{
 use noether_engine::composition_cache::CompositionCache;
 use noether_engine::executor::runner::run_composition;
 use noether_engine::index::SemanticIndex;
-use noether_engine::lagrange::{
-    compute_composition_id, resolve_pinning, serialize_graph, CompositionGraph,
-};
+use noether_engine::lagrange::{compute_composition_id, serialize_graph, CompositionGraph};
 use noether_engine::llm::{LlmConfig, LlmProvider};
 use noether_engine::planner::plan_graph;
 use noether_store::StageStore;
@@ -48,13 +47,15 @@ pub fn cmd_compose(
                 "Cache hit (model: {}, composed: {}s ago). Use --force to recompose.",
                 cached.model, age_secs,
             );
-            // Resolve pinning on a local clone so downstream passes see
-            // concrete impl IDs. composition_id is computed from the
-            // pre-resolution graph (inside emit_result), so rewrites
-            // don't affect the hashed identity.
+            // Composition identity is taken from the **pre-resolution**
+            // graph — the M1 "canonical form is identity" contract.
+            // Compute the id now, then let resolve_and_emit_diagnostics
+            // rewrite the graph for downstream passes.
             let mut cached_graph = cached.graph.clone();
-            if let Err(e) = resolve_pinning(&mut cached_graph.root, store) {
-                eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+            let composition_id =
+                compute_composition_id(&cached_graph).unwrap_or_else(|_| "unknown".into());
+            if let Err(msg) = resolve_and_emit_diagnostics(&mut cached_graph, store) {
+                eprintln!("{}", acli_error(&msg));
                 std::process::exit(1);
             }
             emit_result(
@@ -68,6 +69,7 @@ pub fn cmd_compose(
                     attempts: 0,
                     synthesized: &[],
                     graph: &cached_graph,
+                    composition_id,
                     policy: opts.policy,
                     budget_cents: opts.budget_cents,
                 },
@@ -98,9 +100,11 @@ pub fn cmd_compose(
     }
 
     let (mut graph, synthesized, attempts) = (result.graph, result.synthesized, result.attempts);
-    // Resolve pinning on the fresh graph before downstream passes run.
-    if let Err(e) = resolve_pinning(&mut graph.root, store) {
-        eprintln!("{}", acli_error(&format!("Pinning resolution: {e}")));
+    // Composition identity from the pre-resolution graph — see the
+    // cached branch above for the contract rationale.
+    let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+    if let Err(msg) = resolve_and_emit_diagnostics(&mut graph, store) {
+        eprintln!("{}", acli_error(&msg));
         std::process::exit(1);
     }
     emit_result(
@@ -114,6 +118,7 @@ pub fn cmd_compose(
             attempts,
             synthesized: &synthesized,
             graph: &graph,
+            composition_id,
             policy: opts.policy,
             budget_cents: opts.budget_cents,
         },
@@ -131,12 +136,17 @@ struct EmitCtx<'a> {
     attempts: u32,
     synthesized: &'a [SynthesisResult],
     graph: &'a CompositionGraph,
+    /// Composition identity computed from the **pre-resolution** graph.
+    /// Must be supplied by the caller — hashing `ctx.graph` here would
+    /// see the already-resolved form and violate the M1/#28 contract
+    /// that the same source graph produces a stable id across days.
+    composition_id: String,
     policy: &'a CapabilityPolicy,
     budget_cents: Option<u64>,
 }
 
 fn emit_result(store: &mut dyn StageStore, ctx: EmitCtx<'_>) {
-    let composition_id = compute_composition_id(ctx.graph).unwrap_or_else(|_| "unknown".into());
+    let composition_id = ctx.composition_id.clone();
     let graph_json = serialize_graph(ctx.graph).unwrap_or_else(|_| "{}".into());
 
     let synthesized_json: Vec<serde_json::Value> = ctx

--- a/crates/noether-cli/src/commands/compose.rs
+++ b/crates/noether-cli/src/commands/compose.rs
@@ -52,8 +52,19 @@ pub fn cmd_compose(
             // Compute the id now, then let resolve_and_emit_diagnostics
             // rewrite the graph for downstream passes.
             let mut cached_graph = cached.graph.clone();
-            let composition_id =
-                compute_composition_id(&cached_graph).unwrap_or_else(|_| "unknown".into());
+            let composition_id = match compute_composition_id(&cached_graph) {
+                Ok(id) => id,
+                Err(e) => {
+                    // Cached graph somehow broke hashing. Loud failure
+                    // beats an "unknown" envelope that gives the
+                    // operator no breadcrumb to the cause.
+                    eprintln!(
+                        "{}",
+                        acli_error(&format!("failed to hash cached composition graph: {e}"))
+                    );
+                    std::process::exit(1);
+                }
+            };
             if let Err(msg) = resolve_and_emit_diagnostics(&mut cached_graph, store) {
                 eprintln!("{}", acli_error(&msg));
                 std::process::exit(1);
@@ -102,7 +113,16 @@ pub fn cmd_compose(
     let (mut graph, synthesized, attempts) = (result.graph, result.synthesized, result.attempts);
     // Composition identity from the pre-resolution graph — see the
     // cached branch above for the contract rationale.
-    let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+    let composition_id = match compute_composition_id(&graph) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!(
+                "{}",
+                acli_error(&format!("failed to hash composition graph: {e}"))
+            );
+            std::process::exit(1);
+        }
+    };
     if let Err(msg) = resolve_and_emit_diagnostics(&mut graph, store) {
         eprintln!("{}", acli_error(&msg));
         std::process::exit(1);

--- a/crates/noether-cli/src/commands/compose.rs
+++ b/crates/noether-cli/src/commands/compose.rs
@@ -146,6 +146,16 @@ struct EmitCtx<'a> {
 }
 
 fn emit_result(store: &mut dyn StageStore, ctx: EmitCtx<'_>) {
+    // Loud failure when a future caller forgets to populate
+    // `composition_id`. The field doc says the caller must supply it;
+    // a silent empty string in an ACLI envelope would be a nasty
+    // debugging experience.
+    debug_assert!(
+        !ctx.composition_id.is_empty(),
+        "EmitCtx::composition_id must be computed by the caller on \
+         the pre-resolution graph; see the cache-hit and fresh-compose \
+         paths in cmd_compose for the contract"
+    );
     let composition_id = ctx.composition_id.clone();
     let graph_json = serialize_graph(ctx.graph).unwrap_or_else(|_| "{}".into());
 

--- a/crates/noether-cli/src/commands/mod.rs
+++ b/crates/noether-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod build_browser;
 pub mod build_mobile;
 pub mod compose;
 pub mod executor_builder;
+pub mod resolver_utils;
 pub mod run;
 pub mod serve;
 pub mod stage;

--- a/crates/noether-cli/src/commands/resolver_utils.rs
+++ b/crates/noether-cli/src/commands/resolver_utils.rs
@@ -1,17 +1,11 @@
-//! Shared graph-resolution preamble for every CLI entry point that
-//! ingests a Lagrange graph.
+//! Shared CLI-side graph-resolution preamble.
 //!
-//! The pass is split into two steps by necessity:
-//!
-//! * [`resolve_pinning`] — signature/canonical → concrete implementation
-//!   rewrites, surfacing invariant-violation warnings from the store.
-//! * [`resolve_deprecated_stages`] — follow `successor_id` chains so
-//!   graphs that still reference retired implementations keep running.
-//!
-//! Both used to live inline in `run.rs`. PR #32 extended resolution to
-//! `compose`, `serve`, `build`, `build_browser`, scheduler, broker, and
-//! grid-worker. Duplicating the diagnostic boilerplate at every site
-//! would drift — hence this helper.
+//! Thin wrapper around the two engine-level passes —
+//! [`resolve_pinning`] and [`resolve_deprecated_stages`] — that adds
+//! stderr diagnostic emission in the shape CLI users expect. Broker
+//! and worker crates call the engine passes directly and route
+//! diagnostics through `tracing` instead; this module serves only
+//! the CLI binary's stderr audience.
 //!
 //! `CompositionId` must be computed *before* calling
 //! [`resolve_and_emit_diagnostics`]: the M1 "canonical form is identity"
@@ -20,8 +14,9 @@
 //! observe unstable IDs whenever the store's Active implementation
 //! changes.
 
-use noether_core::stage::{StageId, StageLifecycle};
-use noether_engine::lagrange::{resolve_pinning, CompositionGraph, CompositionNode};
+use noether_engine::lagrange::{
+    resolve_deprecated_stages, resolve_pinning, ChainEvent, CompositionGraph,
+};
 use noether_store::StageStore;
 
 /// Run the post-parse resolution passes on `graph` and print any
@@ -59,100 +54,45 @@ pub fn resolve_and_emit_diagnostics(
         );
     }
 
-    let rewrites = resolve_deprecated_stages(&mut graph.root, store);
-    for (old, new) in &rewrites {
+    let dep_report = resolve_deprecated_stages(&mut graph.root, store);
+    for rw in &dep_report.rewrites {
         eprintln!(
             "Warning: stage {} is deprecated → resolved to successor {}",
-            short(&old.0),
-            short(&new.0),
+            short(&rw.from.0),
+            short(&rw.to.0),
         );
+    }
+    for event in &dep_report.events {
+        match event {
+            ChainEvent::CycleDetected { stage } => {
+                eprintln!(
+                    "Warning: deprecation cycle detected at stage {} — \
+                     the graph keeps the last distinct id before the \
+                     cycle; the store has corrupt deprecation data \
+                     and should be repaired.",
+                    short(&stage.0)
+                );
+            }
+            ChainEvent::MaxHopsExceeded { stage } => {
+                eprintln!(
+                    "Warning: deprecation chain at stage {} exceeded \
+                     the {}-hop cap — execution continues with the \
+                     chain truncated, but the chain should be flattened \
+                     in the store.",
+                    short(&stage.0),
+                    noether_engine::lagrange::MAX_DEPRECATION_HOPS,
+                );
+            }
+        }
     }
     Ok(())
 }
 
+/// Return the first 8 bytes of `id`, guarding against UTF-8
+/// boundaries even though stage ids are hex in practice. `str::get`
+/// returns `None` when the byte index falls mid-codepoint.
 fn short(id: &str) -> &str {
-    &id[..8.min(id.len())]
-}
-
-/// Walk the composition graph and replace any deprecated stage IDs with
-/// their successor, following the chain (up to 10 hops to prevent cycles).
-///
-/// `pub(crate)`: this is a CLI-shaped helper today, but the transform
-/// itself (follow `successor_id` chains over a `CompositionNode`) is a
-/// graph concern. If another crate needs it, the right move is to
-/// migrate it down to `noether-engine::lagrange` next to `resolve_pinning`
-/// rather than widen the CLI-crate surface.
-pub(crate) fn resolve_deprecated_stages(
-    node: &mut CompositionNode,
-    store: &dyn StageStore,
-) -> Vec<(StageId, StageId)> {
-    let mut rewrites = Vec::new();
-
-    match node {
-        CompositionNode::Stage { id, .. } => {
-            let mut current = id.clone();
-            for _ in 0..10 {
-                match store.get(&current) {
-                    Ok(Some(stage)) => {
-                        if let StageLifecycle::Deprecated { successor_id } = &stage.lifecycle {
-                            let old = current.clone();
-                            current = successor_id.clone();
-                            rewrites.push((old, current.clone()));
-                        } else {
-                            break;
-                        }
-                    }
-                    _ => break,
-                }
-            }
-            if current != *id {
-                *id = current;
-            }
-        }
-        CompositionNode::Sequential { stages } => {
-            for s in stages {
-                rewrites.extend(resolve_deprecated_stages(s, store));
-            }
-        }
-        CompositionNode::Parallel { branches } => {
-            for (_, branch) in branches.iter_mut() {
-                rewrites.extend(resolve_deprecated_stages(branch, store));
-            }
-        }
-        CompositionNode::Branch {
-            predicate,
-            if_true,
-            if_false,
-        } => {
-            rewrites.extend(resolve_deprecated_stages(predicate, store));
-            rewrites.extend(resolve_deprecated_stages(if_true, store));
-            rewrites.extend(resolve_deprecated_stages(if_false, store));
-        }
-        CompositionNode::Retry { stage, .. } => {
-            rewrites.extend(resolve_deprecated_stages(stage, store));
-        }
-        CompositionNode::Fanout { source, targets } => {
-            rewrites.extend(resolve_deprecated_stages(source, store));
-            for t in targets {
-                rewrites.extend(resolve_deprecated_stages(t, store));
-            }
-        }
-        CompositionNode::Merge { sources, target } => {
-            for s in sources {
-                rewrites.extend(resolve_deprecated_stages(s, store));
-            }
-            rewrites.extend(resolve_deprecated_stages(target, store));
-        }
-        CompositionNode::Const { .. } | CompositionNode::RemoteStage { .. } => {}
-        CompositionNode::Let { bindings, body } => {
-            for b in bindings.values_mut() {
-                rewrites.extend(resolve_deprecated_stages(b, store));
-            }
-            rewrites.extend(resolve_deprecated_stages(body, store));
-        }
-    }
-
-    rewrites
+    id.get(..8).unwrap_or(id)
 }
 
 #[cfg(test)]
@@ -160,10 +100,11 @@ mod tests {
     use super::*;
     use noether_core::effects::EffectSet;
     use noether_core::stage::{
-        compute_signature_id, compute_stage_id, CostEstimate, SignatureId, Stage, StageSignature,
+        compute_signature_id, compute_stage_id, CostEstimate, SignatureId, Stage, StageId,
+        StageLifecycle, StageSignature,
     };
     use noether_core::types::NType;
-    use noether_engine::lagrange::{CompositionGraph, CompositionNode, Pinning};
+    use noether_engine::lagrange::{CompositionNode, Pinning};
     use noether_store::MemoryStore;
     use std::collections::BTreeSet;
 
@@ -237,55 +178,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_deprecated_follows_successor() {
-        // old stage lives in store as Deprecated pointing at new's id.
-        // Graph references old; walker must rewrite to new.
-        let mut store = MemoryStore::new();
-        let new_stage = make_stage("newer", "impl_new", StageLifecycle::Active);
-        let new_id = new_stage.id.clone();
-        store.put(new_stage).unwrap();
-        let old_stage = Stage {
-            // Manually stamp Deprecated lifecycle — we can't go through
-            // `update_lifecycle(Draft→Deprecated)` without a real Draft.
-            lifecycle: StageLifecycle::Deprecated {
-                successor_id: new_id.clone(),
-            },
-            ..make_stage("older", "impl_old", StageLifecycle::Active)
-        };
-        let old_id = old_stage.id.clone();
-        // Store lifecycle is Draft → Active → Deprecated. Walk it.
-        let mut draft = old_stage.clone();
-        draft.lifecycle = StageLifecycle::Draft;
-        store.put(draft).unwrap();
-        store
-            .update_lifecycle(&old_id, StageLifecycle::Active)
-            .unwrap();
-        store
-            .update_lifecycle(
-                &old_id,
-                StageLifecycle::Deprecated {
-                    successor_id: new_id.clone(),
-                },
-            )
-            .unwrap();
-
-        let mut root = CompositionNode::Stage {
-            id: old_id.clone(),
-            pinning: Pinning::Both,
-            config: None,
-        };
-        let rewrites = resolve_deprecated_stages(&mut root, &store);
-        assert_eq!(rewrites, vec![(old_id, new_id.clone())]);
-        match root {
-            CompositionNode::Stage { id, .. } => assert_eq!(id, new_id),
-            _ => unreachable!(),
-        }
-    }
-
-    #[test]
     fn composition_id_is_unstable_across_resolution() {
-        // This test is the regression guard for the compose.rs timing
-        // fix: if a caller computes `composition_id` AFTER
+        // Regression guard for the compose.rs timing fix: if a
+        // caller computes `composition_id` AFTER
         // `resolve_and_emit_diagnostics`, the same source graph will
         // produce different ids as the store's Active impl rotates.
         // The M1/#28 contract says the id must reflect the graph as
@@ -326,24 +221,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_deprecated_is_noop_on_active_stage() {
-        // Regression guard: a graph referencing an Active stage must
-        // not be mutated by the deprecation walker.
-        let mut store = MemoryStore::new();
-        let stage = make_stage("active", "impl_a", StageLifecycle::Active);
-        let id = stage.id.clone();
-        store.put(stage).unwrap();
-
-        let mut root = CompositionNode::Stage {
-            id: id.clone(),
-            pinning: Pinning::Both,
-            config: None,
-        };
-        let rewrites = resolve_deprecated_stages(&mut root, &store);
-        assert!(rewrites.is_empty());
-        match root {
-            CompositionNode::Stage { id: out, .. } => assert_eq!(out, id),
-            _ => unreachable!(),
-        }
+    fn short_does_not_panic_on_non_ascii() {
+        // Nit from the round-1 review: the old implementation used a
+        // byte-index slice which could panic mid-codepoint. Stage ids
+        // are hex in practice, but making the helper UTF-8 safe
+        // removes a class of potential bugs.
+        assert_eq!(super::short("abcdefghij"), "abcdefgh");
+        assert_eq!(super::short("abc"), "abc");
+        assert_eq!(super::short(""), "");
+        // Mixed-codepoint input: the 8-byte boundary falls inside
+        // the é (U+00E9, two UTF-8 bytes). `str::get` returns None
+        // there so we fall back to the full string rather than
+        // panicking.
+        assert_eq!(super::short("abcdefgé"), "abcdefgé");
     }
 }

--- a/crates/noether-cli/src/commands/resolver_utils.rs
+++ b/crates/noether-cli/src/commands/resolver_utils.rs
@@ -1,0 +1,343 @@
+//! Shared graph-resolution preamble for every CLI entry point that
+//! ingests a Lagrange graph.
+//!
+//! The pass is split into two steps by necessity:
+//!
+//! * [`resolve_pinning`] — signature/canonical → concrete implementation
+//!   rewrites, surfacing invariant-violation warnings from the store.
+//! * [`resolve_deprecated_stages`] — follow `successor_id` chains so
+//!   graphs that still reference retired implementations keep running.
+//!
+//! Both used to live inline in `run.rs`. PR #32 extended resolution to
+//! `compose`, `serve`, `build`, `build_browser`, scheduler, broker, and
+//! grid-worker. Duplicating the diagnostic boilerplate at every site
+//! would drift — hence this helper.
+//!
+//! `CompositionId` must be computed *before* calling
+//! [`resolve_and_emit_diagnostics`]: the M1 "canonical form is identity"
+//! contract says the hash reflects the graph as authored, not the
+//! post-resolution rewrite. Callers hashing after resolution will
+//! observe unstable IDs whenever the store's Active implementation
+//! changes.
+
+use noether_core::stage::{StageId, StageLifecycle};
+use noether_engine::lagrange::{resolve_pinning, CompositionGraph, CompositionNode};
+use noether_store::StageStore;
+
+/// Run the post-parse resolution passes on `graph` and print any
+/// diagnostics to stderr. Returns `Err(message)` on fatal resolution
+/// errors; the caller decides whether to exit or recover.
+pub fn resolve_and_emit_diagnostics(
+    graph: &mut CompositionGraph,
+    store: &dyn StageStore,
+) -> Result<(), String> {
+    let report =
+        resolve_pinning(&mut graph.root, store).map_err(|e| format!("pinning resolution: {e}"))?;
+
+    for rw in &report.rewrites {
+        eprintln!(
+            "Info: {:?}-pinned stage {} resolved to {}",
+            rw.pinning,
+            short(&rw.before),
+            short(&rw.after),
+        );
+    }
+    for w in &report.warnings {
+        eprintln!(
+            "Warning: signature {} has {} Active implementations ({}) — \
+             picked {} deterministically, but the store's ≤1-Active-per-\
+             signature invariant is violated. Deprecate the duplicates \
+             via `noether stage activate` / `noether store retro`.",
+            short(&w.signature_id),
+            w.active_implementation_ids.len(),
+            w.active_implementation_ids
+                .iter()
+                .map(|id| short(id).to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            short(&w.chosen),
+        );
+    }
+
+    let rewrites = resolve_deprecated_stages(&mut graph.root, store);
+    for (old, new) in &rewrites {
+        eprintln!(
+            "Warning: stage {} is deprecated → resolved to successor {}",
+            short(&old.0),
+            short(&new.0),
+        );
+    }
+    Ok(())
+}
+
+fn short(id: &str) -> &str {
+    &id[..8.min(id.len())]
+}
+
+/// Walk the composition graph and replace any deprecated stage IDs with
+/// their successor, following the chain (up to 10 hops to prevent cycles).
+pub fn resolve_deprecated_stages(
+    node: &mut CompositionNode,
+    store: &dyn StageStore,
+) -> Vec<(StageId, StageId)> {
+    let mut rewrites = Vec::new();
+
+    match node {
+        CompositionNode::Stage { id, .. } => {
+            let mut current = id.clone();
+            for _ in 0..10 {
+                match store.get(&current) {
+                    Ok(Some(stage)) => {
+                        if let StageLifecycle::Deprecated { successor_id } = &stage.lifecycle {
+                            let old = current.clone();
+                            current = successor_id.clone();
+                            rewrites.push((old, current.clone()));
+                        } else {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            if current != *id {
+                *id = current;
+            }
+        }
+        CompositionNode::Sequential { stages } => {
+            for s in stages {
+                rewrites.extend(resolve_deprecated_stages(s, store));
+            }
+        }
+        CompositionNode::Parallel { branches } => {
+            for (_, branch) in branches.iter_mut() {
+                rewrites.extend(resolve_deprecated_stages(branch, store));
+            }
+        }
+        CompositionNode::Branch {
+            predicate,
+            if_true,
+            if_false,
+        } => {
+            rewrites.extend(resolve_deprecated_stages(predicate, store));
+            rewrites.extend(resolve_deprecated_stages(if_true, store));
+            rewrites.extend(resolve_deprecated_stages(if_false, store));
+        }
+        CompositionNode::Retry { stage, .. } => {
+            rewrites.extend(resolve_deprecated_stages(stage, store));
+        }
+        CompositionNode::Fanout { source, targets } => {
+            rewrites.extend(resolve_deprecated_stages(source, store));
+            for t in targets {
+                rewrites.extend(resolve_deprecated_stages(t, store));
+            }
+        }
+        CompositionNode::Merge { sources, target } => {
+            for s in sources {
+                rewrites.extend(resolve_deprecated_stages(s, store));
+            }
+            rewrites.extend(resolve_deprecated_stages(target, store));
+        }
+        CompositionNode::Const { .. } | CompositionNode::RemoteStage { .. } => {}
+        CompositionNode::Let { bindings, body } => {
+            for b in bindings.values_mut() {
+                rewrites.extend(resolve_deprecated_stages(b, store));
+            }
+            rewrites.extend(resolve_deprecated_stages(body, store));
+        }
+    }
+
+    rewrites
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noether_core::effects::EffectSet;
+    use noether_core::stage::{
+        compute_signature_id, compute_stage_id, CostEstimate, SignatureId, Stage, StageSignature,
+    };
+    use noether_core::types::NType;
+    use noether_engine::lagrange::{CompositionGraph, CompositionNode, Pinning};
+    use noether_store::MemoryStore;
+    use std::collections::BTreeSet;
+
+    fn make_stage(name: &str, impl_hash: &str, lifecycle: StageLifecycle) -> Stage {
+        let signature = StageSignature {
+            input: NType::Text,
+            output: NType::Text,
+            effects: EffectSet::pure(),
+            implementation_hash: impl_hash.into(),
+        };
+        let id = compute_stage_id(name, &signature).unwrap();
+        let signature_id = compute_signature_id(
+            name,
+            &signature.input,
+            &signature.output,
+            &signature.effects,
+        )
+        .unwrap();
+        Stage {
+            id,
+            signature_id: Some(signature_id),
+            signature,
+            capabilities: BTreeSet::new(),
+            cost: CostEstimate {
+                time_ms_p50: None,
+                tokens_est: None,
+                memory_mb: None,
+            },
+            description: "test".into(),
+            examples: vec![],
+            lifecycle,
+            ed25519_signature: None,
+            signer_public_key: None,
+            implementation_code: None,
+            implementation_language: None,
+            ui_style: None,
+            tags: vec![],
+            aliases: vec![],
+            name: Some(name.into()),
+            properties: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_and_emit_handles_signature_pinning() {
+        // Signature-pinned node must be rewritten to carry the
+        // implementation id so downstream passes can `store.get(id)`.
+        let mut store = MemoryStore::new();
+        let stage = make_stage("sigpin_stage", "impl_hash_a", StageLifecycle::Active);
+        let sig_id: SignatureId = stage.signature_id.clone().unwrap();
+        let expected_impl = stage.id.clone();
+        store.put(stage).unwrap();
+
+        let mut graph = CompositionGraph::new(
+            "t",
+            CompositionNode::Stage {
+                id: StageId(sig_id.0.clone()),
+                pinning: Pinning::Signature,
+                config: None,
+            },
+        );
+
+        resolve_and_emit_diagnostics(&mut graph, &store).unwrap();
+
+        match &graph.root {
+            CompositionNode::Stage { id, .. } => {
+                assert_eq!(*id, expected_impl, "signature pin must rewrite to impl id");
+            }
+            other => panic!("expected Stage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_deprecated_follows_successor() {
+        // old stage lives in store as Deprecated pointing at new's id.
+        // Graph references old; walker must rewrite to new.
+        let mut store = MemoryStore::new();
+        let new_stage = make_stage("newer", "impl_new", StageLifecycle::Active);
+        let new_id = new_stage.id.clone();
+        store.put(new_stage).unwrap();
+        let old_stage = Stage {
+            // Manually stamp Deprecated lifecycle — we can't go through
+            // `update_lifecycle(Draft→Deprecated)` without a real Draft.
+            lifecycle: StageLifecycle::Deprecated {
+                successor_id: new_id.clone(),
+            },
+            ..make_stage("older", "impl_old", StageLifecycle::Active)
+        };
+        let old_id = old_stage.id.clone();
+        // Store lifecycle is Draft → Active → Deprecated. Walk it.
+        let mut draft = old_stage.clone();
+        draft.lifecycle = StageLifecycle::Draft;
+        store.put(draft).unwrap();
+        store
+            .update_lifecycle(&old_id, StageLifecycle::Active)
+            .unwrap();
+        store
+            .update_lifecycle(
+                &old_id,
+                StageLifecycle::Deprecated {
+                    successor_id: new_id.clone(),
+                },
+            )
+            .unwrap();
+
+        let mut root = CompositionNode::Stage {
+            id: old_id.clone(),
+            pinning: Pinning::Both,
+            config: None,
+        };
+        let rewrites = resolve_deprecated_stages(&mut root, &store);
+        assert_eq!(rewrites, vec![(old_id, new_id.clone())]);
+        match root {
+            CompositionNode::Stage { id, .. } => assert_eq!(id, new_id),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn composition_id_is_unstable_across_resolution() {
+        // This test is the regression guard for the compose.rs timing
+        // fix: if a caller computes `composition_id` AFTER
+        // `resolve_and_emit_diagnostics`, the same source graph will
+        // produce different ids as the store's Active impl rotates.
+        // The M1/#28 contract says the id must reflect the graph as
+        // authored (pre-resolution), so we assert here that the two
+        // ids differ — any call site that computes after resolution
+        // is silently violating the contract.
+        use noether_engine::lagrange::compute_composition_id;
+
+        let mut store = MemoryStore::new();
+        let stage = make_stage("sig_stable", "impl_x", StageLifecycle::Active);
+        let sig_id = stage.signature_id.clone().unwrap();
+        store.put(stage).unwrap();
+
+        let build_graph = || {
+            CompositionGraph::new(
+                "t",
+                CompositionNode::Stage {
+                    id: StageId(sig_id.0.clone()),
+                    pinning: Pinning::Signature,
+                    config: None,
+                },
+            )
+        };
+
+        let pre = build_graph();
+        let pre_id = compute_composition_id(&pre).unwrap();
+
+        let mut post = build_graph();
+        resolve_and_emit_diagnostics(&mut post, &store).unwrap();
+        let post_id = compute_composition_id(&post).unwrap();
+
+        assert_ne!(
+            pre_id, post_id,
+            "compose.rs must compute composition_id on the pre-resolution \
+             graph — if these ids match, the resolver is a no-op here and \
+             this test needs a more aggressive rewrite, not a silent fix"
+        );
+    }
+
+    #[test]
+    fn resolve_deprecated_is_noop_on_active_stage() {
+        // Regression guard: a graph referencing an Active stage must
+        // not be mutated by the deprecation walker.
+        let mut store = MemoryStore::new();
+        let stage = make_stage("active", "impl_a", StageLifecycle::Active);
+        let id = stage.id.clone();
+        store.put(stage).unwrap();
+
+        let mut root = CompositionNode::Stage {
+            id: id.clone(),
+            pinning: Pinning::Both,
+            config: None,
+        };
+        let rewrites = resolve_deprecated_stages(&mut root, &store);
+        assert!(rewrites.is_empty());
+        match root {
+            CompositionNode::Stage { id: out, .. } => assert_eq!(out, id),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/noether-cli/src/commands/resolver_utils.rs
+++ b/crates/noether-cli/src/commands/resolver_utils.rs
@@ -76,7 +76,13 @@ fn short(id: &str) -> &str {
 
 /// Walk the composition graph and replace any deprecated stage IDs with
 /// their successor, following the chain (up to 10 hops to prevent cycles).
-pub fn resolve_deprecated_stages(
+///
+/// `pub(crate)`: this is a CLI-shaped helper today, but the transform
+/// itself (follow `successor_id` chains over a `CompositionNode`) is a
+/// graph concern. If another crate needs it, the right move is to
+/// migrate it down to `noether-engine::lagrange` next to `resolve_pinning`
+/// rather than widen the CLI-crate surface.
+pub(crate) fn resolve_deprecated_stages(
     node: &mut CompositionNode,
     store: &dyn StageStore,
 ) -> Vec<(StageId, StageId)> {

--- a/crates/noether-cli/src/commands/run.rs
+++ b/crates/noether-cli/src/commands/run.rs
@@ -1,14 +1,12 @@
+use super::resolver_utils::resolve_and_emit_diagnostics;
 use crate::output::{acli_error, acli_error_hints, acli_ok};
-use noether_core::stage::{StageId, StageLifecycle};
 use noether_engine::checker::{
     check_capabilities, check_effects, check_graph, collect_effect_warnings, infer_effects,
     verify_signatures, CapabilityPolicy, EffectPolicy,
 };
 use noether_engine::executor::budget::{build_cost_map, BudgetedExecutor};
 use noether_engine::executor::runner::run_composition;
-use noether_engine::lagrange::{
-    compute_composition_id, parse_graph, resolve_pinning, resolve_stage_prefixes,
-};
+use noether_engine::lagrange::{compute_composition_id, parse_graph, resolve_stage_prefixes};
 use noether_engine::planner::plan_graph;
 use noether_engine::trace::JsonFileTraceStore;
 use noether_store::StageStore;
@@ -71,55 +69,13 @@ pub fn cmd_run(
         std::process::exit(1);
     }
 
-    // 1b. Resolve pinning — rewrite every `Stage { pinning: Signature, id: <sig> }`
-    //     node to carry the concrete implementation ID instead. Subsequent
-    //     passes (effect inference, capability check, Ed25519 verify, planner,
-    //     budget) all look up stages via `store.get(id)` and assume `id` is an
-    //     implementation hash. Without this pass, signature-pinned graphs would
-    //     type-check but fail in those downstream passes.
-    let resolution_report = match resolve_pinning(&mut graph.root, store) {
-        Ok(rep) => rep,
-        Err(e) => {
-            eprintln!("{}", acli_error(&format!("pinning resolution: {e}")));
-            std::process::exit(1);
-        }
-    };
-    for rw in &resolution_report.rewrites {
-        eprintln!(
-            "Info: {:?}-pinned stage {} resolved to {}",
-            rw.pinning,
-            &rw.before[..8.min(rw.before.len())],
-            &rw.after[..8.min(rw.after.len())]
-        );
-    }
-    for w in &resolution_report.warnings {
-        eprintln!(
-            "Warning: signature {} has {} Active implementations ({}) — \
-             picked {} deterministically, but the store's ≤1-Active-per-\
-             signature invariant is violated. Deprecate the duplicates \
-             via `noether stage activate` / `noether store retro`.",
-            &w.signature_id[..8.min(w.signature_id.len())],
-            w.active_implementation_ids.len(),
-            w.active_implementation_ids
-                .iter()
-                .map(|id| id[..8.min(id.len())].to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-            &w.chosen[..8.min(w.chosen.len())],
-        );
-    }
-
-    // 1c. Resolve deprecated stages — rewrite any stage IDs that point to
-    //     deprecated stages, following the successor_id chain.
-    let rewrites = resolve_deprecated_stages(&mut graph.root, store);
-    if !rewrites.is_empty() {
-        for (old, new) in &rewrites {
-            eprintln!(
-                "Warning: stage {} is deprecated → resolved to successor {}",
-                &old.0[..8.min(old.0.len())],
-                &new.0[..8.min(new.0.len())]
-            );
-        }
+    // 1b+1c. Resolve pinning + deprecated stages in one pass, printing
+    //        rewrite diagnostics and invariant-violation warnings. See
+    //        `resolver_utils` for the canonical preamble used by every
+    //        Lagrange-ingest entry point.
+    if let Err(msg) = resolve_and_emit_diagnostics(&mut graph, store) {
+        eprintln!("{}", acli_error(&msg));
+        std::process::exit(1);
     }
 
     // 2. Type check
@@ -291,81 +247,4 @@ pub fn cmd_run(
             std::process::exit(3);
         }
     }
-}
-
-/// Walk the composition graph and replace any deprecated stage IDs with their
-/// successor, following the chain (up to 10 hops to prevent cycles).
-fn resolve_deprecated_stages(
-    node: &mut noether_engine::lagrange::CompositionNode,
-    store: &dyn StageStore,
-) -> Vec<(StageId, StageId)> {
-    use noether_engine::lagrange::CompositionNode;
-
-    let mut rewrites = Vec::new();
-
-    match node {
-        CompositionNode::Stage { id, .. } => {
-            let mut current = id.clone();
-            for _ in 0..10 {
-                match store.get(&current) {
-                    Ok(Some(stage)) => {
-                        if let StageLifecycle::Deprecated { successor_id } = &stage.lifecycle {
-                            let old = current.clone();
-                            current = successor_id.clone();
-                            rewrites.push((old, current.clone()));
-                        } else {
-                            break;
-                        }
-                    }
-                    _ => break,
-                }
-            }
-            if current != *id {
-                *id = current;
-            }
-        }
-        CompositionNode::Sequential { stages } => {
-            for s in stages {
-                rewrites.extend(resolve_deprecated_stages(s, store));
-            }
-        }
-        CompositionNode::Parallel { branches } => {
-            for (_, branch) in branches.iter_mut() {
-                rewrites.extend(resolve_deprecated_stages(branch, store));
-            }
-        }
-        CompositionNode::Branch {
-            predicate,
-            if_true,
-            if_false,
-        } => {
-            rewrites.extend(resolve_deprecated_stages(predicate, store));
-            rewrites.extend(resolve_deprecated_stages(if_true, store));
-            rewrites.extend(resolve_deprecated_stages(if_false, store));
-        }
-        CompositionNode::Retry { stage, .. } => {
-            rewrites.extend(resolve_deprecated_stages(stage, store));
-        }
-        CompositionNode::Fanout { source, targets } => {
-            rewrites.extend(resolve_deprecated_stages(source, store));
-            for t in targets {
-                rewrites.extend(resolve_deprecated_stages(t, store));
-            }
-        }
-        CompositionNode::Merge { sources, target } => {
-            for s in sources {
-                rewrites.extend(resolve_deprecated_stages(s, store));
-            }
-            rewrites.extend(resolve_deprecated_stages(target, store));
-        }
-        CompositionNode::Const { .. } | CompositionNode::RemoteStage { .. } => {}
-        CompositionNode::Let { bindings, body } => {
-            for b in bindings.values_mut() {
-                rewrites.extend(resolve_deprecated_stages(b, store));
-            }
-            rewrites.extend(resolve_deprecated_stages(body, store));
-        }
-    }
-
-    rewrites
 }

--- a/crates/noether-cli/src/commands/serve.rs
+++ b/crates/noether-cli/src/commands/serve.rs
@@ -1,3 +1,4 @@
+use super::resolver_utils::resolve_and_emit_diagnostics;
 use noether_engine::executor::composite::CompositeExecutor;
 use noether_engine::executor::runner::run_composition;
 use noether_engine::lagrange::{parse_graph, CompositionGraph};
@@ -53,14 +54,20 @@ pub fn cmd_serve(
                     std::process::exit(1);
                 }
             };
-            let graph = match parse_graph(&graph_content) {
+            let mut graph = match parse_graph(&graph_content) {
                 Ok(g) => g,
                 Err(e) => {
                     eprintln!("Invalid graph {graph_path}: {e}");
                     std::process::exit(1);
                 }
             };
-            // Type check each graph
+            // Resolve signature/canonical pinning → impl IDs, and
+            // auto-follow deprecation chains, so graphs authored today
+            // keep serving after an implementation is rotated.
+            if let Err(msg) = resolve_and_emit_diagnostics(&mut graph, store) {
+                eprintln!("Graph {graph_path}: {msg}");
+                std::process::exit(1);
+            }
             if let Err(errors) = noether_engine::checker::check_graph(&graph.root, store) {
                 let msgs: Vec<String> = errors.iter().map(|e| format!("{e}")).collect();
                 eprintln!(
@@ -79,13 +86,17 @@ pub fn cmd_serve(
         routes
     } else {
         // Single graph file (backward compatible)
-        let graph = match parse_graph(&content) {
+        let mut graph = match parse_graph(&content) {
             Ok(g) => g,
             Err(e) => {
                 eprintln!("Invalid graph JSON: {e}");
                 std::process::exit(1);
             }
         };
+        if let Err(msg) = resolve_and_emit_diagnostics(&mut graph, store) {
+            eprintln!("{msg}");
+            std::process::exit(1);
+        }
         if let Err(errors) = noether_engine::checker::check_graph(&graph.root, store) {
             let msgs: Vec<String> = errors.iter().map(|e| format!("{e}")).collect();
             eprintln!("Graph type check failed:\n  {}", msgs.join("\n  "));

--- a/crates/noether-engine/src/lagrange/deprecation.rs
+++ b/crates/noether-engine/src/lagrange/deprecation.rs
@@ -1,0 +1,351 @@
+//! Deprecation-chain resolver.
+//!
+//! Walks a [`CompositionNode`], replacing any `Stage { id }` that
+//! points at a `Deprecated { successor_id }` stage with the final
+//! non-deprecated implementation, following `successor_id` links.
+//!
+//! Paired with [`resolve_pinning`](super::resolver::resolve_pinning):
+//! pinning maps signature → implementation, this maps deprecated
+//! implementation → active successor. Most call sites want both,
+//! pinning first.
+//!
+//! Every entry point that runs this (CLI `run`, `compose`, `serve`,
+//! `build`, `build_browser`, scheduler, grid-broker, grid-worker)
+//! used to carry its own copy of the walker. This module is the
+//! shared implementation.
+
+use noether_core::stage::{StageId, StageLifecycle};
+use noether_store::StageStore;
+
+use super::ast::CompositionNode;
+
+/// Upper bound on successor-chain walks. Chains longer than this
+/// (unusual in practice; indicates either a legitimate very-long
+/// deprecation history or an accidental cycle) are truncated and
+/// surface as [`ChainEvent::MaxHopsExceeded`].
+pub const MAX_DEPRECATION_HOPS: usize = 10;
+
+/// Single rewrite performed by [`resolve_deprecated_stages`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeprecationRewrite {
+    pub from: StageId,
+    pub to: StageId,
+}
+
+/// Condition that ended a successor-chain walk without finding a
+/// non-deprecated stage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainEvent {
+    /// Chain contained a cycle. `stage` is the id we revisited.
+    /// Rewrites up to the cycle point are still applied; execution
+    /// continues with the last distinct id before the loop.
+    CycleDetected { stage: StageId },
+    /// Chain was longer than [`MAX_DEPRECATION_HOPS`]. Execution
+    /// continues with whatever id the walker reached at the cap.
+    MaxHopsExceeded { stage: StageId },
+}
+
+/// Result of walking the graph's stage references.
+#[derive(Debug, Default, Clone)]
+pub struct DeprecationReport {
+    /// Successful rewrites (`from` found Deprecated, was replaced
+    /// with its eventual non-deprecated successor).
+    pub rewrites: Vec<DeprecationRewrite>,
+    /// Anomalies encountered during the walk. Callers should
+    /// surface these to operators — silent truncation hides broken
+    /// deprecation chains in the store.
+    pub events: Vec<ChainEvent>,
+}
+
+/// Walk the graph, following `successor_id` chains to resolve
+/// references to deprecated stages. Returns a report; the caller is
+/// expected to log the events and/or present them to the user.
+///
+/// Cycles are detected explicitly via a per-root visited set rather
+/// than relying on the hop cap alone — a cycle is a data-integrity
+/// problem in the store, not a legitimate 11-hop chain, and the two
+/// failure modes deserve different operator responses.
+pub fn resolve_deprecated_stages(
+    node: &mut CompositionNode,
+    store: &dyn StageStore,
+) -> DeprecationReport {
+    let mut report = DeprecationReport::default();
+    walk(node, store, &mut report);
+    report
+}
+
+fn walk(node: &mut CompositionNode, store: &dyn StageStore, report: &mut DeprecationReport) {
+    match node {
+        CompositionNode::Stage { id, .. } => follow_chain(id, store, report),
+        CompositionNode::Sequential { stages } => {
+            for s in stages {
+                walk(s, store, report);
+            }
+        }
+        CompositionNode::Parallel { branches } => {
+            for (_, branch) in branches.iter_mut() {
+                walk(branch, store, report);
+            }
+        }
+        CompositionNode::Branch {
+            predicate,
+            if_true,
+            if_false,
+        } => {
+            walk(predicate, store, report);
+            walk(if_true, store, report);
+            walk(if_false, store, report);
+        }
+        CompositionNode::Retry { stage, .. } => walk(stage, store, report),
+        CompositionNode::Fanout { source, targets } => {
+            walk(source, store, report);
+            for t in targets {
+                walk(t, store, report);
+            }
+        }
+        CompositionNode::Merge { sources, target } => {
+            for s in sources {
+                walk(s, store, report);
+            }
+            walk(target, store, report);
+        }
+        CompositionNode::Const { .. } | CompositionNode::RemoteStage { .. } => {}
+        CompositionNode::Let { bindings, body } => {
+            for b in bindings.values_mut() {
+                walk(b, store, report);
+            }
+            walk(body, store, report);
+        }
+    }
+}
+
+fn follow_chain(id: &mut StageId, store: &dyn StageStore, report: &mut DeprecationReport) {
+    let mut visited: std::collections::HashSet<StageId> = std::collections::HashSet::new();
+    visited.insert(id.clone());
+    let mut current = id.clone();
+    let mut hops = 0usize;
+
+    while let Ok(Some(stage)) = store.get(&current) {
+        let successor = match &stage.lifecycle {
+            StageLifecycle::Deprecated { successor_id } => successor_id.clone(),
+            _ => break,
+        };
+
+        if !visited.insert(successor.clone()) {
+            // Cycle — stop before looping. `current` is the last
+            // distinct id before the re-entry; that's what we
+            // leave in the graph.
+            report.events.push(ChainEvent::CycleDetected {
+                stage: successor.clone(),
+            });
+            break;
+        }
+
+        hops += 1;
+        if hops > MAX_DEPRECATION_HOPS {
+            report.events.push(ChainEvent::MaxHopsExceeded {
+                stage: successor.clone(),
+            });
+            break;
+        }
+
+        report.rewrites.push(DeprecationRewrite {
+            from: current.clone(),
+            to: successor.clone(),
+        });
+        current = successor;
+    }
+
+    if current != *id {
+        *id = current;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lagrange::ast::Pinning;
+    use noether_core::effects::EffectSet;
+    use noether_core::stage::{
+        compute_stage_id, CostEstimate, Stage, StageLifecycle, StageSignature,
+    };
+    use noether_core::types::NType;
+    use noether_store::MemoryStore;
+    use std::collections::BTreeSet;
+
+    fn stage(name: &str, impl_hash: &str, lifecycle: StageLifecycle) -> Stage {
+        let signature = StageSignature {
+            input: NType::Text,
+            output: NType::Text,
+            effects: EffectSet::pure(),
+            implementation_hash: impl_hash.into(),
+        };
+        let id = compute_stage_id(name, &signature).unwrap();
+        Stage {
+            id,
+            signature_id: None,
+            signature,
+            capabilities: BTreeSet::new(),
+            cost: CostEstimate {
+                time_ms_p50: None,
+                tokens_est: None,
+                memory_mb: None,
+            },
+            description: "t".into(),
+            examples: vec![],
+            lifecycle,
+            ed25519_signature: None,
+            signer_public_key: None,
+            implementation_code: None,
+            implementation_language: None,
+            ui_style: None,
+            tags: vec![],
+            aliases: vec![],
+            name: Some(name.into()),
+            properties: Vec::new(),
+        }
+    }
+
+    fn leaf(id: &StageId) -> CompositionNode {
+        CompositionNode::Stage {
+            id: id.clone(),
+            pinning: Pinning::Both,
+            config: None,
+        }
+    }
+
+    #[test]
+    fn noop_on_active_stage() {
+        let mut store = MemoryStore::new();
+        let active = stage("a", "ha", StageLifecycle::Active);
+        let id = active.id.clone();
+        store.put(active).unwrap();
+
+        let mut root = leaf(&id);
+        let report = resolve_deprecated_stages(&mut root, &store);
+        assert!(report.rewrites.is_empty());
+        assert!(report.events.is_empty());
+    }
+
+    #[test]
+    fn single_hop_rewrites() {
+        let mut store = MemoryStore::new();
+        let new_stage = stage("new", "hn", StageLifecycle::Active);
+        let new_id = new_stage.id.clone();
+        store.put(new_stage).unwrap();
+
+        // Add `old` as Active then transition to Deprecated — only
+        // way through the store's lifecycle-validation path.
+        let old_active = stage("old", "ho", StageLifecycle::Active);
+        let old_id = old_active.id.clone();
+        store.put(old_active).unwrap();
+        store
+            .update_lifecycle(
+                &old_id,
+                StageLifecycle::Deprecated {
+                    successor_id: new_id.clone(),
+                },
+            )
+            .unwrap();
+
+        let mut root = leaf(&old_id);
+        let report = resolve_deprecated_stages(&mut root, &store);
+        assert_eq!(
+            report.rewrites,
+            vec![DeprecationRewrite {
+                from: old_id,
+                to: new_id.clone(),
+            }]
+        );
+        match root {
+            CompositionNode::Stage { id, .. } => assert_eq!(id, new_id),
+            _ => unreachable!(),
+        }
+        assert!(report.events.is_empty());
+    }
+
+    #[test]
+    fn cycle_detected_and_surfaced() {
+        // Two stages, each claiming the other as its successor.
+        // A real store can't get into this state through the public
+        // API (update_lifecycle requires the successor to exist at
+        // deprecation time), so we construct a bespoke fake store
+        // that serves the cycle directly.
+        use noether_store::{StageStore, StoreError, StoreStats};
+        use std::collections::HashMap;
+
+        struct CyclicStore {
+            stages: HashMap<String, Stage>,
+        }
+
+        impl StageStore for CyclicStore {
+            fn put(&mut self, _s: Stage) -> Result<StageId, StoreError> {
+                unimplemented!()
+            }
+            fn upsert(&mut self, _s: Stage) -> Result<StageId, StoreError> {
+                unimplemented!()
+            }
+            fn remove(&mut self, _id: &StageId) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            fn get(&self, id: &StageId) -> Result<Option<&Stage>, StoreError> {
+                Ok(self.stages.get(&id.0))
+            }
+            fn contains(&self, id: &StageId) -> bool {
+                self.stages.contains_key(&id.0)
+            }
+            fn list(&self, _lc: Option<&StageLifecycle>) -> Vec<&Stage> {
+                self.stages.values().collect()
+            }
+            fn update_lifecycle(
+                &mut self,
+                _id: &StageId,
+                _lc: StageLifecycle,
+            ) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            fn stats(&self) -> StoreStats {
+                StoreStats {
+                    total: self.stages.len(),
+                    by_lifecycle: Default::default(),
+                    by_effect: Default::default(),
+                }
+            }
+        }
+
+        let a = stage("a", "ha", StageLifecycle::Active);
+        let b = stage("b", "hb", StageLifecycle::Active);
+        let a_id = a.id.clone();
+        let b_id = b.id.clone();
+
+        let a_dep = Stage {
+            lifecycle: StageLifecycle::Deprecated {
+                successor_id: b_id.clone(),
+            },
+            ..a
+        };
+        let b_dep = Stage {
+            lifecycle: StageLifecycle::Deprecated {
+                successor_id: a_id.clone(),
+            },
+            ..b
+        };
+        let mut stages = HashMap::new();
+        stages.insert(a_id.0.clone(), a_dep);
+        stages.insert(b_id.0.clone(), b_dep);
+        let store = CyclicStore { stages };
+
+        let mut root = leaf(&a_id);
+        let report = resolve_deprecated_stages(&mut root, &store);
+
+        // Walker must terminate and surface the cycle.
+        assert!(
+            report
+                .events
+                .iter()
+                .any(|e| matches!(e, ChainEvent::CycleDetected { .. })),
+            "expected CycleDetected event, got {:?}",
+            report.events
+        );
+    }
+}

--- a/crates/noether-engine/src/lagrange/mod.rs
+++ b/crates/noether-engine/src/lagrange/mod.rs
@@ -1,9 +1,14 @@
 mod ast;
 pub mod canonical;
+pub mod deprecation;
 pub mod resolver;
 
 pub use ast::{collect_stage_ids, resolve_stage_ref, CompositionGraph, CompositionNode, Pinning};
 pub use canonical::canonicalise;
+pub use deprecation::{
+    resolve_deprecated_stages, ChainEvent, DeprecationReport, DeprecationRewrite,
+    MAX_DEPRECATION_HOPS,
+};
 pub use resolver::{resolve_pinning, ResolutionError, Rewrite};
 
 use noether_core::stage::{Stage, StageId};

--- a/crates/noether-grid-broker/src/routes.rs
+++ b/crates/noether-grid-broker/src/routes.rs
@@ -198,6 +198,45 @@ pub async fn submit_job(
             .into_response();
     }
 
+    // Follow deprecation chains too. Without this pass, a
+    // broker-submitted graph referencing a `Deprecated { successor_id }`
+    // stage would resolve pinning fine and then dispatch to the
+    // now-retired implementation on a worker, rather than being
+    // silently forwarded to the successor the way the CLI does. The
+    // broker logs through `tracing` (not stderr), so we surface
+    // rewrites and anomalies as structured events instead of
+    // reusing the CLI's `resolve_and_emit_diagnostics` helper.
+    let dep_report =
+        noether_engine::lagrange::resolve_deprecated_stages(&mut graph.root, &stages_snapshot);
+    for rw in &dep_report.rewrites {
+        tracing::info!(
+            from = %rw.from.0,
+            to = %rw.to.0,
+            "resolved deprecated stage to successor"
+        );
+    }
+    for event in &dep_report.events {
+        match event {
+            noether_engine::lagrange::ChainEvent::CycleDetected { stage } => {
+                tracing::warn!(
+                    stage_id = %stage.0,
+                    "deprecation cycle detected — store has corrupt \
+                     deprecation data; graph dispatched against the \
+                     last distinct id before the cycle"
+                );
+            }
+            noether_engine::lagrange::ChainEvent::MaxHopsExceeded { stage } => {
+                tracing::warn!(
+                    stage_id = %stage.0,
+                    cap = noether_engine::lagrange::MAX_DEPRECATION_HOPS,
+                    "deprecation chain exceeded hop cap — dispatched \
+                     against the truncated id; chain should be \
+                     flattened in the store"
+                );
+            }
+        }
+    }
+
     // Look up the graph's required LLM models from the broker's stage
     // catalogue. If the catalogue doesn't know a stage, the splitter
     // leaves it alone — no model requirement is contributed.

--- a/crates/noether-grid-broker/src/routes.rs
+++ b/crates/noether-grid-broker/src/routes.rs
@@ -170,7 +170,7 @@ pub async fn submit_job(
     state.metrics.jobs_submitted_total.inc();
     // Parse the graph. Invalid JSON → 400 immediately; the graph wouldn't
     // run anyway and we want a clear error before any worker bookkeeping.
-    let graph = match noether_engine::lagrange::parse_graph(&spec.graph.to_string()) {
+    let mut graph = match noether_engine::lagrange::parse_graph(&spec.graph.to_string()) {
         Ok(g) => g,
         Err(e) => {
             return (
@@ -181,13 +181,26 @@ pub async fn submit_job(
         }
     };
 
-    // Look up the graph's required LLM models from the broker's stage
-    // catalogue. If the catalogue doesn't know a stage, the splitter
-    // leaves it alone — no model requirement is contributed.
+    // Resolve pinning. The splitter and model-inference walks both
+    // look stages up by implementation ID; signature-pinned refs
+    // would silently be left alone. Run this once up front so the
+    // rest of the pipeline sees concrete impls. Errors (unknown
+    // signature, missing impl) are client-facing 400s, not 5xx.
     let stages_snapshot = {
         let lock = state.stages.lock().await;
         clone_store(&lock)
     };
+    if let Err(e) = noether_engine::lagrange::resolve_pinning(&mut graph.root, &stages_snapshot) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("pinning resolution: {e}")})),
+        )
+            .into_response();
+    }
+
+    // Look up the graph's required LLM models from the broker's stage
+    // catalogue. If the catalogue doesn't know a stage, the splitter
+    // leaves it alone — no model requirement is contributed.
     let models = splitter::required_llm_models(&graph.root, &stages_snapshot);
 
     // Pre-flight pool capacity. With graph splitting we don't pick a

--- a/crates/noether-grid-broker/src/splitter.rs
+++ b/crates/noether-grid-broker/src/splitter.rs
@@ -41,6 +41,16 @@ pub struct SplitResult {
 /// chosen worker (or a refusal that aborts the whole rewrite). Tests
 /// can pass a deterministic picker; the production caller wires it to
 /// the routing module.
+///
+/// # Pre-condition — pinning must be resolved
+///
+/// `node` must already have been normalised via
+/// [`noether_engine::lagrange::resolve_pinning`] so every `Stage`
+/// reference holds a concrete implementation ID. The splitter looks
+/// stages up via `store.get(id)`; signature-pinned references (where
+/// `id` is a `SignatureId`) would miss and silently leave the node
+/// unrewritten. Callers that invoke the splitter directly on a user-
+/// authored graph should resolve pinning first.
 pub fn split_graph<F>(
     node: &CompositionNode,
     stages: &MemoryStore,

--- a/crates/noether-grid-worker/src/main.rs
+++ b/crates/noether-grid-worker/src/main.rs
@@ -480,6 +480,13 @@ async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
     // canonical-form contract); grid-submitted graphs ride through
     // the resolver before dispatch so signature-pinned nodes reach
     // the executor with concrete impl ids.
+    //
+    // Invariant: `composition_id` is set from the pre-resolution
+    // graph and therefore stays populated even on `Failed` results —
+    // including failures surfaced by the resolver itself. A broker
+    // correlating runs across workers sees the same id for the same
+    // source graph regardless of which (possibly now-deprecated)
+    // implementation it resolved to on any given run.
     let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
     if let Err(e) = resolve_pinning(&mut graph.root, store) {
         return JobResult {

--- a/crates/noether-grid-worker/src/main.rs
+++ b/crates/noether-grid-worker/src/main.rs
@@ -459,9 +459,9 @@ async fn execute_single_stage(
 async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
     use noether_engine::executor::composite::CompositeExecutor;
     use noether_engine::executor::runner::run_composition;
-    use noether_engine::lagrange::{compute_composition_id, parse_graph};
+    use noether_engine::lagrange::{compute_composition_id, parse_graph, resolve_pinning};
 
-    let graph = match parse_graph(&req.graph.to_string()) {
+    let mut graph = match parse_graph(&req.graph.to_string()) {
         Ok(g) => g,
         Err(e) => {
             return JobResult {
@@ -476,7 +476,22 @@ async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
         }
     };
 
+    // Composition identity comes from the pre-resolution graph (M1
+    // canonical-form contract); grid-submitted graphs ride through
+    // the resolver before dispatch so signature-pinned nodes reach
+    // the executor with concrete impl ids.
     let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+    if let Err(e) = resolve_pinning(&mut graph.root, store) {
+        return JobResult {
+            job_id: req.job_id,
+            status: JobStatus::Failed,
+            output: serde_json::Value::Null,
+            spent_cents: 0,
+            composition_id: Some(composition_id),
+            error: Some(format!("pinning resolution: {e}")),
+            completed_at: Utc::now(),
+        };
+    }
     let executor = CompositeExecutor::from_store(store);
 
     // Run the graph on a blocking thread — the executor is synchronous.

--- a/crates/noether-scheduler/src/main.rs
+++ b/crates/noether-scheduler/src/main.rs
@@ -180,7 +180,7 @@ async fn run_job(job: &ScheduledJob, config: &SchedulerConfig) {
         }
     };
 
-    let graph = match parse_graph(&graph_json) {
+    let mut graph = match parse_graph(&graph_json) {
         Ok(g) => g,
         Err(e) => {
             error!("Job {} — invalid graph JSON: {}", job.name, e);
@@ -247,7 +247,16 @@ async fn run_job(job: &ScheduledJob, config: &SchedulerConfig) {
         use noether_engine::llm::LlmConfig;
 
         let inline = InlineExecutor::from_store(store.as_ref());
+        // composition_id from the pre-resolution graph — stable across
+        // store changes, per #28.
         let cid = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+        // Resolve pinning against the store snapshot. Signature-pinned
+        // refs rewrite to concrete implementation IDs; without this the
+        // run would fail inside the executor's store.get() call.
+        if let Err(e) = noether_engine::lagrange::resolve_pinning(&mut graph.root, store.as_ref()) {
+            error!("Job {} — pinning resolution failed: {e}", job.name);
+            return;
+        }
         let job_input = job.input.clone().unwrap_or(serde_json::Value::Null);
 
         let result = if llm_name != "mock" {


### PR DESCRIPTION
## Summary

Closes the integration gap flagged in the #28 review: the resolver
pass was only called inside `noether run`. Signature-pinned graphs
type-checked there but silently failed in every other entry point
that looks up stages via `store.get`.

### Entry points now resolving pinning

| Site | File | Resolution outcome |
|------|------|--------------------|
| `noether build` (native) | `commands/build.rs` | Verbose stderr info + warnings |
| `noether build` (browser) | `commands/build_browser.rs` | Terse error; stdout reserved for bundle |
| `noether compose` | `commands/compose.rs` | Both fresh-synthesis and cache-hit paths |
| `noether-scheduler` | `crates/noether-scheduler/src/main.rs` | Resolves against store snapshot before `run_composition` |
| `noether-grid-broker /jobs` | `crates/noether-grid-broker/src/routes.rs` | 400 on resolution failure (not 5xx) |
| `noether-grid-broker::split_graph` | `crates/noether-grid-broker/src/splitter.rs` | Documented pre-condition; splitter stays referentially transparent |

### Invariants preserved

- **composition_id is pre-resolution.** Every site computes
  `compute_composition_id(&graph)` *before* calling `resolve_pinning`,
  so the same source graph yields the same ID across days as Active
  implementations evolve (M1/#28 timing fix still holds).
- **`pinning` label preserved on rewrite.** A node declared
  `pinning: "signature"` still says `"signature"` in serialised
  output; only the `id` field is rewritten.
- **Errors surface, don't swallow.** Pinning resolution failures
  return clear error envelopes at every site: CLI prints `acli_error`
  + exits 1; the broker returns HTTP 400; the scheduler logs and
  skips the job.

### Gaps closed vs. gaps remaining

**Closed:**
- `noether build` now resolves.
- `noether build --target browser` now resolves.
- `noether compose` now resolves in both fresh and cache paths.
- `noether-scheduler` now resolves.
- `noether-grid-broker /jobs` now resolves.

**Still open (tracked, not this PR):**
- `noether-cloud /compositions/run` (separate repo). When the registry
  ever loads a graph and runs it locally, it'll need to resolve too.
  Today it forwards to engine-side runners which may already handle
  this via the library API.
- Store-level "≤1 Active per signature" invariant enforcement — still
  the resolver only warns; `MemoryStore::put` doesn't reject.

### Stacked on

`main` (post-v0.6.0).

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Review: the pattern is "compute composition_id pre-resolution;
      resolve; proceed". Consistent across 6 sites — worth hoisting
      into a helper in `noether_engine`, or keep inline for clarity?
- [ ] Review: compose.rs clones on cache-hit to mutate. Cheap today
      (graphs are small) but if they grow, the clone is a hot-path
      cost. Worth caching the post-resolution graph instead?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
