### PR TITLE
feat(M2.5): property DSL expansion — relational variants

### DIFF
--- a/.cli/schemas/stage-spec.json
+++ b/.cli/schemas/stage-spec.json
@@ -37,7 +37,7 @@
     "property": {
       "type": "object",
       "description": "Declarative property the stage claims to satisfy for every (input, output) pair. See crates/noether-core/src/stage/property.rs for semantics.",
-      "required": ["kind", "field"],
+      "required": ["kind"],
       "oneOf": [
         {
           "properties": {
@@ -55,6 +55,49 @@
             "max": { "type": "number", "description": "Inclusive upper bound. Omit for unbounded." }
           },
           "required": ["kind", "field"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "field_length_eq" },
+            "left_field": { "type": "string" },
+            "right_field": { "type": "string" }
+          },
+          "required": ["kind", "left_field", "right_field"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "field_length_max" },
+            "subject_field": { "type": "string" },
+            "bound_field": { "type": "string" }
+          },
+          "required": ["kind", "subject_field", "bound_field"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "subset_of" },
+            "subject_field": { "type": "string" },
+            "super_field": { "type": "string" }
+          },
+          "required": ["kind", "subject_field", "super_field"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "equals" },
+            "left_field": { "type": "string" },
+            "right_field": { "type": "string" }
+          },
+          "required": ["kind", "left_field", "right_field"]
+        },
+        {
+          "properties": {
+            "kind": { "const": "field_type_in" },
+            "field": { "type": "string" },
+            "allowed": {
+              "type": "array",
+              "items": { "enum": ["null", "bool", "number", "string", "array", "object"] }
+            }
+          },
+          "required": ["kind", "field", "allowed"]
         }
       ]
     },

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -115,8 +115,18 @@ structured object tagged by `kind`:
 ]
 ```
 
-**Kinds frozen at 1.0.** `"set_member"` and `"range"` carry the
-meanings documented in `crates/noether-core/src/stage/property.rs`.
+**Kinds frozen at 1.0.** The v0.7-era set:
+
+- `"set_member"` — value at `field` is in an enumerated set
+- `"range"` — numeric value at `field` is within `[min, max]`
+- `"field_length_eq"` — length of `left_field` equals length of `right_field`
+- `"field_length_max"` — length of `subject_field` ≤ length of `bound_field`
+- `"subset_of"` — every element / key of `subject_field` appears in `super_field`
+- `"equals"` — JSON-value equality between `left_field` and `right_field`
+- `"field_type_in"` — runtime JSON type at `field` is in the `allowed` list
+
+Meanings and required fields are documented in
+`crates/noether-core/src/stage/property.rs`.
 
 **Promise.** Existing `kind` strings, their required fields, and their
 evaluation semantics are frozen across 1.x. New `kind` variants may

--- a/crates/noether-core/src/stage/property.rs
+++ b/crates/noether-core/src/stage/property.rs
@@ -6,15 +6,25 @@
 //!
 //! ## Scope
 //!
-//! Per the M2 roadmap, the DSL is deliberately tiny:
+//! The v0.6 DSL shipped with two variants; M2.5 (v0.7) added five more
+//! for relational and type-shape constraints:
 //!
 //! - [`Property::SetMember`] — a named field is one of a fixed set of
 //!   JSON values.
 //! - [`Property::Range`] — a named numeric field is within `[min, max]`
 //!   (either bound optional).
+//! - [`Property::FieldLengthEq`] — two fields have the same length
+//!   (string UTF-8 chars / array length / object key count).
+//! - [`Property::FieldLengthMax`] — `subject_field` length ≤
+//!   `bound_field` length.
+//! - [`Property::SubsetOf`] — every element / key of `subject_field`
+//!   appears in `super_field`.
+//! - [`Property::Equals`] — two fields are JSON-value-equal.
+//! - [`Property::FieldTypeIn`] — the runtime JSON type at `field` is
+//!   one of the allowed set.
 //!
 //! Higher-order predicates (implications over examples, quantifiers,
-//! type-class predicates) are explicit non-goals for 1.0.
+//! type-class predicates) remain explicit non-goals for 1.0.
 //!
 //! ## Wire format
 //!
@@ -70,6 +80,59 @@ pub enum Property {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         max: Option<f64>,
     },
+    /// The length of the value at `left_field` equals the length of the
+    /// value at `right_field`. "Length" is defined as:
+    /// - UTF-8 character count for strings
+    /// - element count for arrays
+    /// - key count for objects
+    ///
+    /// Added in M2.5 to express length-preservation invariants
+    /// (`text_reverse`, `text_upper`, `map`, etc.).
+    FieldLengthEq {
+        left_field: String,
+        right_field: String,
+    },
+    /// The length of `subject_field` is less than or equal to the
+    /// length of `bound_field`. Useful for stages like `filter`,
+    /// `take`, `list_dedup` where the output is bounded by the
+    /// input's size but not equal to it.
+    ///
+    /// Added in M2.5.
+    FieldLengthMax {
+        subject_field: String,
+        bound_field: String,
+    },
+    /// Every element of `subject_field` appears (by JSON-value
+    /// equality) in `super_field`. Arrays are treated as sets;
+    /// duplicates in subject are allowed as long as the value is
+    /// present in super.
+    ///
+    /// Useful for `sort` (output is a permutation of input), stages
+    /// that project or re-group a subset of input fields.
+    ///
+    /// Added in M2.5.
+    SubsetOf {
+        subject_field: String,
+        super_field: String,
+    },
+    /// `left_field` and `right_field` are equal by JSON-value
+    /// equality. The most common use is reflexivity (`output ==
+    /// input` for identity stages) and content preservation (output
+    /// body bytes match a source field).
+    ///
+    /// Added in M2.5.
+    Equals {
+        left_field: String,
+        right_field: String,
+    },
+    /// The runtime JSON type at `field` is one of the allowed kinds.
+    /// Kinds are the strings `"null"`, `"bool"`, `"number"`,
+    /// `"string"`, `"array"`, `"object"`. Bridges the gap between
+    /// the structural type system's compile-time view and the
+    /// actual runtime shape.
+    ///
+    /// Added in M2.5.
+    FieldTypeIn { field: String, allowed: Vec<String> },
     /// A property kind this reader doesn't know how to evaluate.
     /// Produced by the deserialiser for forward compatibility when a
     /// future minor release adds a new `kind` variant; the original
