### PR TITLE
fix: propagate compute_composition_id errors instead of "unknown" fallback

### DIFF
--- a/crates/noether-cli/src/commands/build.rs
+++ b/crates/noether-cli/src/commands/build.rs
@@ -524,7 +524,19 @@ fn bootstrap() -> (
     }
 
     let graph = parse_graph(GRAPH_JSON).expect("embedded graph is invalid");
-    let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "embedded".into());
+    // The graph is baked in at `noether build` time — a hash
+    // failure here means the build step produced a broken binary.
+    // Panicking with a clear message beats silently shipping a
+    // stringly-typed "embedded" placeholder that would collide in
+    // any post-build correlation log. This path only runs once, at
+    // the generated binary's startup.
+    let composition_id = compute_composition_id(&graph).unwrap_or_else(|e| {
+        panic!(
+            "embedded composition graph failed to hash: {e}. \
+             The binary produced by `noether build` is malformed — \
+             rebuild from a current noether release."
+        )
+    });
 
     let (llm, _) = providers::build_llm_provider();
     let executor = Arc::new(

--- a/crates/noether-cli/src/commands/build.rs
+++ b/crates/noether-cli/src/commands/build.rs
@@ -526,17 +526,24 @@ fn bootstrap() -> (
     let graph = parse_graph(GRAPH_JSON).expect("embedded graph is invalid");
     // The graph is baked in at `noether build` time — a hash
     // failure here means the build step produced a broken binary.
-    // Panicking with a clear message beats silently shipping a
-    // stringly-typed "embedded" placeholder that would collide in
-    // any post-build correlation log. This path only runs once, at
-    // the generated binary's startup.
-    let composition_id = compute_composition_id(&graph).unwrap_or_else(|e| {
-        panic!(
-            "embedded composition graph failed to hash: {e}. \
-             The binary produced by `noether build` is malformed — \
-             rebuild from a current noether release."
-        )
-    });
+    // Matches run.rs's shape (clean stderr + exit 1) rather than a
+    // panic with a backtrace — easier for operators to read, and
+    // still hard-fails the bogus binary loudly. Silently shipping a
+    // stringly-typed "embedded" placeholder would collide in any
+    // post-build correlation log.
+    let composition_id = match compute_composition_id(&graph) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!(
+                "{}",
+                acli_error(&format!(
+                    "failed to hash composition graph: {e} — the binary produced by \
+                     `noether build` is malformed; rebuild from a current noether release."
+                ))
+            );
+            std::process::exit(1);
+        }
+    };
 
     let (llm, _) = providers::build_llm_provider();
     let executor = Arc::new(

--- a/crates/noether-cli/src/commands/run.rs
+++ b/crates/noether-cli/src/commands/run.rs
@@ -6,11 +6,38 @@ use noether_engine::checker::{
 };
 use noether_engine::executor::budget::{build_cost_map, BudgetedExecutor};
 use noether_engine::executor::runner::run_composition;
-use noether_engine::lagrange::{compute_composition_id, parse_graph, resolve_stage_prefixes};
+use noether_engine::lagrange::{
+    compute_composition_id, parse_graph, resolve_stage_prefixes, CompositionGraph,
+};
 use noether_engine::planner::plan_graph;
 use noether_engine::trace::JsonFileTraceStore;
 use noether_store::StageStore;
 use serde_json::json;
+
+/// Hash the graph or return a ready-made ACLI error line.
+///
+/// Extracted so the error path (contract: stderr message starts
+/// with the ACLI error prefix, contains "failed to hash composition
+/// graph", and does NOT contain the pre-fix "unknown" placeholder)
+/// can be exercised by a unit test without fabricating a
+/// serde_jcs-hostile `serde_json::Value` — the test injects a
+/// closure that returns `Err` directly.
+///
+/// The caller is responsible for `eprintln!` + `exit(1)`.
+fn compute_composition_id_or_error_line<H>(
+    graph: &CompositionGraph,
+    hasher: H,
+) -> Result<String, String>
+where
+    H: FnOnce(&CompositionGraph) -> Result<String, serde_json::Error>,
+{
+    match hasher(graph) {
+        Ok(id) => Ok(id),
+        Err(e) => Err(acli_error(&format!(
+            "failed to hash composition graph: {e}"
+        ))),
+    }
+}
 
 /// Pre-flight policies for a single `noether run` invocation.
 pub struct RunPolicies<'a> {
@@ -64,13 +91,11 @@ pub fn cmd_run(
     // "unknown" — a silent stringly-typed fallback in the ACLI
     // envelope would rob the caller of any breadcrumb to the cause.
     // Matches the post-#32 compose.rs shape.
-    let composition_id = match compute_composition_id(&graph) {
+    let composition_id = match compute_composition_id_or_error_line(&graph, compute_composition_id)
+    {
         Ok(id) => id,
-        Err(e) => {
-            eprintln!(
-                "{}",
-                acli_error(&format!("failed to hash composition graph: {e}"))
-            );
+        Err(line) => {
+            eprintln!("{line}");
             std::process::exit(1);
         }
     };
@@ -262,5 +287,68 @@ pub fn cmd_run(
             eprintln!("{}", acli_error(&format!("execution failed: {e}")));
             std::process::exit(3);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noether_core::stage::StageId;
+    use noether_engine::lagrange::{CompositionNode, Pinning};
+
+    fn dummy_graph() -> CompositionGraph {
+        CompositionGraph::new(
+            "t",
+            CompositionNode::Stage {
+                id: StageId("abc".into()),
+                pinning: Pinning::Signature,
+                config: None,
+            },
+        )
+    }
+
+    // Contract: on hash failure, the CLI surfaces a single ACLI
+    // error line mentioning "failed to hash composition graph" and
+    // never the pre-fix literal "unknown". The caller then
+    // `exit(1)`s; this helper's return value is the full line
+    // operators will see on stderr. See PR #40 review for why
+    // "mock compute_composition_id to return Err" is the chosen
+    // test strategy (serde_jcs-hostile `serde_json::Value`s can't
+    // be constructed through `Number::from_f64`).
+    #[test]
+    fn hash_failure_produces_acli_error_line() {
+        let graph = dummy_graph();
+        let failing_hasher =
+            |_: &CompositionGraph| Err(serde_json::from_str::<()>("not json").unwrap_err());
+
+        let outcome = compute_composition_id_or_error_line(&graph, failing_hasher);
+        let line = outcome.expect_err("hash should have failed");
+
+        assert!(
+            line.contains("failed to hash composition graph"),
+            "line should identify the failure: {line}"
+        );
+        assert!(
+            !line.contains("unknown"),
+            "line should not stringly-type to 'unknown': {line}"
+        );
+        // ACLI error envelope contract: ok=false + error field.
+        assert!(
+            line.contains("\"ok\":false") || line.contains("\"ok\": false"),
+            "expected ACLI error envelope shape: {line}"
+        );
+        assert!(
+            line.contains("\"error\""),
+            "expected ACLI error field: {line}"
+        );
+    }
+
+    #[test]
+    fn hash_success_returns_non_empty_non_unknown_id() {
+        let graph = dummy_graph();
+        let outcome = compute_composition_id_or_error_line(&graph, compute_composition_id);
+        let id = outcome.expect("real hasher should succeed on a trivial graph");
+        assert!(!id.is_empty());
+        assert_ne!(id, "unknown");
     }
 }

--- a/crates/noether-cli/src/commands/run.rs
+++ b/crates/noether-cli/src/commands/run.rs
@@ -60,7 +60,20 @@ pub fn cmd_run(
     // Trace correlation against specific implementations uses `execution_id`
     // on the trace record (computed after resolution, not yet wired — see
     // #28 follow-up).
-    let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+    // Propagate hash failures loudly rather than falling back to
+    // "unknown" — a silent stringly-typed fallback in the ACLI
+    // envelope would rob the caller of any breadcrumb to the cause.
+    // Matches the post-#32 compose.rs shape.
+    let composition_id = match compute_composition_id(&graph) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!(
+                "{}",
+                acli_error(&format!("failed to hash composition graph: {e}"))
+            );
+            std::process::exit(1);
+        }
+    };
 
     // 1a. Resolve stage ID prefixes against the store. Hand-authored graphs
     //     can use the 8-char prefixes that `noether stage list` prints; the

--- a/crates/noether-grid-broker/src/routes.rs
+++ b/crates/noether-grid-broker/src/routes.rs
@@ -430,7 +430,7 @@ async fn dispatch(
                 tracing::error!(
                     job_id = %job_id.0,
                     error = %e,
-                    "failed to hash rewritten graph for composition_id"
+                    "failed to hash composition graph (rewritten)"
                 );
                 let mut jobs = state.jobs.lock().await;
                 if let Some(j) = jobs.get_mut(&job_id) {
@@ -441,10 +441,11 @@ async fn dispatch(
                         output: serde_json::Value::Null,
                         spent_cents: 0,
                         composition_id: None,
-                        error: Some(format!("failed to hash graph: {e}")),
+                        error: Some(format!("failed to hash composition graph: {e}")),
                         completed_at: Utc::now(),
                     });
                 }
+                drop(jobs);
                 return;
             }
         };

--- a/crates/noether-grid-broker/src/routes.rs
+++ b/crates/noether-grid-broker/src/routes.rs
@@ -415,8 +415,39 @@ async fn dispatch(
             graph.description.clone(),
             split.rewritten,
         );
-        let composition_id =
-            compute_composition_id(&rewritten).unwrap_or_else(|_| "unknown".into());
+        // The rewritten graph was already parsed, type-checked, and
+        // split successfully; a hash failure here is an internal
+        // anomaly (e.g. serde_jcs choking on some edge case). Log
+        // loudly and surface to the job record so operators can
+        // distinguish "hash failed" from "stage failed." Failing a
+        // single in-flight job is preferable to crashing the broker,
+        // and dropping a stringly-typed "unknown" into the envelope
+        // would collide with other unrelated hash failures in
+        // trace-correlation logs.
+        let composition_id = match compute_composition_id(&rewritten) {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::error!(
+                    job_id = %job_id.0,
+                    error = %e,
+                    "failed to hash rewritten graph for composition_id"
+                );
+                let mut jobs = state.jobs.lock().await;
+                if let Some(j) = jobs.get_mut(&job_id) {
+                    j.status = JobStatus::Failed;
+                    j.result = Some(JobResult {
+                        job_id: job_id.clone(),
+                        status: JobStatus::Failed,
+                        output: serde_json::Value::Null,
+                        spent_cents: 0,
+                        composition_id: None,
+                        error: Some(format!("failed to hash graph: {e}")),
+                        completed_at: Utc::now(),
+                    });
+                }
+                return;
+            }
+        };
         let input = spec.input.clone();
         let exec_store = stages_snapshot;
         let comp_id = composition_id.clone();

