### PR TITLE
docs: agent-first documentation — AGENTS.md + 5 playbooks + noether agent-docs CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+Dense, machine-readable map of Noether for AI agents. Humans reading this for the first time: start at [`README.md`](README.md), then [`docs/architecture.md`](docs/architecture.md) — both are narrative-shaped. This file is indexable fragments optimised for token-efficient agent consumption.
+
+## What Noether is, in one paragraph
+
+Content-addressed, typed, composable stages (functions) wired into verified pipelines. Every stage has: a structural type signature (`input → output`), a declared effect set, examples, a SHA-256 content hash as its identity. Graphs over stages (`Sequential`, `Parallel`, `Branch`, `Fanout`, `Merge`, `Retry`, `Let`) are type-checked before execution and hash-identified so the same source graph produces the same `composition_id` forever. Stage execution is sandboxed by default (`bwrap` subprocess) from v0.7. Built for AI agents to decompose problems into verified compositions; humans use it too.
+
+## Layered reference
+
+- [`STABILITY.md`](STABILITY.md) — v1.x wire-format contract. What's frozen, what's additive, what's deprecated. Authoritative on what your code can rely on.
+- [`SECURITY.md`](SECURITY.md) — trust model. Isolation semantics, capability boundaries, what the sandbox does and doesn't defend against.
+- [`CHANGELOG.md`](CHANGELOG.md) — per-release delta. Start here when checking "what changed between vX and vY."
+- [`docs/architecture.md`](docs/architecture.md) — 4-layer architecture (Nix execution, stage store, composition engine, agent interface). Decision-maker's read.
+- [`docs/agents/`](docs/agents/) — intent-keyed playbooks. Each answers one concrete "how do I…?" question.
+
+## Agent entry points
+
+Use these instead of grepping the codebase:
+
+| Intent | Tool |
+| --- | --- |
+| List available playbooks | `noether agent-docs` |
+| Read a playbook | `noether agent-docs <key>` |
+| Search playbooks by keyword | `noether agent-docs --search <term>` |
+| Full command tree as JSON (ACLI) | `noether introspect` |
+| Search stages by intent | `noether stage search "<problem description>"` |
+| List all registered stages | `noether stage list` |
+| Get a specific stage | `noether stage get <id-or-prefix>` |
+| Type-check a graph without executing | `noether run --dry-run <graph.json>` |
+| Produce a graph from a problem description | `noether compose "<problem>"` |
+
+## Playbook index
+
+Each playbook is a fixed-shape fragment (`Intent / Preconditions / Steps / Output shape / Failure modes / Verification`). Load on demand — you do not need to read them linearly.
+
+- [`compose-a-graph`](docs/agents/compose-a-graph.md) — translate a problem description into a valid composition graph using the Composition Agent.
+- [`find-an-existing-stage`](docs/agents/find-an-existing-stage.md) — search the stdlib + registry for stages matching a type signature or intent.
+- [`synthesize-a-new-stage`](docs/agents/synthesize-a-new-stage.md) — author a stage when nothing in the catalogue fits; sign, validate, register.
+- [`express-a-property`](docs/agents/express-a-property.md) — add declarative property claims to a stage using the DSL.
+- [`debug-a-failed-graph`](docs/agents/debug-a-failed-graph.md) — interpret type errors, effect violations, capability errors, resolver warnings, and runtime traces.
+
+## Type system at a glance
+
+`NType` is structural. Subtyping is structural. Relevant variants (see `crates/noether-core/src/types/`):
+
+- `Text`, `Number`, `Bool`, `Null`, `Bytes`, `VNode`, `Any`
+- `List(T)`, `Map<K, V>`
+- `Record { field: T, ... }` — width + depth subtyping (`Record { a, b, c }` is subtype of `Record { a, b }`).
+- `Union(variants)` — flattened, deduped, sorted by constructor (`union()` is the only normalising path).
+- `Stream<T>` — unbounded, typed channel.
+
+`Any` is a bidirectional escape hatch: `is_subtype_of(T, Any)` AND `is_subtype_of(Any, T)` both hold.
+
+## Effect system at a glance
+
+`EffectSet` is a set of `Effect` variants (`crates/noether-core/src/effects/effect.rs`):
+
+- `Pure` — no side effects. Default when nothing declared.
+- `Fallible` — can return an error the caller must handle.
+- `Network` — makes outbound network calls. Sandbox uses this to toggle `--share-net`.
+- `Llm { model }` — invokes an LLM. `model` string is a hint; policy checks use `EffectKind::Llm`.
+- `NonDeterministic` — same input may produce different output.
+- `Process` — spawns, signals, or waits on OS processes.
+- `Cost { cents }` — declared monetary cost. `--budget-cents` uses this.
+- `Unknown` — effect-inference LLM couldn't classify; treated conservatively.
+
+## Wire formats
+
+- **Stage spec**: see `.cli/schemas/stage-spec.json` (JSON Schema).
+- **Composition graph (Lagrange)**: see `crates/noether-engine/src/lagrange/ast.rs` — `CompositionNode` enum, tagged on `"op"`.
+- **Isolation policy**: see `crates/noether-isolation/src/lib.rs` — `IsolationPolicy` struct, serde-enabled for cross-process use.
+- **ACLI response envelope**: see `acli` crate. Every CLI output is `{ ok: bool, command: str, result?|error: ..., meta: {version, duration_ms} }`.
+
+## Non-goals (stop here, do not try these)
+
+- Noether is **not** a workflow orchestrator, pipeline runner, AI agent framework, or package manager. Don't try to use it to schedule recurring jobs (use `noether-scheduler`), glue LLM prompts together (use an agent framework), or distribute binaries (use a package registry).
+- Stages are content-addressed. Mutation is modelled via new stages + deprecation chains, not in-place edits. Don't try to "update" an existing stage; put a new one with the same `signature_id` and the store auto-deprecates the old.
+- Graph identity is pre-resolution (M1 contract). Never hash a graph after `resolve_pinning` — the id drifts when the Active implementation rotates.
+
+## Versioning
+
+- Current: **v0.7.1** (M2 closed + `noether-isolation` extracted).
+- STABILITY.md applies from 0.7.0.
+- Breaking changes go in major/minor bumps with a CHANGELOG entry marked `Breaking`.
+- 1.0 target: M4 completion (see `docs/roadmap/2026-04-18-rock-solid-plan.md`).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **Typed, content-addressed pipelines — reproducible by construction, LLM-assisted by option.**
 