@@ -113,6 +176,78 @@ pub enum PropertyViolation {
 
     #[error("field `{path}` is {actual}; expected <= {max}")]
     AboveMax { path: String, actual: f64, max: f64 },
+
+    // ── M2.5 violation variants ────────────────────────────────────────
+    #[error(
+        "field `{path}` has no measurable length ({actual}); expected a \
+         string, array, or object for a length check"
+    )]
+    NotMeasurable {
+        path: String,
+        actual: serde_json::Value,
+    },
+
+    #[error(
+        "length check failed: `{left}` has length {left_len}, `{right}` \
+         has length {right_len}; expected equal"
+    )]
+    LengthMismatch {
+        left: String,
+        left_len: usize,
+        right: String,
+        right_len: usize,
+    },
+
+    #[error(
+        "length bound violated: `{subject}` has length {subject_len} but \
+         `{bound}` has length {bound_len}; expected subject ≤ bound"
+    )]
+    LengthExceedsBound {
+        subject: String,
+        subject_len: usize,
+        bound: String,
+        bound_len: usize,
+    },
+
+    #[error(
+        "field `{subject}` is not a subset of `{super_field}`: element \
+         {element} appears in subject but not in super"
+    )]
+    NotSubset {
+        subject: String,
+        super_field: String,
+        element: serde_json::Value,
+    },
+
+    #[error(
+        "subset check needs arrays, objects, or strings; `{path}` is \
+         {actual}"
+    )]
+    NotCollectionForSubset {
+        path: String,
+        actual: serde_json::Value,
+    },
+
+    #[error(
+        "equality check failed: `{left}` is {left_value}; `{right}` is \
+         {right_value}"
+    )]
+    NotEqual {
+        left: String,
+        left_value: serde_json::Value,
+        right: String,
+        right_value: serde_json::Value,
+    },
+
+    #[error(
+        "field `{path}` is of JSON type `{actual}`; expected one of: \
+         {allowed:?}"
+    )]
+    TypeNotInAllowed {
+        path: String,
+        actual: String,
+        allowed: Vec<String>,
+    },
 }
 
 /// Why a property failed static validation against a stage's declared
@@ -143,13 +278,23 @@ pub enum PropertyTypeError {
 }
 
 impl Property {
-    /// The field path this property constrains. Used by callers that
-    /// want to group properties by target field for reporting.
-    /// Returns an empty string for [`Property::Unknown`] since the
-    /// reader doesn't know how to interpret it.
+    /// The primary field path this property constrains. Used by
+    /// callers that want to group properties by target field for
+    /// reporting.
+    ///
+    /// For relational variants (`FieldLengthEq`, `FieldLengthMax`,
+    /// `SubsetOf`, `Equals`) this returns the left/subject side.
+    /// Returns an empty string for [`Property::Unknown`].
     pub fn field(&self) -> &str {
         match self {
-            Property::SetMember { field, .. } | Property::Range { field, .. } => field,
+            Property::SetMember { field, .. }
+            | Property::Range { field, .. }
+            | Property::FieldTypeIn { field, .. } => field,
+            Property::FieldLengthEq { left_field, .. } | Property::Equals { left_field, .. } => {
+                left_field
+            }
+            Property::FieldLengthMax { subject_field, .. }
+            | Property::SubsetOf { subject_field, .. } => subject_field,
             Property::Unknown { .. } => "",
         }
     }
@@ -269,6 +414,16 @@ impl Property {
                     declared_type: format!("{other:?}"),
                 }),
             },
+            // M2.5 relational variants: type-aware validation of
+            // these pairs would require resolving BOTH paths, which
+            // validate_against_types doesn't do today (it validates
+            // one path). Accept them structurally; runtime
+            // evaluation still catches real shape mismatches.
+            Property::FieldLengthEq { .. }
+            | Property::FieldLengthMax { .. }
+            | Property::SubsetOf { .. }
+            | Property::Equals { .. }
+            | Property::FieldTypeIn { .. } => Ok(()),
         }
     }
 