--- a/crates/noether-grid-worker/src/main.rs
+++ b/crates/noether-grid-worker/src/main.rs
@@ -7,9 +7,10 @@
 use axum::{extract::State, http::StatusCode, routing, Json, Router};
 use chrono::Utc;
 use clap::Parser;
+use noether_engine::lagrange::CompositionGraph;
 use noether_grid_protocol::{
-    AuthVia, ExecuteRequest, Heartbeat, JobResult, JobStatus, LlmCapability, WorkerAdvertisement,
-    WorkerId,
+    AuthVia, ExecuteRequest, Heartbeat, JobId, JobResult, JobStatus, LlmCapability,
+    WorkerAdvertisement, WorkerId,
 };
 use noether_store::{JsonFileStore, StageStore};
 use serde_json::json;
@@ -456,6 +457,48 @@ async fn execute_single_stage(
     }
 }
 
+/// Hash the pre-resolution graph or return a ready-made failure
+/// `JobResult` describing why we couldn't hash it.
+///
+/// Extracted from [`run_graph`] so the error path (contract:
+/// `status == Failed` + `composition_id == None` + non-empty
+/// `error`) can be exercised by a unit test without fabricating a
+/// serde_jcs-hostile `serde_json::Value` — the test injects a
+/// closure that returns `Err` directly.
+///
+/// The contract this helper encodes:
+/// - `Ok(id)` on successful hash — never the literal `"unknown"`.
+/// - `Err(JobResult)` on hash failure, with `composition_id: None`
+///   (so broker correlation can distinguish "unhashable" from any
+///   real composition id) and a structured error message.
+//
+// `result_large_err` fires because `JobResult` is chunky (Value +
+// timestamps + JobId); boxing it here would obscure the helper's
+// intent for essentially zero runtime payoff — the failure path
+// only fires on serde_jcs anomalies, which are exceptional.
+#[allow(clippy::result_large_err)]
+fn hash_or_build_failure<H>(
+    graph: &CompositionGraph,
+    job_id: &JobId,
+    hasher: H,
+) -> Result<String, JobResult>
+where
+    H: FnOnce(&CompositionGraph) -> Result<String, serde_json::Error>,
+{
+    match hasher(graph) {
+        Ok(id) => Ok(id),
+        Err(e) => Err(JobResult {
+            job_id: job_id.clone(),
+            status: JobStatus::Failed,
+            output: serde_json::Value::Null,
+            spent_cents: 0,
+            composition_id: None,
+            error: Some(format!("failed to hash composition graph: {e}")),
+            completed_at: Utc::now(),
+        }),
+    }
+}
+
 async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
     use noether_engine::executor::composite::CompositeExecutor;
     use noether_engine::executor::runner::run_composition;