-Decompose computation into stages with structural type signatures. The type checker verifies every edge of a composition graph before execution (topology only — it does not prove stage *bodies* correct). Run stages in a Nix-pinned runtime for byte-identical reproduction. Replay any run from its composition hash.
+Decompose computation into stages with structural type signatures. The type checker verifies every edge of a composition graph before execution (topology only — it does not prove stage *bodies* correct). Run stages in a Nix-pinned runtime for byte-identical reproduction, sandboxed by default (v0.7+) via bubblewrap. Replay any run from its composition hash.
 
-> **Trust model (read first):** the Nix-pinned runtime is a reproducibility boundary, **not** an isolation boundary. Stages run with host-user privileges and can read the filesystem, make network calls, and touch your environment. See [SECURITY.md](./SECURITY.md) before running a stage you did not write.
+> **Trust model (read first):** the Nix-pinned runtime is a reproducibility boundary; the bubblewrap sandbox layer (v0.7 default when `--isolate=auto` finds bwrap) is the isolation boundary. Together they bound what a stage can read, write, and reach. See [SECURITY.md](./SECURITY.md) for the full model and caveats, and [STABILITY.md](./STABILITY.md) for the v1.x wire-format contract.
+
+> **Reading this as an AI agent?** Start at [AGENTS.md](./AGENTS.md) and query playbooks via `noether agent-docs` — dense, intent-keyed, machine-readable. The rest of this README is human-facing narrative.
 
 [![Crates.io](https://img.shields.io/crates/v/noether-cli.svg)](https://crates.io/crates/noether-cli)
 [![Docs](https://img.shields.io/badge/docs-noether.alpibru.com-blue.svg)](https://alpibrusl.github.io/noether/)
@@ -41,7 +43,7 @@ Noether is **not** a workflow orchestrator, request-response framework, or AI ag
 ### When Noether is *not* the right tool
 
 - **You need request/response with SLAs, autoscaling, or sticky sessions.** Use a regular service framework (axum, FastAPI, …). Noether doesn't serve traffic; it runs graphs and returns.
-- **You want a real sandbox for untrusted code.** The Nix-pinned runtime is a reproducibility boundary, not an isolation boundary. If you need to execute code you didn't write, wrap the executor in bwrap/firejail/nsjail yourself — or wait until Noether ships opt-in isolation.
+- **You need a hardened sandbox for hostile, untrusted code on a shared host.** The v0.7 bwrap sandbox is Phase 1 — fresh namespaces, UID-mapped to nobody, cap-drop ALL, sandbox-private tmpfs `/work`. Enough for LLM-synthesized stages you haven't audited, not enough for genuinely hostile adversaries targeting a multi-tenant shared kernel. See [SECURITY.md](./SECURITY.md) for the threat model, and the [`stage-isolation`](./docs/roadmap/2026-04-18-stage-isolation.md) roadmap for Phase 2 (native namespaces + Landlock + seccomp, v0.8).
 - **You're scheduling 30 jobs a day across Airflow/Prefect/Dagster-style DAGs with UI ops + lineage + alerting.** Those tools are mature here and Noether has no UI.
 - **Your pipeline only runs once.** The content-addressing + verification overhead is there so the *second* run is free. If there is no second run, a plain script is simpler.
 - **Your inputs aren't JSON-typable.** Noether's type system is structural over JSON. Streaming video, arbitrary binary, live-network protocols — doable, but you'll fight the model.
@@ -66,7 +68,7 @@ Two binaries ship from this repo:
 | **GitHub Releases** | [Download prebuilt binaries](https://github.com/alpibrusl/noether/releases/latest) — Linux / macOS / Windows, both binaries packaged separately |
 | **Source** | `cargo build --release -p noether-cli -p noether-scheduler` |
 
-Nix is optional; it's required only to execute Python / JavaScript / Bash stages in a Nix-pinned runtime (reproducibility, not isolation). Rust-native stdlib stages run without it.
+Nix is optional; it's required only to execute Python / JavaScript / Bash stages in a Nix-pinned runtime. Rust-native stdlib stages run without it. `bubblewrap` (the v0.7 sandbox backend) is also optional — `--isolate=auto` falls back to unsandboxed with a warning when bwrap is absent; pass `--require-isolation` in CI to turn the fallback into a hard error.
 
 ---
 

--- a/crates/noether-cli/src/commands/agent_docs.rs
+++ b/crates/noether-cli/src/commands/agent_docs.rs
@@ -1,0 +1,202 @@
+//! `noether agent-docs` — emit playbooks as ACLI-shaped JSON so AI
+//! agents can query Noether documentation by intent keyword without
+//! parsing prose.
+//!
+//! Playbooks are compiled into the binary via `include_str!`, so the
+//! subcommand works offline and regardless of where the binary is
+//! installed. When an agent wants the latest content, they can
+//! always read `docs/agents/*.md` in a checked-out repo directly —
+//! this command exists to make in-process lookup deterministic.
+
+use crate::output::{acli_error, acli_ok};
+use serde_json::json;
+
+/// One playbook: a static (key, markdown body) pair. The markdown
+/// content is the authoritative source; the parser below extracts a
+/// title and intent blurb for the list/search endpoints.
+struct Playbook {
+    key: &'static str,
+    body: &'static str,
+}
+
+const PLAYBOOKS: &[Playbook] = &[
+    Playbook {
+        key: "compose-a-graph",
+        body: include_str!("../../../../docs/agents/compose-a-graph.md"),
+    },
+    Playbook {
+        key: "find-an-existing-stage",
+        body: include_str!("../../../../docs/agents/find-an-existing-stage.md"),
+    },
+    Playbook {
+        key: "synthesize-a-new-stage",
+        body: include_str!("../../../../docs/agents/synthesize-a-new-stage.md"),
+    },
+    Playbook {
+        key: "express-a-property",
+        body: include_str!("../../../../docs/agents/express-a-property.md"),
+    },
+    Playbook {
+        key: "debug-a-failed-graph",
+        body: include_str!("../../../../docs/agents/debug-a-failed-graph.md"),
+    },
+];
+
+/// Dispatch: `noether agent-docs` → list; `noether agent-docs <key>`
+/// → one playbook; `noether agent-docs --search <q>` → filtered list.
+pub fn cmd_agent_docs(key: Option<&str>, search: Option<&str>) {
+    if let Some(q) = search {
+        let lower = q.to_ascii_lowercase();
+        let hits: Vec<_> = PLAYBOOKS
+            .iter()
+            .filter(|p| p.body.to_ascii_lowercase().contains(&lower))
+            .map(playbook_summary)
+            .collect();
+        println!(
+            "{}",
+            acli_ok(json!({
+                "query": q,
+                "hits": hits,
+            }))
+        );
+        return;
+    }
+
+    match key {
+        None => {
+            // List available playbooks with a one-line intent.
+            let list: Vec<_> = PLAYBOOKS.iter().map(playbook_summary).collect();
+            println!(
+                "{}",
+                acli_ok(json!({
+                    "playbooks": list,
+                    "usage": "noether agent-docs <key>   # dump one playbook\n\
+                              noether agent-docs --search <term>   # search by keyword",
+                }))
+            );
+        }
+        Some(k) => match PLAYBOOKS.iter().find(|p| p.key == k) {
+            Some(p) => {
+                println!(
+                    "{}",
+                    acli_ok(json!({
+                        "key": p.key,
+                        "title": extract_title(p.body),
+                        "intent": extract_intent(p.body),
+                        "body": p.body,
+                    }))
+                );
+            }
+            None => {
+                let available: Vec<&str> = PLAYBOOKS.iter().map(|p| p.key).collect();
+                eprintln!(
+                    "{}",
+                    acli_error(&format!(
+                        "no playbook with key `{k}`. Available: {}",
+                        available.join(", ")
+                    ))
+                );
+                std::process::exit(2);
+            }
+        },
+    }
+}
+
+fn playbook_summary(p: &Playbook) -> serde_json::Value {
+    json!({
+        "key": p.key,
+        "title": extract_title(p.body),
+        "intent": extract_intent(p.body),
+    })
+}
+
+/// Pull the H1 from a playbook body (first `# ...` line). Falls back
+/// to the key if malformed.
+fn extract_title(body: &str) -> String {
+    body.lines()
+        .find_map(|l| l.strip_prefix("# ").map(|s| s.trim().to_string()))
+        .unwrap_or_default()
+}
+
+/// Pull the "Intent" section body — the first paragraph after the
+/// `## Intent` header. Playbooks follow a fixed shape so this parse
+/// is deterministic.
+fn extract_intent(body: &str) -> String {
+    let mut lines = body.lines();
+    // Find the "## Intent" header.
+    let mut found_header = false;
+    let mut buf = String::new();
+    for line in lines.by_ref() {
+        if !found_header {
+            if line.trim().eq_ignore_ascii_case("## intent") {
+                found_header = true;
+            }
+            continue;
+        }
+        // Everything until the next blank-separated header.
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") {
+            break;
+        }
+        if trimmed.is_empty() && !buf.is_empty() {
+            break;
+        }
+        if !trimmed.is_empty() {
+            if !buf.is_empty() {
+                buf.push(' ');
+            }
+            buf.push_str(trimmed);
+        }
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_playbook_has_title_and_intent() {
+        // Contract check for the playbook shape: each one must have
+        // an H1 and an "## Intent" section. Prevents accidental
+        // format drift that would silently produce empty summaries
+        // in the list/search output.
+        for p in PLAYBOOKS {
+            assert!(
+                !extract_title(p.body).is_empty(),
+                "playbook {} has no H1 title",
+                p.key
+            );
+            assert!(
+                !extract_intent(p.body).is_empty(),
+                "playbook {} has no '## Intent' section",
+                p.key
+            );
+        }
+    }
+
+    #[test]
+    fn playbook_keys_match_file_headers() {
+        // Defence against renaming a playbook file without updating
+        // the `key` field. The H1 is `# Playbook: <key>`.
+        for p in PLAYBOOKS {
+            let title = extract_title(p.body);
+            let expected = format!("Playbook: {}", p.key);
+            assert_eq!(
+                title, expected,
+                "playbook {} H1 should be `# {expected}`, got `# {title}`",
+                p.key
+            );
+        }
+    }
+
+    #[test]
+    fn extract_intent_handles_blank_lines() {
+        let body = "# t\n\n## Intent\n\nfirst line.\nsecond line.\n\n## Preconditions\n\nignored\n";
+        assert_eq!(
+            extract_intent(body),
+            "first line. second line.",
+            "intent paragraph should terminate at the blank line before the next ## header"
+        );
+    }
+}

--- a/crates/noether-cli/src/commands/mod.rs
+++ b/crates/noether-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_docs;
 pub mod build;
 pub mod build_browser;
 pub mod build_mobile;

--- a/crates/noether-cli/src/main.rs
+++ b/crates/noether-cli/src/main.rs
@@ -32,6 +32,19 @@ enum Commands {
     Introspect,
     /// Show version information
     Version,
+    /// AI-agent documentation. Emits playbooks from `docs/agents/`
+    /// as structured JSON so an agent can query by intent keyword
+    /// instead of parsing prose. Human-facing narrative lives in
+    /// docs/architecture.md — this subcommand is for the
+    /// machine-readable path.
+    AgentDocs {
+        /// Playbook key (e.g. `compose-a-graph`). When omitted,
+        /// lists available playbooks.
+        key: Option<String>,
+        /// Search by substring. Matches title + intent + body.
+        #[arg(long, short = 's')]
+        search: Option<String>,
+    },
     /// Stage management commands
     Stage {
         #[command(subcommand)]
@@ -520,6 +533,9 @@ fn main() {
                     "version": env!("CARGO_PKG_VERSION")
                 }))
             );
+        }
+        Commands::AgentDocs { key, search } => {
+            commands::agent_docs::cmd_agent_docs(key.as_deref(), search.as_deref());
         }
         Commands::Stage { command } => {
             let mut store = build_store(registry);

--- a/docs/agents/compose-a-graph.md
+++ b/docs/agents/compose-a-graph.md
@@ -1,0 +1,75 @@
+# Playbook: compose-a-graph
+
+## Intent
+
+Translate a natural-language problem description into a valid, type-checked, executable composition graph using the Composition Agent.
+
+## Preconditions
+
+- At least one LLM provider is configured via env. Noether auto-selects in this order: `VERTEX_AI_*` > `ANTHROPIC_API_KEY` > `OPENAI_API_KEY` > `MISTRAL_API_KEY`.
+- The stdlib is registered. `noether stage list` should return ≥70 stages. If empty, reload with `noether stage sync <dir>` (or wait for the first-run loader).
+- The semantic index has been built (happens automatically on first agent invocation).
+
+## Steps
+
+1. **Invoke the agent.** Agent searches the top-20 semantic candidates, builds a prompt, calls the LLM, parses the response as `CompositionGraph`, type-checks it, retries up to 3 times on failure.
+   ```bash
+   noether compose "extract the price from each line item and sum the total"
+   ```
+2. **Supply input.** Use `--input '<json>'` for structured input or pipe JSON on stdin.
+3. **Dry-run before executing.** `--dry-run` produces the graph + plan without running:
+   ```bash
+   noether compose --dry-run "<problem>" --input '{"text": "..."}'
+   ```
+4. **Pin model explicitly** when agent-to-agent consistency matters: `--model gemini-2.0-flash` / `--model claude-sonnet-4-6` / etc.
+5. **If synthesis happens**, the response includes `synthesized: [{ stage_id, language, attempts, is_new }]`. The new stage is registered in the store under your signing key and persists for future compositions.
+
+## Output shape
+
+ACLI envelope:
+
+```json
+{
+  "ok": true,
+  "command": "compose",
+  "result": {
+    "composition_id": "<sha256>",
+    "attempts": 1,
+    "from_cache": false,
+    "synthesized": [],
+    "graph": { "description": "...", "root": {"op": "Sequential", "stages": [...]}, "version": "0.1.0" },
+    "output": <stage output>,
+    "trace": { "duration_ms": 42, "stages": [...] },
+    "warnings": []
+  },
+  "meta": { "version": "0.7.1", "duration_ms": 42 }
+}
+```
+
+`composition_id` is computed on the **pre-resolution** graph (M1 identity contract). The same `problem` + same stdlib state produces the same id; changes to Active implementations do not perturb it.
+
+## Failure modes
+
+| Error code | Meaning | Remedy |
+| --- | --- | --- |
+| `composition failed: ...` (exit 2) | LLM couldn't produce a type-checkable graph in `max_retries` attempts (default 3) | Refine the problem statement; add `--verbose` to see the LLM transcripts |
+| `X capability violation(s)` (exit 2) | Composed graph needs a capability you didn't grant | Pass `--allow-capabilities network,fs-read,...` |
+| `X effect violation(s)` (exit 2) | Composed graph has an effect the policy forbids | Pass `--allow-effects network,llm,...` |
+| `composition exceeds cost budget` (exit 2) | `--budget-cents N` set and estimate exceeds it | Raise the budget or accept the cheaper composition |
+| `execution failed: ...` (exit 3) | Type-check passed, but runtime error | Read the trace; often a missing LLM key or a stage that panicked on real input |
+
+## Verification
+
+Minimal runnable probe that exercises the full path:
+
+```bash
+noether compose --dry-run "count the words in a sentence" --input '{"text": "hello world"}'
+```
+
+Expect `ok: true`, `graph.root.op` to be `Stage` or `Sequential`, and `type_check.input/output` to be consistent with the stage signature.
+
+## See also
+
+- [`find-an-existing-stage`](find-an-existing-stage.md) — if you want to bypass the LLM and assemble a graph manually.
+- [`synthesize-a-new-stage`](synthesize-a-new-stage.md) — what happens inside the agent when no existing stage fits.
+- [`debug-a-failed-graph`](debug-a-failed-graph.md) — how to interpret the common failure modes above.

--- a/docs/agents/debug-a-failed-graph.md
+++ b/docs/agents/debug-a-failed-graph.md
@@ -1,0 +1,115 @@
+# Playbook: debug-a-failed-graph
+
+## Intent
+
+Interpret a Noether CLI failure — exit code, stderr shape, ACLI envelope — and decide the remediation. Noether exits consistently: `0` = success, `1` = parse/IO/resolution error, `2` = policy / validation / capability / effect violation, `3` = runtime execution error. Every failure is a structured ACLI envelope, not free-form text.
+
+## Preconditions
+
+- Access to the stderr + stdout of the failing invocation.
+- Ability to re-run with `--dry-run` (plan without executing) and/or `--verbose` (show composition reasoning).
+- If a trace file exists (`~/.noether/traces/<composition_id>.json`), you can inspect it with `noether trace <id>`.
+
+## Steps — by exit code
+
+### Exit 1 — graph didn't reach the executor
+
+Common shapes:
+
+| ACLI `error.code` / message fragment | Cause | Remedy |
+| --- | --- | --- |
+| `invalid graph JSON` | Lagrange parser rejected the file | Check the `op` discriminator on every node; `CompositionNode` is tagged by `op` (serde `tag = "op"`) |
+| `stage reference: not found` | A stage id in the graph doesn't match any store entry | `noether stage list` to confirm; check tenant scoping if using a remote registry |
+| `stage reference: ambiguous prefix` | Shortened id matches >1 stage | Use ≥12 hex chars or the full 64-char id |
+| `pinning resolution: unknown signature` | `Stage { pinning: Signature, id: <sig> }` but no Active stage has that `signature_id` | List candidates with `noether stage list | jq '.result[] | .signature_id'`; activate a Draft with that signature |
+| `pinning resolution: multiple Active` | Store violates the ≤1-Active-per-signature invariant | Rare — only possible via direct SQL. Fix via `noether stage activate` on the intended one (auto-deprecates the others) |
+| `deprecation cycle detected at stage <id>` | Corrupt deprecation chain in the store | Repair the store: `UPDATE stages SET lifecycle = ...` or re-push clean data |
+| `deprecation chain exceeded 10 hops` | Chain is longer than the cap | Flatten in the store; run the resolver on a clean snapshot |
+
+### Exit 2 — validation / policy / budget rejected the graph
+
+All exit-2 failures happen before execution. Read the ACLI `error.message` field — the format is `"<N> violation(s):\n  <detail>"`.
+
+| Category | Common violations | Remedy |
+| --- | --- | --- |
+| Type check | `input type X is not subtype of declared Y at edge (A → B)` | Either fix the graph wiring (the output of A doesn't match B's input) or broaden the stage signature |
+| Capability | `stage X requires capability Network, not in allow list` | `--allow-capabilities network,fs-read,...` or drop the capability-requiring stage |
+| Effect | `composition emits Llm, not in --allow-effects` | Add to allow list or use a different stage |
+| Signature | `stage X has ed25519_signature but signer_public_key is not trusted` | Add the signer's pubkey to the trust store, or skip verification with `--no-verify-signatures` (not recommended) |
+| Cost budget | `composition exceeds cost budget: <est>¢ > <budget>¢` | Raise `--budget-cents` or compose a cheaper graph |
+| Stage validation | `too few examples`, `input type mismatch on example N`, `property[i] shadowed_known_kind` | See `synthesize-a-new-stage` and `express-a-property` playbooks |
+
+### Exit 3 — runtime failure
+
+Execution passed all pre-flight checks and the graph actually ran, but a stage returned an error.
+
+| Error code | Cause | Remedy |
+| --- | --- | --- |
+| `StageFailed: <id>: <stderr>` | User code raised an exception / exited non-zero | Read the stderr fragment; often a dependency missing (`# requires:` not installed), a malformed input the stage didn't anticipate, or an LLM API error |
+| `TimedOut: <id>: <secs>s` | Stage exceeded `NixConfig::timeout_secs` (default 30s) | Raise `NOETHER_STAGE_TIMEOUT_SECS`; profile the stage for O(n²) hotspots |
+| `StageNotFound: <id>` | No executor had an implementation — synthesized stages must be registered to Nix/Inline before dispatch | Check that `CompositeExecutor::register_synthesized` was called (happens automatically in `compose`); for direct `run`, verify the stage has `implementation_code` set |
+| `cost budget exceeded at runtime: spent N¢ of M¢` | Actual cost overran the budget mid-execution | Raise budget; audit which stage consumed it via `noether trace <id>` |
+| `pinning resolution: <e>` (rare at exit 3) | Deprecation chain changed between plan and execute | Re-run — the resolver is idempotent against a stable store |
+
+## Structured diagnosis with `noether trace`
+
+Every graph execution writes a trace to `~/.noether/traces/<composition_id>.json`:
+
+```bash
+noether trace <composition_id>
+```
+
+Output (abbreviated):
+
+```json
+{
+  "composition_id": "...",
+  "duration_ms": 142,
+  "stages": [
+    {
+      "stage_id": "...",
+      "name": "word_count",
+      "input": {"text": "hello world"},
+      "output": {"count": 2},
+      "duration_ms": 5,
+      "effects_observed": ["Pure"]
+    },
+    {
+      "stage_id": "...",
+      "name": "llm_classify",
+      "input": {...},
+      "error": {"kind": "StageFailed", "message": "API rate limit"},
+      "duration_ms": 1200
+    }
+  ]
+}
+```
+
+The trace is the ground truth — stderr is a summary.
+
+## Isolation-specific failures (v0.7+)
+
+If running with `--isolate=bwrap`:
+
+| Message | Cause | Remedy |
+| --- | --- | --- |
+| `bubblewrap (bwrap) not found on PATH` | Missing bwrap | Install `bubblewrap` (apt/brew/nix) |
+| `bwrap resolved via $PATH` (warning) | bwrap found outside trusted system paths | Install to `/usr/bin` or a system nix profile; indicates potential PATH-planting risk |
+| `nix is installed at /usr/bin/nix (outside /nix/store)` | Distro-packaged nix needs host libs the sandbox doesn't bind | Install via Determinate/upstream installer (places nix under /nix/store), or run with `--isolate=none` |
+| `refusing to run without isolation` | `--require-isolation` set and bwrap unavailable | Install bwrap; or drop the flag if CI-requirement doesn't apply |
+| Stage runs but can't resolve DNS with `network=true` effect | NSS config missing inside sandbox | Check `/etc/resolv.conf` / `/etc/hosts` / `/etc/nsswitch.conf` exist on host (they're `--ro-bind-try`d when network is declared) |
+
+## Verification — make a failure happen on purpose
+
+```bash
+# Type error the checker should catch:
+echo '{"description":"bad","version":"0.1.0",
+       "root":{"op":"Stage","id":"0000000000000000000000000000000000000000000000000000000000000000","pinning":{"kind":"both"}}}' > /tmp/bad.json
+noether run /tmp/bad.json   # expect exit 1 with stage-not-found
+```
+
+## See also
+
+- [`STABILITY.md`](../../STABILITY.md) — which error codes are part of the 1.x contract and which may be renamed.
+- [`SECURITY.md`](../../SECURITY.md) — isolation failure modes in more detail.
+- `crates/noether-engine/src/executor/mod.rs` — `ExecutionError` enum is the authoritative source for exit-3 variants.

--- a/docs/agents/express-a-property.md
+++ b/docs/agents/express-a-property.md
@@ -1,0 +1,118 @@
+# Playbook: express-a-property
+
+## Intent
+
+Attach one or more declarative property claims to a stage so its behaviour is verifiable beyond its type signature. A property is checked against every declared example at registration time and can be re-checked against runtime traces.
+
+## Preconditions
+
+- You're authoring or updating a stage spec. Properties live under the top-level `"properties": []` array.
+- You know which of the seven v0.7 property kinds matches your claim (see table below).
+
+## Steps
+
+1. **Pick the right kind** using the table:
+
+   | Kind | Checks | Example |
+   | --- | --- | --- |
+   | `set_member` | Field value ∈ a fixed set of JSON values | `{"kind":"set_member","field":"output.severity","set":["LOW","HIGH"]}` |
+   | `range` | Numeric field ∈ `[min, max]` (either optional) | `{"kind":"range","field":"output","min":0,"max":100}` |
+   | `field_length_eq` | Two fields have equal length (string UTF-8 codepoints / array / object keys) | `{"kind":"field_length_eq","left_field":"output","right_field":"input"}` |
+   | `field_length_max` | `subject_field` length ≤ `bound_field` length | `{"kind":"field_length_max","subject_field":"output","bound_field":"input.items"}` |
+   | `subset_of` | Elements/keys/substring of `subject_field` appear in `super_field` | `{"kind":"subset_of","subject_field":"output.keys","super_field":"input.keys"}` |
+   | `equals` | Two fields are JSON-value equal (identity, content preservation) | `{"kind":"equals","left_field":"output","right_field":"input"}` |
+   | `field_type_in` | Runtime JSON type at `field` is one of the allowed kinds | `{"kind":"field_type_in","field":"output.x","allowed":["number","null"]}` |
+
+2. **Write the path.** Properties navigate into either `input` or `output` — the first segment of `field` / `left_field` / `subject_field` / etc. must be exactly `input` or `output`, then dot-separated keys into the JSON value.
+
+3. **Use `field_type_in` allowed kinds from the exact six**: `null`, `bool`, `number`, `string`, `array`, `object`. Anything else deserialises as `Property::Unknown` and `noether stage add` rejects it with a `shadowed_known_kind` error pointing at the typo.
+
+4. **Validate at registration**:
+   ```bash
+   noether stage add spec.json          # ingest rejects unsatisfiable / typo'd properties
+   noether stage verify <id> --with-properties   # re-run properties against every example
+   ```
+
+5. **Re-check against runtime traces** (optional but encouraged in CI):
+   ```bash
+   noether trace <composition_id>       # get the trace
+   # Each stage invocation in the trace records (input, output); re-run properties against
+   # those pairs to catch behavioural drift from the example-only check.
+   ```
+
+## Output shape
+
+A property stored on a stage:
+
+```json
+{
+  "properties": [
+    {"kind": "range", "field": "output.soc_percent", "min": 0, "max": 100},
+    {"kind": "field_length_eq", "left_field": "output", "right_field": "input"}
+  ]
+}
+```
+
+Violation (on `stage verify`):
+
+```json
+{
+  "example_index": 2,
+  "violation": {
+    "kind": "out_of_range",
+    "path": "output.soc_percent",
+    "actual": 150.0,
+    "bounds": {"min": 0, "max": 100}
+  }
+}
+```
+
+## Failure modes
+
+| Symptom | Meaning | Remedy |
+| --- | --- | --- |
+| `property[i]: looks like a <kind> but failed to deserialise` | Typo inside a known kind's fields (most common: `allowed: ["bolean"]` on `field_type_in`) | Fix the typo — ingest correctly refuses to silently drop the check |
+| `BadPath: <path>` | Path doesn't start with `input`/`output`, or dot-navigation fails mid-way | Rewrite the path; test with a tiny synthetic example first |
+| `NotMeasurable` on length checks | Applied `field_length_eq`/`field_length_max` to a numeric/bool/null field | Length is only defined for string (codepoints), array (elements), object (keys). Use `equals` or `range` instead |
+| `NotNumber` on `range` | Field resolved to a non-numeric value in at least one example | Either fix the example or widen the property to cover `Any` via `field_type_in` + a follow-up check |
+| Property passes at ingest but violates at runtime | Examples were narrower than production traffic | Add more examples, or add runtime re-check via `noether trace` |
+
+## Length semantics — exact contract
+
+- **String**: UTF-8 **code-point** count (`str::chars().count()`), not bytes, not grapheme clusters. `"a̐"` → 2 codepoints; `"👨‍👩‍👧"` → 5 codepoints (3 emoji + 2 ZWJs).
+- **Array**: element count.
+- **Object**: key count.
+- **Number / bool / null**: not measurable; property fails with `NotMeasurable`.
+
+Cross-kind comparisons are mechanically defined (`field_length_eq { left: array, right: string }` compares element-count against codepoint-count) but almost never what an author means. Prefer paths of the same JSON kind.
+
+## SubsetOf — branch-by-kind semantics
+
+| Subject kind | Super kind | Semantics |
+| --- | --- | --- |
+| Array | Array | Every element of subject appears in super by JSON-value equality; duplicates allowed |
+| Object | Object | Every `(key, value)` of subject appears in super; key-presence alone is NOT enough |
+| String | String | **Substring** containment (contiguous), not a character-set subset. `"abc" ⊄ "bac"` even though all chars match |
+| Any mixed pair | | `NotCollectionForSubset` violation (blame the non-collection side) |
+
+## Verification
+
+Minimal probe — a stage whose property claim is intentionally violated at example 2, should fail ingest cleanly:
+
+```bash
+cat > /tmp/bad_prop.json <<'JSON'
+{"name":"clamp_soc","description":"clamp a battery SOC to [0,100]",
+ "input":"Number","output":"Number","effects":["Pure"],"language":"python",
+ "implementation":"def execute(x):\n    return x\n",
+ "examples":[{"input":0,"output":0},{"input":150,"output":150},
+             {"input":50,"output":50},{"input":100,"output":100},{"input":25,"output":25}],
+ "properties":[{"kind":"range","field":"output","min":0,"max":100}]}
+JSON
+noether stage add /tmp/bad_prop.json   # expect failure citing example 2
+```
+
+## See also
+
+- [`synthesize-a-new-stage`](synthesize-a-new-stage.md) — the spec context properties live inside.
+- `crates/noether-core/src/stage/property.rs` — authoritative source for variants, evaluator, and violations.
+- [`STABILITY.md`](../../STABILITY.md) — property set is additive in 1.x; existing kinds cannot be removed, but new kinds may appear in `Unknown` when read by an older binary.

--- a/docs/agents/find-an-existing-stage.md
+++ b/docs/agents/find-an-existing-stage.md
@@ -1,0 +1,79 @@
+# Playbook: find-an-existing-stage
+
+## Intent
+
+Find a stage already in the store that matches a given type signature or intent, instead of synthesizing a new one. Cheaper, more reproducible, and the provenance is clearer (signed by the stdlib key or a known tenant).
+
+## Preconditions
+
+- Local store populated (`noether stage list` returns ≥1 stage) — the stdlib alone gives ~70 general-purpose stages.
+- Semantic index built. It's constructed automatically on first search; you don't need to force it.
+
+## Steps
+
+1. **Semantic search** is the fastest path. Scored 0.3 signature + 0.5 description + 0.2 example via cosine similarity:
+   ```bash
+   noether stage search "sum a list of numbers"
+   ```
+   Top results come with `id`, `description`, `signature (input → output)`, `score`, `tags`. The 8-char `id` prefix is unique enough to paste into a graph.
+2. **Filter by tag** when you know the category (browse tags with `noether stage list --tags`):
+   ```bash
+   noether stage search "http request" --tag network
+   noether stage list --tag text
+   ```
+3. **Inspect a specific stage** once you have a candidate:
+   ```bash
+   noether stage get <id-or-prefix>
+   ```
+   Returns the full `Stage` struct: signature, effects, examples, properties, capabilities, cost estimate.
+4. **Verify behaviourally** when the stakes are high — run the stage's own declared examples through the executor:
+   ```bash
+   noether stage verify <id> --with-properties
+   ```
+5. **Use the stage in a graph** by dropping its id (full or 8-char prefix) into a `CompositionNode::Stage`. Default pinning is `Signature` (the resolver picks the currently-Active implementation at execution time), stable across bugfix rewrites.
+
+## Output shape
+
+`noether stage search` result:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "query": "sum a list of numbers",
+    "hits": [
+      {
+        "id": "a1b2c3d4...",
+        "signature_id": "...",
+        "description": "Sum all numeric elements in a list",
+        "signature": {"input": "List<Number>", "output": "Number", "effects": ["Pure"]},
+        "score": 0.87,
+        "tags": ["scalar", "list"],
+        "lifecycle": "Active"
+      }
+    ]
+  }
+}
+```
+
+## Failure modes
+
+| Symptom | Meaning | Remedy |
+| --- | --- | --- |
+| `no stages match` | Semantic index has results but all below threshold (0.5 default) | Broaden the query; drop the `--tag` filter; fall back to `noether compose` for synthesis |
+| `ambiguous prefix` | Multiple stages share the prefix | Use ≥12 hex chars or the full 64-char id |
+| `stage not found` on `get` | Id isn't in the local store | Check the tenant (`--registry` env); `stage list` to confirm; `sync` if you have a stages dir |
+| High-score match exists but signature mismatches your use | The description embedding matched an unrelated stage | Read `signature` carefully; a `Text → Text` match is not interchangeable with `Record { body: Text } → Text` |
+
+## Verification
+
+```bash
+# Expect ≥1 hit for a common stdlib intent.
+noether stage search "count words" | jq '.result.hits | length'
+```
+
+## See also
+
+- [`compose-a-graph`](compose-a-graph.md) — once you have your stages, combine them automatically with the agent.
+- [`synthesize-a-new-stage`](synthesize-a-new-stage.md) — when nothing in search is close enough.
+- `noether introspect` — the full command tree if you need flags this playbook didn't cover.

--- a/docs/agents/synthesize-a-new-stage.md
+++ b/docs/agents/synthesize-a-new-stage.md
@@ -1,0 +1,115 @@
+# Playbook: synthesize-a-new-stage
+
+## Intent
+
+Author a new stage from scratch — either (a) automatically via the Composition Agent during `noether compose`, or (b) by hand via `noether stage add <spec.json>`. The output is a content-addressed, signed, registered stage that future compositions can reference.
+
+## Preconditions
+
+- **Manual path**: a spec file matching `.cli/schemas/stage-spec.json`. Required: `name`, `implementation`. Recommended: `input`, `output`, `effects`, `examples` (≥5), `tags`, `aliases`, `properties`.
+- **Agent path**: an LLM configured, and the composition agent determined no existing stage fits (via `noether compose`).
+- A local signing key. Auto-generated on first `stage add`; persists at `~/.noether/signing_key`.
+
+## Steps — manual path
+
+1. **Author the spec** (simple form recommended for authoring; `full` form is for importing pre-signed stages):
+   ```json
+   {
+     "name": "price_sum",
+     "description": "Sum a list of numeric prices",
+     "input": {"List": "Number"},
+     "output": "Number",
+     "effects": ["Pure"],
+     "language": "python",
+     "implementation": "def execute(prices):\n    return sum(prices)\n",
+     "examples": [
+       {"input": [], "output": 0},
+       {"input": [1.5], "output": 1.5},
+       {"input": [1, 2, 3], "output": 6},
+       {"input": [0.1, 0.2], "output": 0.3},
+       {"input": [99.99, 0.01], "output": 100.0}
+     ],
+     "tags": ["scalar", "math"],
+     "properties": [
+       {"kind": "range", "field": "output", "min": 0}
+     ]
+   }
+   ```
+2. **Register**:
+   ```bash
+   noether stage add spec.json
+   ```
+   The CLI computes the content hash, signs the id with your key, validates examples against the declared signature, rejects typo'd property kinds (`Property::shadowed_known_kind`), and stores under the local tenant.
+3. **Verify**:
+   ```bash
+   noether stage verify <id> --with-properties
+   ```
+   Runs every declared example through the executor and checks each property claim. Fails loudly if any example mismatches or a property is violated.
+4. **Promote to Active** if it was registered as Draft:
+   ```bash
+   noether stage activate <id>
+   ```
+   Store enforces ≤1 Active per `signature_id` and auto-deprecates any previous Active with the same signature.
+
+## Steps — agent path (inside `noether compose`)
+
+The Composition Agent synthesizes when semantic search returns no satisfying stage. The agent:
+
+1. Asks the LLM for a spec (name, input, output, description, implementation, examples, effects inferred).
+2. Builds via `StageBuilder::build_signed` with an ephemeral session key.
+3. Checks `index.check_duplicate_before_insert` (cosine ≥0.92) to avoid duplicating a near-identical stage; reuses if found signed.
+4. Inserts + promotes to Active (auto-deprecates any colliding Active).
+5. Returns `SynthesisResult { stage_id, implementation, language, effects, attempts, is_new }`.
+6. Composition is retried with the new stage available in the store.
+
+Nothing in the agent path is interactive; the agent is the only caller. To inspect what got synthesized, re-run `compose --verbose`.
+
+## Output shape
+
+`noether stage add`:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "id": "<64-hex-sha256>",
+    "signature_id": "<64-hex-sha256>",
+    "lifecycle": "Draft",
+    "validation": {"passed": true, "errors": [], "warnings": []}
+  }
+}
+```
+
+## Failure modes
+
+| Error | Meaning | Remedy |
+| --- | --- | --- |
+| `too few examples: need at least N, got M` | Spec had <5 examples for a stdlib-signed stage | Add more `examples[]` entries covering edge cases |
+| `input type mismatch on example N` | Example input doesn't satisfy declared `input` type | Fix the example or widen the declared type |
+| `output type mismatch on example N` | Example output doesn't satisfy declared `output` type | Fix the output or widen the type |
+| `property[i]: looks like a \`<kind>\` but failed to deserialise` | Typo'd property kind (e.g. `allowed: ["bolean"]`) | Fix the property — ingest rejects typo'd `Unknown` that shadows a known kind |
+| `content hash mismatch` | `id` in spec doesn't match `sha256(signature)` | Either use the simple form (id computed by CLI) or recompute the id |
+| `AlreadyExists` → auto-deprecate | Another Active stage has the same `signature_id` | Expected; the old one is now Deprecated with this stage as successor |
+
+## Verification
+
+Minimal end-to-end registration check:
+
+```bash
+# Create a tiny spec, register, verify — all local, no network.
+cat > /tmp/probe.json <<'JSON'
+{"name":"probe_identity","description":"echo input unchanged",
+ "input":"Any","output":"Any","effects":["Pure"],"language":"python",
+ "implementation":"def execute(x):\n    return x\n",
+ "examples":[{"input":1,"output":1},{"input":"a","output":"a"},
+             {"input":[1,2],"output":[1,2]},{"input":{"a":1},"output":{"a":1}},
+             {"input":null,"output":null}]}
+JSON
+noether stage add /tmp/probe.json | jq '.result.id'
+```
+
+## See also
+
+- [`find-an-existing-stage`](find-an-existing-stage.md) — always check before synthesizing; duplicate effort wastes the content-addressing story.
+- [`express-a-property`](express-a-property.md) — make the stage's claims verifiable, not just a description string.
+- `crates/noether-core/src/stage/builder.rs` — `StageBuilder` is the canonical in-Rust construction path (`build_stdlib` / `build_signed` / `build_unsigned`).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,9 @@
 # Architecture Overview
 
+> **Reading this as an AI agent or tooling?** [`AGENTS.md`](../../AGENTS.md) at the repo root is your entry point — denser, keyed by intent, with runnable verification on every fragment. `noether agent-docs` emits the same content as structured JSON.
+>
+> **Docs philosophy.** Noether's primary readers are AI agents, not humans — agents pay per token and want schema + error codes + "verify with this one-liner," not motivation or analogies. Rather than compromise both audiences with one doc set, Noether maintains two: this overview + [`SECURITY.md`](../../SECURITY.md) + [`STABILITY.md`](../../STABILITY.md) + [Getting started](../getting-started/index.md) for humans; `AGENTS.md` + [`docs/agents/`](../agents/) playbooks for agents. The playbooks are authoritative for API reference; the human docs link into them for depth.
+
 Noether has four layers. Each layer depends only on the one below it.
 
 ```mermaid
@@ -16,12 +20,15 @@ graph TB
 
 Stages run inside Nix-managed environments. Each stage declares its language runtime (Python 3.11, Node 20, Bash) and Nix provides a runtime with the exact dependencies pinned to the Nix store hash.
 
-This is a **reproducibility boundary, not an isolation boundary**: the subprocess inherits the host user's privileges, filesystem access, and network. Stages can `os.system(...)`, read `~/.ssh/id_ed25519`, and make arbitrary HTTP calls. Don't execute stages you did not write unless you have independent isolation (bwrap, firejail, nsjail, a container, a throwaway VM).
+Nix is the **reproducibility boundary**. From v0.7 the separate **isolation boundary** lives in a companion layer: the `noether-isolation` crate + bubblewrap (Phase 1) or native namespaces + Landlock + seccomp (Phase 2, v0.8). `noether run --isolate=auto` (the default from v0.7) wraps every stage subprocess in bwrap when available: UID mapped to `nobody`, fresh namespaces, `/work` sandbox-private tmpfs, `--cap-drop ALL`, new session, env cleared to a short allowlist, network namespace unshared unless the stage declares `Effect::Network`. See [`SECURITY.md`](../../SECURITY.md) for the full threat model and [`docs/roadmap/2026-04-18-stage-isolation.md`](../roadmap/2026-04-18-stage-isolation.md) for the Phase-2 plan.
 
-What you do get:
+What you get from L1 when isolation is on:
 - The same `StageId` produces the same output on any machine that has Nix.
 - No "works on my machine" — dependencies are content-addressed.
-- No ambient environment leaks — stages cannot access the host filesystem or network unless their `effects` declare it.
+- No ambient environment leaks — stages see only `/nix/store`, the noether cache dir, a tmpfs `/work`, and whatever their declared effects open up.
+- When `Effect::Network` is declared, the sandbox binds `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, `/etc/ssl/certs` (via `--ro-bind-try` so NixOS hosts that manage DNS differently don't break) so DNS + TLS actually work.
+
+Caveat: the sandbox requires `nix` installed under `/nix/store` (upstream or Determinate installer). A distro-packaged `/usr/bin/nix` is dynamically linked against host libraries that aren't bound, so the executor refuses to run under isolation in that configuration with a clear message pointing at the upstream installer.
 
 ## L2 — Stage Store
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,6 +2,8 @@
 
 From zero to a running composition in under five minutes.
 
+> **AI agents**: skip this page and read [`AGENTS.md`](../../AGENTS.md) + the [intent-keyed playbooks](../agents/) instead. Or query by intent: `noether agent-docs --search "<your question>"`. This page is narrative; the playbooks are dense, runnable fragments.
+
 ## Install
 
 === "crates.io"
@@ -44,6 +46,14 @@ From zero to a running composition in under five minutes.
 
 **Nix is optional.** You need it only to execute Python / JavaScript / Bash
 stages in a hermetic sandbox. Rust-native stdlib stages run without it.
+
+**bubblewrap is optional but recommended** (v0.7+). When present, `noether run`
+wraps every stage subprocess in a sandbox — fresh namespaces, UID mapped to
+`nobody`, `/work` tmpfs, `--cap-drop ALL`. `--isolate=auto` (the default)
+falls back to unsandboxed with a warning if bwrap is missing. In CI pass
+`--require-isolation` (or `NOETHER_REQUIRE_ISOLATION=1`) to make the
+fallback a hard error. Install with `apt install bubblewrap` /
+`brew install bubblewrap` / nix.
 
 ## Point at the public registry
 


### PR DESCRIPTION
AI agents will be the primary readers of Noether's docs. This PR lands the agent-facing shape first; human-facing quickstart + architecture doc follow in a separate PR.

Delivers:
- `AGENTS.md` at repo root (~1500 tokens, dense map + index).
- 5 intent-keyed playbooks under `docs/agents/` with fixed shape (Intent / Preconditions / Steps / Output shape / Failure modes / Verification / See also).
- `noether agent-docs` CLI subcommand — lists / dumps / searches playbooks as ACLI JSON. Playbooks compiled via `include_str!`; contract test enforces H1 key consistency.

See the commit message for full rationale on why agent-facing docs have a different shape than a traditional mdBook. Human-facing docs land next.

## Test plan

- [x] `cargo test --workspace` — 3 new parser contract tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke: `noether agent-docs` lists 5 playbooks; `--search` narrows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)