@@ -285,37 +440,30 @@ impl Property {
         input: &serde_json::Value,
         output: &serde_json::Value,
     ) -> Result<(), PropertyViolation> {
-        if let Property::Unknown { .. } = self {
-            return Ok(());
-        }
-        let path = self.field();
-        let value = resolve_path(path, input, output)?;
         match self {
-            Property::SetMember { set, .. } => {
+            Property::Unknown { .. } => Ok(()),
+            Property::SetMember { field, set } => {
+                let value = resolve_path(field, input, output)?;
                 if set.iter().any(|allowed| allowed == value) {
                     Ok(())
                 } else {
                     Err(PropertyViolation::NotInSet {
-                        path: path.to_string(),
+                        path: field.clone(),
                         actual: value.clone(),
                         expected: set.clone(),
                     })
                 }
             }
-            Property::Unknown { .. } => unreachable!("handled above"),
-            Property::Range { min, max, .. } => {
-                let n = value
-                    .as_f64()
-                    .or_else(|| value.as_i64().map(|i| i as f64))
-                    .or_else(|| value.as_u64().map(|u| u as f64))
-                    .ok_or_else(|| PropertyViolation::NotNumber {
-                        path: path.to_string(),
-                        actual: value.clone(),
-                    })?;
+            Property::Range { field, min, max } => {
+                let value = resolve_path(field, input, output)?;
+                let n = coerce_number(value).ok_or_else(|| PropertyViolation::NotNumber {
+                    path: field.clone(),
+                    actual: value.clone(),
+                })?;
                 if let Some(lo) = min {
                     if n < *lo {
                         return Err(PropertyViolation::BelowMin {
-                            path: path.to_string(),
+                            path: field.clone(),
                             actual: n,
                             min: *lo,
                         });
@@ -324,7 +472,7 @@ impl Property {
                 if let Some(hi) = max {
                     if n > *hi {
                         return Err(PropertyViolation::AboveMax {
-                            path: path.to_string(),
+                            path: field.clone(),
                             actual: n,
                             max: *hi,
                         });
@@ -332,7 +480,206 @@ impl Property {
                 }
                 Ok(())
             }
+            Property::FieldLengthEq {
+                left_field,
+                right_field,
+            } => {
+                let left = resolve_path(left_field, input, output)?;
+                let right = resolve_path(right_field, input, output)?;
+                let left_len =
+                    measurable_length(left).ok_or_else(|| PropertyViolation::NotMeasurable {
+                        path: left_field.clone(),
+                        actual: left.clone(),
+                    })?;
+                let right_len =
+                    measurable_length(right).ok_or_else(|| PropertyViolation::NotMeasurable {
+                        path: right_field.clone(),
+                        actual: right.clone(),
+                    })?;
+                if left_len == right_len {
+                    Ok(())
+                } else {
+                    Err(PropertyViolation::LengthMismatch {
+                        left: left_field.clone(),
+                        left_len,
+                        right: right_field.clone(),
+                        right_len,
+                    })
+                }
+            }
+            Property::FieldLengthMax {
+                subject_field,
+                bound_field,
+            } => {
+                let subject = resolve_path(subject_field, input, output)?;
+                let bound = resolve_path(bound_field, input, output)?;
+                let subject_len =
+                    measurable_length(subject).ok_or_else(|| PropertyViolation::NotMeasurable {
+                        path: subject_field.clone(),
+                        actual: subject.clone(),
+                    })?;
+                let bound_len =
+                    measurable_length(bound).ok_or_else(|| PropertyViolation::NotMeasurable {
+                        path: bound_field.clone(),
+                        actual: bound.clone(),
+                    })?;
+                if subject_len <= bound_len {
+                    Ok(())
+                } else {
+                    Err(PropertyViolation::LengthExceedsBound {
+                        subject: subject_field.clone(),
+                        subject_len,
+                        bound: bound_field.clone(),
+                        bound_len,
+                    })
+                }
+            }
+            Property::SubsetOf {
+                subject_field,
+                super_field,
+            } => {
+                let subject = resolve_path(subject_field, input, output)?;
+                let superset = resolve_path(super_field, input, output)?;
+                check_subset(subject_field, subject, super_field, superset)
+            }
+            Property::Equals {
+                left_field,
+                right_field,
+            } => {
+                let left = resolve_path(left_field, input, output)?;
+                let right = resolve_path(right_field, input, output)?;
+                if left == right {
+                    Ok(())
+                } else {
+                    Err(PropertyViolation::NotEqual {
+                        left: left_field.clone(),
+                        left_value: left.clone(),
+                        right: right_field.clone(),
+                        right_value: right.clone(),
+                    })
+                }
+            }
+            Property::FieldTypeIn { field, allowed } => {
+                let value = resolve_path(field, input, output)?;
+                let actual = json_type_name(value);
+                if allowed.iter().any(|a| a == actual) {
+                    Ok(())
+                } else {
+                    Err(PropertyViolation::TypeNotInAllowed {
+                        path: field.clone(),
+                        actual: actual.to_string(),
+                        allowed: allowed.clone(),
+                    })
+                }
+            }
         }
+    }
+}
+
+fn coerce_number(v: &serde_json::Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_i64().map(|i| i as f64))
+        .or_else(|| v.as_u64().map(|u| u as f64))
+}
+
+/// Return the length of a JSON value for length-based property
+/// checks. UTF-8 chars for strings, element count for arrays, key
+/// count for objects. `None` for non-measurable types (numbers,
+/// bools, null).
+fn measurable_length(v: &serde_json::Value) -> Option<usize> {
+    match v {
+        serde_json::Value::String(s) => Some(s.chars().count()),
+        serde_json::Value::Array(a) => Some(a.len()),
+        serde_json::Value::Object(o) => Some(o.len()),
+        _ => None,
+    }
+}
+
+/// Element-wise subset check used by `Property::SubsetOf`. Works on
+/// arrays, objects (key set), and strings (substring).
+fn check_subset(
+    subject_path: &str,
+    subject: &serde_json::Value,
+    super_path: &str,
+    superset: &serde_json::Value,
+) -> Result<(), PropertyViolation> {
+    match (subject, superset) {
+        (serde_json::Value::Array(sub), serde_json::Value::Array(sup)) => {
+            for element in sub {
+                if !sup.iter().any(|s| s == element) {
+                    return Err(PropertyViolation::NotSubset {
+                        subject: subject_path.to_string(),
+                        super_field: super_path.to_string(),
+                        element: element.clone(),
+                    });
+                }
+            }
+            Ok(())
+        }
+        (serde_json::Value::Object(sub), serde_json::Value::Object(sup)) => {
+            // Object subset = every key in subject appears in super
+            // with an equal value.
+            for (key, val) in sub {
+                match sup.get(key) {
+                    Some(sup_val) if sup_val == val => {}
+                    _ => {
+                        return Err(PropertyViolation::NotSubset {
+                            subject: subject_path.to_string(),
+                            super_field: super_path.to_string(),
+                            element: serde_json::json!({ key.as_str(): val }),
+                        });
+                    }
+                }
+            }
+            Ok(())
+        }
+        (serde_json::Value::String(sub), serde_json::Value::String(sup)) => {
+            if sup.contains(sub.as_str()) {
+                Ok(())
+            } else {
+                Err(PropertyViolation::NotSubset {
+                    subject: subject_path.to_string(),
+                    super_field: super_path.to_string(),
+                    element: serde_json::Value::String(sub.clone()),
+                })
+            }
+        }
+        // Cross-type or scalar subject/super: not a meaningful subset check.
+        (_, _) => Err(PropertyViolation::NotCollectionForSubset {
+            path: if matches!(
+                subject,
+                serde_json::Value::Array(_)
+                    | serde_json::Value::Object(_)
+                    | serde_json::Value::String(_)
+            ) {
+                super_path.to_string()
+            } else {
+                subject_path.to_string()
+            },
+            actual: if matches!(
+                subject,
+                serde_json::Value::Array(_)
+                    | serde_json::Value::Object(_)
+                    | serde_json::Value::String(_)
+            ) {
+                superset.clone()
+            } else {
+                subject.clone()
+            },
+        }),
+    }
+}
+
+/// Map a serde_json::Value to one of the six canonical type-name
+/// strings used by `Property::FieldTypeIn`.
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -553,6 +900,227 @@ mod tests {
         let r = percent_prop();
         let v: serde_json::Value = serde_json::to_value(&r).unwrap();
         assert_eq!(v["kind"], json!("range"));
+    }
+
+    // ── M2.5 new variants ──────────────────────────────────────────
+
+    #[test]
+    fn field_length_eq_passes_on_equal_string_lengths() {
+        let p = Property::FieldLengthEq {
+            left_field: "output".into(),
+            right_field: "input".into(),
+        };
+        assert!(p.check(&json!("abc"), &json!("cba")).is_ok());
+    }
+
+    #[test]
+    fn field_length_eq_fails_on_different_lengths() {
+        let p = Property::FieldLengthEq {
+            left_field: "output".into(),
+            right_field: "input".into(),
+        };
+        let err = p.check(&json!("abc"), &json!("abcd")).unwrap_err();
+        assert!(matches!(err, PropertyViolation::LengthMismatch { .. }));
+    }
+
+    #[test]
+    fn field_length_eq_handles_arrays() {
+        let p = Property::FieldLengthEq {
+            left_field: "output.items".into(),
+            right_field: "input.items".into(),
+        };
+        assert!(p
+            .check(
+                &json!({"items": [1, 2, 3]}),
+                &json!({"items": ["a", "b", "c"]})
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn field_length_eq_rejects_non_measurable() {
+        let p = Property::FieldLengthEq {
+            left_field: "output".into(),
+            right_field: "input".into(),
+        };
+        let err = p.check(&json!(42), &json!("abc")).unwrap_err();
+        assert!(matches!(err, PropertyViolation::NotMeasurable { .. }));
+    }
+
+    #[test]
+    fn field_length_max_passes_when_subject_bounded() {
+        let p = Property::FieldLengthMax {
+            subject_field: "output.items".into(),
+            bound_field: "input.items".into(),
+        };
+        assert!(p
+            .check(&json!({"items": [1, 2]}), &json!({"items": [10]}))
+            .is_ok());
+        assert!(p
+            .check(
+                &json!({"items": [1, 2, 3]}),
+                &json!({"items": [10, 20, 30]})
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn field_length_max_fails_when_subject_exceeds_bound() {
+        let p = Property::FieldLengthMax {
+            subject_field: "output.items".into(),
+            bound_field: "input.items".into(),
+        };
+        let err = p
+            .check(&json!({"items": [10, 20]}), &json!({"items": [1, 2, 3, 4]}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::LengthExceedsBound { .. }));
+    }
+
+    #[test]
+    fn subset_of_passes_on_array_subset() {
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+        assert!(p.check(&json!([1, 2, 3, 4]), &json!([1, 3])).is_ok());
+    }
+
+    #[test]
+    fn subset_of_fails_on_non_subset() {
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+        let err = p.check(&json!([1, 2, 3]), &json!([99, 100])).unwrap_err();
+        assert!(matches!(err, PropertyViolation::NotSubset { .. }));
+    }
+
+    #[test]
+    fn subset_of_objects_uses_key_subset() {
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+        assert!(p
+            .check(&json!({"a": 1, "b": 2, "c": 3}), &json!({"a": 1, "b": 2}))
+            .is_ok());
+    }
+
+    #[test]
+    fn equals_passes_on_identical_values() {
+        let p = Property::Equals {
+            left_field: "output".into(),
+            right_field: "input".into(),
+        };
+        assert!(p.check(&json!({"a": 1}), &json!({"a": 1})).is_ok());
+    }
+
+    #[test]
+    fn equals_fails_on_different_values() {
+        let p = Property::Equals {
+            left_field: "output".into(),
+            right_field: "input".into(),
+        };
+        let err = p.check(&json!({"a": 1}), &json!({"a": 2})).unwrap_err();
+        assert!(matches!(err, PropertyViolation::NotEqual { .. }));
+    }
+
+    #[test]
+    fn field_type_in_passes_on_allowed_type() {
+        let p = Property::FieldTypeIn {
+            field: "output.value".into(),
+            allowed: vec!["number".into(), "null".into()],
+        };
+        assert!(p.check(&json!(null), &json!({"value": 42})).is_ok());
+        assert!(p.check(&json!(null), &json!({"value": null})).is_ok());
+    }
+
+    #[test]
+    fn field_type_in_fails_on_disallowed_type() {
+        let p = Property::FieldTypeIn {
+            field: "output.value".into(),
+            allowed: vec!["number".into()],
+        };
+        let err = p
+            .check(&json!(null), &json!({"value": "oops"}))
+            .unwrap_err();
+        assert!(matches!(err, PropertyViolation::TypeNotInAllowed { .. }));
+    }
+
+    #[test]
+    fn new_variants_serde_roundtrip() {
+        let cases = vec![
+            Property::FieldLengthEq {
+                left_field: "output".into(),
+                right_field: "input".into(),
+            },
+            Property::FieldLengthMax {
+                subject_field: "output".into(),
+                bound_field: "input.items".into(),
+            },
+            Property::SubsetOf {
+                subject_field: "output.keys".into(),
+                super_field: "input.keys".into(),
+            },
+            Property::Equals {
+                left_field: "output".into(),
+                right_field: "input".into(),
+            },
+            Property::FieldTypeIn {
+                field: "output.id".into(),
+                allowed: vec!["string".into()],
+            },
+        ];
+        for p in cases {
+            let serialised = serde_json::to_string(&p).unwrap();
+            let parsed: Property = serde_json::from_str(&serialised).unwrap();
+            assert_eq!(p, parsed, "round-trip failed: {serialised}");
+        }
+    }
+
+    #[test]
+    fn new_variants_json_shape_is_tagged_snake_case() {
+        let cases = vec![
+            (
+                Property::FieldLengthEq {
+                    left_field: "output".into(),
+                    right_field: "input".into(),
+                },
+                "field_length_eq",
+            ),
+            (
+                Property::FieldLengthMax {
+                    subject_field: "output".into(),
+                    bound_field: "input".into(),
+                },
+                "field_length_max",
+            ),
+            (
+                Property::SubsetOf {
+                    subject_field: "output".into(),
+                    super_field: "input".into(),
+                },
+                "subset_of",
+            ),
+            (
+                Property::Equals {
+                    left_field: "output".into(),
+                    right_field: "input".into(),
+                },
+                "equals",
+            ),
+            (
+                Property::FieldTypeIn {
+                    field: "output".into(),
+                    allowed: vec!["string".into()],
+                },
+                "field_type_in",
+            ),
+        ];
+        for (p, expected_kind) in cases {
+            let v: serde_json::Value = serde_json::to_value(&p).unwrap();
+            assert_eq!(v["kind"], json!(expected_kind));
+        }
     }
 
     // ── validate_against_types tests ────────────────────────────────

--- a/crates/noether-core/src/stage/property.rs
+++ b/crates/noether-core/src/stage/property.rs
@@ -147,6 +147,12 @@ pub enum Property {
     ///
     /// Added in M2.5 to express length-preservation invariants
     /// (`text_reverse`, `text_upper`, `map`, etc.).
+    ///
+    /// **Cross-kind comparisons are allowed but rarely useful.**
+    /// `FieldLengthEq { left: array, right: string }` compares the
+    /// array's element count against the string's code-point count
+    /// — mechanically defined, but almost never what an author
+    /// means. Prefer paths of the same JSON kind.
     FieldLengthEq {
         left_field: String,
         right_field: String,
@@ -750,29 +756,24 @@ fn check_subset(
                 })
             }
         }
-        // Cross-type or scalar subject/super: not a meaningful subset check.
-        (_, _) => Err(PropertyViolation::NotCollectionForSubset {
-            path: if matches!(
+        // Cross-type or scalar subject/super: not a meaningful
+        // subset check. Blame whichever side is *not* a collection
+        // (array / object / string) so the error points the operator
+        // at the malformed field rather than the well-formed one.
+        (_, _) => {
+            let subject_is_collection = matches!(
                 subject,
                 serde_json::Value::Array(_)
                     | serde_json::Value::Object(_)
                     | serde_json::Value::String(_)
-            ) {
-                super_path.to_string()
+            );
+            let (path, actual) = if subject_is_collection {
+                (super_path.to_string(), superset.clone())
             } else {
-                subject_path.to_string()
-            },
-            actual: if matches!(
-                subject,
-                serde_json::Value::Array(_)
-                    | serde_json::Value::Object(_)
-                    | serde_json::Value::String(_)
-            ) {
-                superset.clone()
-            } else {
-                subject.clone()
-            },
-        }),
+                (subject_path.to_string(), subject.clone())
+            };
+            Err(PropertyViolation::NotCollectionForSubset { path, actual })
+        }
     }
 }
 
@@ -1247,6 +1248,34 @@ mod tests {
             None,
             "truly unknown kinds must not be flagged as shadowing"
         );
+    }
+
+    #[test]
+    fn field_type_in_empty_allowlist_always_fails() {
+        // Edge case: an empty `allowed` list is vacuously unsatisfiable.
+        // Pins the intended behavior so a future refactor can't
+        // silently short-circuit `allowed.is_empty() => Ok(())`.
+        let p = Property::FieldTypeIn {
+            field: "output".into(),
+            allowed: vec![],
+        };
+        let err = p.check(&json!(null), &json!("x")).unwrap_err();
+        assert!(matches!(err, PropertyViolation::TypeNotInAllowed { .. }));
+    }
+
+    #[test]
+    fn subset_of_empty_subject_is_vacuously_true() {
+        // Every side is a subset of anything when the subject is
+        // empty — trivially true for arrays, objects, and strings.
+        // Protects against a refactor that accidentally special-cases
+        // empty inputs as violations.
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+        assert!(p.check(&json!([1, 2, 3]), &json!([])).is_ok());
+        assert!(p.check(&json!({"a": 1, "b": 2}), &json!({})).is_ok());
+        assert!(p.check(&json!("abc"), &json!("")).is_ok());
     }
 
     #[test]

--- a/crates/noether-core/src/stage/property.rs
+++ b/crates/noether-core/src/stage/property.rs
@@ -47,6 +47,59 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The six JSON runtime-value kinds. Used by
+/// [`Property::FieldTypeIn`] to declare a field's acceptable kinds.
+///
+/// Typed rather than a free-form `String` so that wire-format typos
+/// (`"bolean"`, `"interger"`) fail at deserialisation with a clear
+/// serde error rather than silently making every example violate
+/// the property. Wire format is unchanged from M2.5 round-1:
+/// `"allowed": ["number", "string"]` — snake_case strings matching
+/// the serde-renamed variant names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonKind {
+    Null,
+    Bool,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+impl JsonKind {
+    /// Return the kind of a given JSON value.
+    pub fn of(v: &serde_json::Value) -> Self {
+        match v {
+            serde_json::Value::Null => JsonKind::Null,
+            serde_json::Value::Bool(_) => JsonKind::Bool,
+            serde_json::Value::Number(_) => JsonKind::Number,
+            serde_json::Value::String(_) => JsonKind::String,
+            serde_json::Value::Array(_) => JsonKind::Array,
+            serde_json::Value::Object(_) => JsonKind::Object,
+        }
+    }
+
+    /// The wire-format string for this kind — same bytes that
+    /// serde emits. Used for human-readable error messages.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            JsonKind::Null => "null",
+            JsonKind::Bool => "bool",
+            JsonKind::Number => "number",
+            JsonKind::String => "string",
+            JsonKind::Array => "array",
+            JsonKind::Object => "object",
+        }
+    }
+}
+
+impl std::fmt::Display for JsonKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A declarative property claim on a stage.
 ///
 /// The wire format is a tagged union on the `"kind"` field. Unknown
@@ -81,10 +134,16 @@ pub enum Property {
         max: Option<f64>,
     },
     /// The length of the value at `left_field` equals the length of the
-    /// value at `right_field`. "Length" is defined as:
-    /// - UTF-8 character count for strings
-    /// - element count for arrays
-    /// - key count for objects
+    /// value at `right_field`. "Length" is:
+    ///
+    /// - **String**: UTF-8 **code-point** count (`str::chars().count()`),
+    ///   not byte count and not grapheme cluster count. `"a̐"` has
+    ///   length 2 (two codepoints: `a` + combining accent); `"👨‍👩‍👧"`
+    ///   has length 5 (three emoji + two zero-width joiners).
+    /// - **Array**: element count.
+    /// - **Object**: key count.
+    /// - **Other scalars (number, bool, null)**: not measurable; the
+    ///   property fails with [`PropertyViolation::NotMeasurable`].
     ///
     /// Added in M2.5 to express length-preservation invariants
     /// (`text_reverse`, `text_upper`, `map`, etc.).
@@ -102,13 +161,28 @@ pub enum Property {
         subject_field: String,
         bound_field: String,
     },
-    /// Every element of `subject_field` appears (by JSON-value
-    /// equality) in `super_field`. Arrays are treated as sets;
-    /// duplicates in subject are allowed as long as the value is
-    /// present in super.
+    /// Every element / key / character of `subject_field` appears in
+    /// `super_field`. Semantics depend on the runtime JSON shape of
+    /// the two values — all three branches are useful in practice,
+    /// but they're different checks:
     ///
-    /// Useful for `sort` (output is a permutation of input), stages
-    /// that project or re-group a subset of input fields.
+    /// - **Array vs Array**: every element of `subject` appears (by
+    ///   JSON-value equality) in `super`. Duplicates allowed as long
+    ///   as the value is present. Useful for `sort`, `filter`,
+    ///   `project` — output elements are drawn from input.
+    /// - **Object vs Object**: every `(key, value)` of `subject`
+    ///   appears with an equal value in `super` — *stricter* than
+    ///   key-presence. `{"a": 1}` is NOT a subset of `{"a": 2}`.
+    /// - **String vs String**: `subject` is a **contiguous
+    ///   substring** of `super` — not a character set. So
+    ///   `SubsetOf { subject: "abc", super: "bac" }` is false (`abc`
+    ///   is not a substring of `bac`) even though every character in
+    ///   `abc` appears somewhere in `bac`. This matches the
+    ///   "output string is a quote from the input" use case; declare
+    ///   a `Range` or `FieldLengthMax` if you want a weaker claim.
+    ///
+    /// Mixed-type pairs (`Array` vs `Object`, scalar vs anything) and
+    /// scalar-only pairs produce [`PropertyViolation::NotCollectionForSubset`].
     ///
     /// Added in M2.5.
     SubsetOf {
@@ -126,13 +200,16 @@ pub enum Property {
         right_field: String,
     },
     /// The runtime JSON type at `field` is one of the allowed kinds.
-    /// Kinds are the strings `"null"`, `"bool"`, `"number"`,
-    /// `"string"`, `"array"`, `"object"`. Bridges the gap between
-    /// the structural type system's compile-time view and the
-    /// actual runtime shape.
+    /// Kinds are enumerated by [`JsonKind`] (typed rather than
+    /// free-form strings, so wire-format typos fail at
+    /// deserialisation). Bridges the gap between the structural type
+    /// system's compile-time view and the actual runtime shape.
     ///
     /// Added in M2.5.
-    FieldTypeIn { field: String, allowed: Vec<String> },
+    FieldTypeIn {
+        field: String,
+        allowed: Vec<JsonKind>,
+    },
     /// A property kind this reader doesn't know how to evaluate.
     /// Produced by the deserialiser for forward compatibility when a
     /// future minor release adds a new `kind` variant; the original
@@ -245,8 +322,8 @@ pub enum PropertyViolation {
     )]
     TypeNotInAllowed {
         path: String,
-        actual: String,
-        allowed: Vec<String>,
+        actual: JsonKind,
+        allowed: Vec<JsonKind>,
     },
 }
 
@@ -304,6 +381,35 @@ impl Property {
     /// should treat these as skips, not passes or failures.
     pub fn is_unknown(&self) -> bool {
         matches!(self, Property::Unknown { .. })
+    }
+
+    /// If this property came out as [`Property::Unknown`] but its raw
+    /// `"kind"` matches a KNOWN variant name, return the known kind
+    /// string. This captures the case where a user typo'd a field
+    /// *within* a known kind (e.g. `allowed: ["bolean"]` inside a
+    /// valid `field_type_in`) and serde fell through to the
+    /// forward-compat `Unknown` variant instead of surfacing the
+    /// error. Downstream ingest paths (stage add, `validate_spec`)
+    /// should treat `Some(...)` here as a hard error — the user
+    /// intended a known property kind but wrote something malformed,
+    /// and the `Unknown` escape hatch would silently drop the check.
+    pub fn shadowed_known_kind(&self) -> Option<&str> {
+        const KNOWN_KINDS: &[&str] = &[
+            "set_member",
+            "range",
+            "field_length_eq",
+            "field_length_max",
+            "subset_of",
+            "equals",
+            "field_type_in",
+        ];
+        match self {
+            Property::Unknown { raw } => raw
+                .get("kind")
+                .and_then(|k| k.as_str())
+                .filter(|k| KNOWN_KINDS.contains(k)),
+            _ => None,
+        }
     }
 
     /// Validate that this property's field path is reachable in the
@@ -561,13 +667,13 @@ impl Property {
             }
             Property::FieldTypeIn { field, allowed } => {
                 let value = resolve_path(field, input, output)?;
-                let actual = json_type_name(value);
-                if allowed.iter().any(|a| a == actual) {
+                let actual = JsonKind::of(value);
+                if allowed.contains(&actual) {
                     Ok(())
                 } else {
                     Err(PropertyViolation::TypeNotInAllowed {
                         path: field.clone(),
-                        actual: actual.to_string(),
+                        actual,
                         allowed: allowed.clone(),
                     })
                 }
@@ -667,19 +773,6 @@ fn check_subset(
                 subject.clone()
             },
         }),
-    }
-}
-
-/// Map a serde_json::Value to one of the six canonical type-name
-/// strings used by `Property::FieldTypeIn`.
-fn json_type_name(v: &serde_json::Value) -> &'static str {
-    match v {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "bool",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -1007,6 +1100,64 @@ mod tests {
     }
 
     #[test]
+    fn subset_of_strings_is_substring_not_character_set() {
+        // Pinning test for the round-2 review finding: `SubsetOf`
+        // on strings means **contiguous substring**, not a
+        // character-set subset. This test contrasts the two
+        // interpretations so the chosen semantics can't drift.
+        //
+        // "abc" ⊂ "bac" under character-subset (every char of "abc"
+        //   appears in "bac") — but we DO NOT want that match.
+        // "abc" ⊂ "zabcz" under both substring and char-subset.
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+
+        // input = "bac" contains the chars a,b,c but not the
+        // substring "abc". Property must fail — the docstring's
+        // substring contract is the authoritative one.
+        let err = p
+            .check(&json!("bac"), &json!("abc"))
+            .expect_err("expected substring check to reject 'abc' ⊄ 'bac'");
+        assert!(
+            matches!(err, PropertyViolation::NotSubset { .. }),
+            "expected NotSubset, got {err:?}"
+        );
+
+        // input = "zabcz" contains the substring "abc" — passes.
+        assert!(p.check(&json!("zabcz"), &json!("abc")).is_ok());
+
+        // Identity (trivial substring of self) passes.
+        assert!(p.check(&json!("abc"), &json!("abc")).is_ok());
+    }
+
+    #[test]
+    fn subset_of_rejects_mixed_collection_kinds() {
+        // Array-vs-object and collection-vs-scalar both surface as
+        // NotCollectionForSubset rather than a false pass/fail.
+        let p = Property::SubsetOf {
+            subject_field: "output".into(),
+            super_field: "input".into(),
+        };
+        let err = p
+            .check(&json!({"a": 1}), &json!([1, 2]))
+            .expect_err("array subject vs object super must fail");
+        assert!(matches!(
+            err,
+            PropertyViolation::NotCollectionForSubset { .. }
+        ));
+
+        let err = p
+            .check(&json!(42), &json!([1, 2, 3]))
+            .expect_err("scalar super vs array subject must fail");
+        assert!(matches!(
+            err,
+            PropertyViolation::NotCollectionForSubset { .. }
+        ));
+    }
+
+    #[test]
     fn equals_passes_on_identical_values() {
         let p = Property::Equals {
             left_field: "output".into(),
@@ -1029,7 +1180,7 @@ mod tests {
     fn field_type_in_passes_on_allowed_type() {
         let p = Property::FieldTypeIn {
             field: "output.value".into(),
-            allowed: vec!["number".into(), "null".into()],
+            allowed: vec![JsonKind::Number, JsonKind::Null],
         };
         assert!(p.check(&json!(null), &json!({"value": 42})).is_ok());
         assert!(p.check(&json!(null), &json!({"value": null})).is_ok());
@@ -1039,12 +1190,77 @@ mod tests {
     fn field_type_in_fails_on_disallowed_type() {
         let p = Property::FieldTypeIn {
             field: "output.value".into(),
-            allowed: vec!["number".into()],
+            allowed: vec![JsonKind::Number],
         };
         let err = p
             .check(&json!(null), &json!({"value": "oops"}))
             .unwrap_err();
         assert!(matches!(err, PropertyViolation::TypeNotInAllowed { .. }));
+    }
+
+    #[test]
+    fn field_type_in_typo_surfaces_as_shadowed_known_kind() {
+        // The `JsonKind` enum catches typos at the Rust API level
+        // (code that constructs `Property::FieldTypeIn { allowed: ... }`
+        // can't pass a bad string). But wire-format typos fall
+        // through to `Property::Unknown` via serde's forward-compat
+        // untagged fallback — we don't want to break loading
+        // v0.8 graphs in a v0.7 reader just because a new kind
+        // was added.
+        //
+        // `shadowed_known_kind` splits the two cases: an unknown
+        // variant with a truly unknown `kind` is fine (v0.8
+        // forward-compat); an unknown variant with a KNOWN `kind`
+        // means the user mistyped inside a known property and
+        // should be rejected at ingest time.
+        let bad = r#"{
+            "kind": "field_type_in",
+            "field": "output.x",
+            "allowed": ["bolean"]
+        }"#;
+        let p: Property = serde_json::from_str(bad).unwrap();
+        assert!(
+            matches!(p, Property::Unknown { .. }),
+            "typo falls through to Unknown via serde untagged fallback"
+        );
+        assert_eq!(
+            p.shadowed_known_kind(),
+            Some("field_type_in"),
+            "shadow of a known kind must be detectable; ingest paths \
+             should reject properties that report this non-None"
+        );
+    }
+
+    #[test]
+    fn genuinely_unknown_kind_does_not_shadow() {
+        // A hypothetical v0.8 kind that v0.7 doesn't know about
+        // must NOT be flagged as shadowing — forward compat.
+        let future = r#"{
+            "kind": "v08_implication",
+            "premise": "input.x",
+            "conclusion": "output.y"
+        }"#;
+        let p: Property = serde_json::from_str(future).unwrap();
+        assert!(matches!(p, Property::Unknown { .. }));
+        assert_eq!(
+            p.shadowed_known_kind(),
+            None,
+            "truly unknown kinds must not be flagged as shadowing"
+        );
+    }
+
+    #[test]
+    fn field_type_in_wire_format_is_snake_case_strings() {
+        // Regression guard on the `#[serde(rename_all = "snake_case")]`
+        // contract — the byte-count argument in the round-1 review
+        // depends on `JsonKind::Number` serialising as `"number"`,
+        // not `"Number"` or some other casing.
+        let p = Property::FieldTypeIn {
+            field: "output.x".into(),
+            allowed: vec![JsonKind::Bool, JsonKind::Null],
+        };
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(json["allowed"], serde_json::json!(["bool", "null"]));
     }
 
     #[test]
@@ -1068,7 +1284,7 @@ mod tests {
             },
             Property::FieldTypeIn {
                 field: "output.id".into(),
-                allowed: vec!["string".into()],
+                allowed: vec![JsonKind::String],
             },
         ];
         for p in cases {
@@ -1112,7 +1328,7 @@ mod tests {
             (
                 Property::FieldTypeIn {
                     field: "output".into(),
-                    allowed: vec!["string".into()],
+                    allowed: vec![JsonKind::String],
                 },
                 "field_type_in",
             ),

--- a/crates/noether-core/src/stage/validation.rs
+++ b/crates/noether-core/src/stage/validation.rs
@@ -127,6 +127,26 @@ pub enum ValidationError {
         min: usize,
         got: usize,
     },
+    /// A property in the stage's `properties` array deserialised into
+    /// [`Property::Unknown`] with a `kind` string that names a
+    /// variant this reader DOES know about. That signals a user typo
+    /// inside a known property kind (e.g. `allowed: ["bolean"]`
+    /// inside a `field_type_in`) rather than a genuinely unknown
+    /// future kind. Rejecting at ingest prevents the typo'd property
+    /// from silently becoming a no-op check.
+    ///
+    /// See [`Property::shadowed_known_kind`] for the detection
+    /// semantics.
+    ///
+    /// [`Property::Unknown`]: crate::stage::property::Property::Unknown
+    /// [`Property::shadowed_known_kind`]: crate::stage::property::Property::shadowed_known_kind
+    ShadowedKnownKind {
+        /// Position in the stage's `properties` array.
+        index: usize,
+        /// The known-kind string that the malformed property
+        /// reported (e.g. `"field_type_in"`).
+        kind: String,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -153,6 +173,13 @@ impl fmt::Display for ValidationError {
             ValidationError::TooFewExamples { min, got } => {
                 write!(f, "too few examples: need at least {min}, got {got}")
             }
+            ValidationError::ShadowedKnownKind { index, kind } => write!(
+                f,
+                "property[{index}]: looks like a `{kind}` but failed to \
+                 deserialise into that variant (likely a typo in one of \
+                 its fields). Fix the property — registering it as-is \
+                 would silently drop the check at runtime."
+            ),
         }
     }
 }
@@ -166,6 +193,20 @@ pub fn validate_stage(stage: &Stage, min_examples: usize) -> ValidationResult {
             min: min_examples,
             got: stage.examples.len(),
         });
+    }
+
+    // Reject properties that came out as `Property::Unknown` but name
+    // a known kind — see ValidationError::ShadowedKnownKind. Running
+    // before example-type-checking keeps the error message close to
+    // "your property JSON is malformed" rather than burying it under
+    // an output-type mismatch.
+    for (i, prop) in stage.properties.iter().enumerate() {
+        if let Some(kind) = prop.shadowed_known_kind() {
+            errors.push(ValidationError::ShadowedKnownKind {
+                index: i,
+                kind: kind.to_string(),
+            });
+        }
     }
 
     for (i, example) in stage.examples.iter().enumerate() {
@@ -301,5 +342,75 @@ mod tests {
         let t = infer_type(&vnode);
         // Should be a Record, not VNode (VNode requires an explicit hint)
         assert!(matches!(t, NType::Record(_)));
+    }
+
+    #[test]
+    fn validate_stage_rejects_shadowed_known_kind() {
+        // End-to-end: a stage spec with a typo inside a known
+        // property kind (e.g. `allowed: ["bolean"]` in a
+        // `field_type_in`) deserialises as `Property::Unknown` via
+        // serde's untagged fallback. `validate_stage` must surface
+        // that as a ShadowedKnownKind error so ingest (stage add,
+        // validate_spec) rejects it.
+        use crate::effects::EffectSet;
+        use crate::stage::property::Property;
+        use crate::stage::schema::{
+            CostEstimate, Example, Stage, StageId, StageLifecycle, StageSignature,
+        };
+        use std::collections::BTreeSet;
+
+        // Hand-construct the Unknown shape serde would produce for
+        // a shadowed typo — round-tripping through JSON keeps this
+        // test honest about what a real ingest path sees.
+        let typo_json = json!({
+            "kind": "field_type_in",
+            "field": "output.x",
+            "allowed": ["bolean"]
+        });
+        let typo: Property = serde_json::from_value(typo_json).unwrap();
+        assert!(matches!(typo, Property::Unknown { .. }));
+        assert_eq!(typo.shadowed_known_kind(), Some("field_type_in"));
+
+        let stage = Stage {
+            id: StageId("abc".into()),
+            signature_id: None,
+            signature: StageSignature {
+                input: NType::Text,
+                output: NType::Text,
+                effects: EffectSet::pure(),
+                implementation_hash: "h".into(),
+            },
+            capabilities: BTreeSet::new(),
+            cost: CostEstimate {
+                time_ms_p50: None,
+                tokens_est: None,
+                memory_mb: None,
+            },
+            description: "t".into(),
+            examples: vec![Example {
+                input: json!("x"),
+                output: json!("x"),
+            }],
+            lifecycle: StageLifecycle::Active,
+            ed25519_signature: None,
+            signer_public_key: None,
+            implementation_code: None,
+            implementation_language: None,
+            ui_style: None,
+            tags: vec![],
+            aliases: vec![],
+            name: None,
+            properties: vec![typo],
+        };
+
+        let result = validate_stage(&stage, 0);
+        assert!(
+            result.errors.iter().any(|e| matches!(
+                e,
+                ValidationError::ShadowedKnownKind { kind, .. } if kind == "field_type_in"
+            )),
+            "expected ShadowedKnownKind error, got: {:?}",
+            result.errors
+        );
     }
 }


### PR DESCRIPTION
## Summary

Five new `Property` variants that unlock meaningful backfill on ~75
more stdlib stages. The v0.6 DSL could only express numeric bounds
and enumerated sets; most stdlib guarantees are *relational*
(length preservation, subset containment, identity) which the
original DSL couldn't capture.

### New variants

| Variant | Example use |
|---------|-------------|
| `FieldLengthEq { left_field, right_field }` | `text_reverse`: `output.length == input.length` |
| `FieldLengthMax { subject_field, bound_field }` | `filter`: `output.items ≤ input.items` |
| `SubsetOf { subject_field, super_field }` | `sort`: `output ⊆ input && input ⊆ output` |
| `Equals { left_field, right_field }` | identity stages: `output == input` |
| `FieldTypeIn { field, allowed }` | `parse_json`: `output.kind ∈ {"number","string",...}` |

Length is defined uniformly as UTF-8 char count for strings, element
count for arrays, key count for objects. `SubsetOf` works on arrays
(element subset), objects (key + value subset), and strings
(substring).

### Tests

**17 new**, covering each variant's success + failure paths, serde
round-trips, JSON tag shape, cross-type edge cases (array + object
length, object key subset, substring subset, non-measurable rejects,
type-name mismatches). 39 property tests total (was 22).

### Forward compatibility

Strictly additive. `Property::Unknown` (shipped in v0.6) catches any
future `"kind"` the reader doesn't recognise — so v0.6 readers load
a v0.7 graph with these new kinds and skip them in aggregation,
exactly as `STABILITY.md` promises.

### Stacked on

`main` (post-v0.6.0).

## What this unlocks

Per `docs/roadmap/2026-04-18-property-dsl-expansion.md` (shipped in
#31), the backfillable stdlib stage count goes from ~45 (v0.6) to
~120 (this PR). The remaining ~35 polymorphic / content-generating
stages wait for M3 refinement types.

Actual stdlib backfill lands in a follow-up PR.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 39 property tests pass (17 new)
- [ ] Review: length semantics — UTF-8 chars for strings is my call.
      Acceptable, or should `FieldLengthEq` spell out what "length" means?
- [ ] Review: `SubsetOf` behaviour on cross-type pairs (array subject
      + object super) — currently errors via `NotCollectionForSubset`.
      Correct, or should it be a different violation?
- [ ] Review: `FieldTypeIn` allowed values are strings; could be an
      enum instead. Strings are cheaper to serialise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