@@ -486,26 +529,14 @@ async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
     // including failures surfaced by the resolver itself. A broker
     // correlating runs across workers sees the same id for the same
     // source graph regardless of which (possibly now-deprecated)
-    // implementation it resolved to on any given run.
-    // Hash the pre-resolution graph. On failure the job can't be
-    // correlated — returning a Failed result with composition_id=None
-    // tells the broker "we got a graph we couldn't hash" rather than
-    // silently attributing the failure to a stringly-typed
-    // "unknown" correlation id that would collide with other
-    // unrelated hash failures.
-    let composition_id = match compute_composition_id(&graph) {
+    // implementation it resolved to on any given run. The one
+    // exception is `hash_or_build_failure` returning `Err` below,
+    // where no id can be produced — we record `composition_id:
+    // None` rather than shipping a stringly-typed "unknown" that
+    // would collide with other unrelated hash failures.
+    let composition_id = match hash_or_build_failure(&graph, &req.job_id, compute_composition_id) {
         Ok(id) => id,
-        Err(e) => {
-            return JobResult {
-                job_id: req.job_id,
-                status: JobStatus::Failed,
-                output: serde_json::Value::Null,
-                spent_cents: 0,
-                composition_id: None,
-                error: Some(format!("failed to hash graph: {e}")),
-                completed_at: Utc::now(),
-            };
-        }
+        Err(result) => return result,
     };
     if let Err(e) = resolve_pinning(&mut graph.root, store) {
         return JobResult {
@@ -557,5 +588,67 @@ async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
             error: Some(format!("task panicked: {e}")),
             completed_at: Utc::now(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noether_core::stage::StageId;
+    use noether_engine::lagrange::{compute_composition_id, CompositionNode, Pinning};
+
+    fn dummy_graph() -> CompositionGraph {
+        CompositionGraph::new(
+            "test",
+            CompositionNode::Stage {
+                id: StageId("abc".into()),
+                pinning: Pinning::Signature,
+                config: None,
+            },
+        )
+    }
+
+    // serde_jcs rejects very little that serde_json's own `Value`
+    // can represent (non-finite floats are already rejected at
+    // `Value` construction time, so they never reach the
+    // canonicaliser). Injecting a hasher that returns `Err` is the
+    // contract-level way to exercise the failure path — the
+    // reviewer on PR #40 explicitly listed "mock
+    // compute_composition_id to return Err" as acceptable.
+    #[test]
+    fn hash_failure_yields_failed_jobresult_with_no_composition_id() {
+        let graph = dummy_graph();
+        let job_id = JobId("job-1".into());
+        let failing_hasher =
+            |_: &CompositionGraph| Err(serde_json::from_str::<()>("not json").unwrap_err());
+
+        let outcome = hash_or_build_failure(&graph, &job_id, failing_hasher);
+        let failure = outcome.expect_err("hash should have failed");
+
+        assert_eq!(failure.status, JobStatus::Failed);
+        assert_eq!(failure.composition_id, None);
+        assert_eq!(failure.output, serde_json::Value::Null);
+        assert_eq!(failure.spent_cents, 0);
+        assert_eq!(failure.job_id.0, "job-1");
+        let err = failure.error.as_deref().expect("error must be populated");
+        assert!(
+            err.contains("failed to hash composition graph"),
+            "error message should identify the failure: {err}"
+        );
+        // Guard against the pre-fix behaviour sneaking back in.
+        assert!(
+            !err.contains("unknown"),
+            "error should not stringly-type to 'unknown': {err}"
+        );
+    }
+
+    #[test]
+    fn successful_hash_returns_composition_id() {
+        let graph = dummy_graph();
+        let job_id = JobId("job-2".into());
+        let outcome = hash_or_build_failure(&graph, &job_id, compute_composition_id);
+        let id = outcome.expect("real hasher should succeed on a trivial graph");
+        assert!(!id.is_empty());
+        assert_ne!(id, "unknown");
     }
 }

--- a/crates/noether-grid-worker/src/main.rs
+++ b/crates/noether-grid-worker/src/main.rs
@@ -487,7 +487,26 @@ async fn run_graph(store: &JsonFileStore, req: ExecuteRequest) -> JobResult {
     // correlating runs across workers sees the same id for the same
     // source graph regardless of which (possibly now-deprecated)
     // implementation it resolved to on any given run.
-    let composition_id = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+    // Hash the pre-resolution graph. On failure the job can't be
+    // correlated — returning a Failed result with composition_id=None
+    // tells the broker "we got a graph we couldn't hash" rather than
+    // silently attributing the failure to a stringly-typed
+    // "unknown" correlation id that would collide with other
+    // unrelated hash failures.
+    let composition_id = match compute_composition_id(&graph) {
+        Ok(id) => id,
+        Err(e) => {
+            return JobResult {
+                job_id: req.job_id,
+                status: JobStatus::Failed,
+                output: serde_json::Value::Null,
+                spent_cents: 0,
+                composition_id: None,
+                error: Some(format!("failed to hash graph: {e}")),
+                completed_at: Utc::now(),
+            };
+        }
+    };
     if let Err(e) = resolve_pinning(&mut graph.root, store) {
         return JobResult {
             job_id: req.job_id,

--- a/crates/noether-scheduler/src/main.rs
+++ b/crates/noether-scheduler/src/main.rs
@@ -248,8 +248,20 @@ async fn run_job(job: &ScheduledJob, config: &SchedulerConfig) {
 
         let inline = InlineExecutor::from_store(store.as_ref());
         // composition_id from the pre-resolution graph — stable across
-        // store changes, per #28.
-        let cid = compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into());
+        // store changes, per #28. Hash failures skip the job and log
+        // loudly: a stringly-typed "unknown" fallback would collide
+        // across unrelated failures in the webhook payload and the
+        // cron log, making operator triage harder.
+        let cid = match compute_composition_id(&graph) {
+            Ok(id) => id,
+            Err(e) => {
+                error!(
+                    "Job {} — failed to hash composition graph; skipping: {e}",
+                    job.name
+                );
+                return;
+            }
+        };
         // Resolve pinning against the store snapshot. Signature-pinned
         // refs rewrite to concrete implementation IDs; without this the
         // run would fail inside the executor's store.get() call.


### PR DESCRIPTION
Closes the tech-debt follow-up noted in the v0.7.0 CHANGELOG. The `compute_composition_id(&graph).unwrap_or_else(|_| "unknown".into())` pattern silently stringly-typed hash failures into a shared "unknown" correlation id across run.rs, grid-worker, scheduler, grid-broker, and (as "embedded") build.rs. This PR replaces each with a surface-appropriate loud failure — CLI exits 1, grid-worker returns Failed, scheduler skips+logs, broker fails the job entry, build.rs panics. Details in the commit message.

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)