### PR TITLE
docs: mkdocs audit + 3 new human tutorial pages

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,0 +1,78 @@
+# For AI Agents — the philosophy
+
+These docs are **not** the first thing a human should read. They're the first thing an **AI agent** should read — dense, keyed by intent, machine-readable. Humans browsing the site see them listed so the format is visible; humans doing real work should start at [Home](../index.md) or [Getting Started](../getting-started/index.md) instead.
+
+## Why two doc sets?
+
+Noether's primary readers are AI agents, not humans. Agents pay per token, read linearly only when they have to, and want "verify with this one-liner" more than they want analogies or motivation. Serving narrative-shaped documentation to a token-constrained agent wastes their context budget; serving schema + error codes + runnable probes to a human makes the project look unapproachable.
+
+Rather than compromise both audiences with one doc set, Noether maintains two:
+
+- **Human-facing**: [`README.md`](https://github.com/alpibrusl/noether/blob/main/README.md), these MkDocs pages (`architecture/`, `getting-started/`, `guides/`, `tutorial/`), `SECURITY.md`, `STABILITY.md`. Narrative, worked examples, diagrams.
+- **Agent-facing**: [`AGENTS.md`](https://github.com/alpibrusl/noether/blob/main/AGENTS.md) at the repo root + the playbook fragments in this directory + the `noether agent-docs` CLI subcommand. Dense, keyed by intent, every fragment has a runnable verification step.
+
+The agent docs are the **authoritative reference** for the API surface they cover; human docs link into them for depth. Only one place to maintain a signature, an error code, a failure-mode table — drift is minimized.
+
+## Playbook shape
+
+Every playbook in `docs/agents/` follows a fixed skeleton so an agent knows exactly what each section contains:
+
+```
+# Playbook: <key>
+
+## Intent
+One sentence. What this playbook enables.
+
+## Preconditions
+Bullet list. Environment state required before the steps work.
+
+## Steps
+Numbered. Each step includes the exact CLI invocation or API call.
+
+## Output shape
+JSON schema fragment. What the agent should expect back.
+
+## Failure modes
+Table: error code → cause → remedy. No prose-only explanations.
+
+## Verification
+One-liner the agent can run to sanity-check its reading.
+
+## See also
+Cross-references to adjacent playbooks.
+```
+
+## Accessing playbooks as structured JSON
+
+From the command line (inside a shell, inside an agent that can shell out, inside a CI runner — anywhere with a Noether install):
+
+```bash
+# List available playbooks + one-line intents.
+noether agent-docs
+
+# Dump a specific playbook as JSON (body, title, intent, key fields).
+noether agent-docs compose-a-graph
+
+# Keyword-search across all playbooks.
+noether agent-docs --search "deprecation cycle"
+```
+
+The playbook markdown files are compiled into the `noether` binary via `include_str!`, so the command works offline and regardless of where the binary was installed. A contract test enforces that every playbook's H1 matches `# Playbook: <key>` so renames can't drift from the CLI key.
+
+## The five current playbooks
+
+| Key | Intent |
+|---|---|
+| [`compose-a-graph`](compose-a-graph.md) | Translate a natural-language problem description into a valid composition graph using the Composition Agent. |
+| [`find-an-existing-stage`](find-an-existing-stage.md) | Find a stage already in the store that matches a signature or intent, instead of synthesizing a new one. |
+| [`synthesize-a-new-stage`](synthesize-a-new-stage.md) | Author, sign, validate, and register a new stage when nothing in the catalogue fits. |
+| [`express-a-property`](express-a-property.md) | Attach declarative property claims (the seven DSL kinds) so a stage's behaviour is verifiable beyond its type signature. |
+| [`debug-a-failed-graph`](debug-a-failed-graph.md) | Interpret Noether CLI failures — exit code, stderr, ACLI envelope — and choose the remediation. |
+
+New playbooks are cheap to add as support questions or adoption friction surface. The format is intentionally terse; most playbooks come in under 600 tokens.
+
+## Related agent resources
+
+- `noether introspect` — full CLI command tree as JSON (ACLI standard). Higher-level than the playbooks; lower detail.
+- `noether stage search "<query>"` — semantic-index search over the entire registered stage set. The primary "what does this store contain?" query an agent makes.
+- `noether agent-docs --search "<term>"` — keyword search across these playbooks only.

--- a/docs/architecture/nix-execution.md
+++ b/docs/architecture/nix-execution.md
@@ -3,13 +3,28 @@
 Nix provides a reproducible, pinned runtime for Python, JavaScript, and bash
 stages. It is Noether's L1 — the layer below the stage store.
 
-!!! danger "Reproducibility, not isolation"
-    Nix pins the runtime's binaries and libraries so you always get the same
-    Python, the same NumPy, the same everything. It does **not** run the
-    stage inside a sandbox. The subprocess inherits the host user's
-    privileges, filesystem, and network. A stage can call `os.system(...)`,
-    read files outside its working directory, and make arbitrary HTTP
-    requests. Treat stages you did not write as untrusted code.
+!!! info "Reproducibility and isolation are separate boundaries (v0.7+)"
+    Nix pins the runtime's binaries and libraries so you always get
+    the same Python, NumPy, everything — that's the **reproducibility**
+    boundary. The **isolation** boundary is separate: from v0.7,
+    `noether run --isolate=auto` (the default) wraps every stage
+    subprocess in bubblewrap with UID mapped to `nobody`, `--cap-drop
+    ALL`, sandbox-private `/work` tmpfs, and network unshared unless
+    the stage declares `Effect::Network`. See
+    [`noether-isolation`](https://github.com/alpibrusl/noether/tree/main/crates/noether-isolation)
+    for the crate, [`SECURITY.md`](https://github.com/alpibrusl/noether/blob/main/SECURITY.md)
+    for the threat model, and
+    [`docs/roadmap/2026-04-18-stage-isolation.md`](../roadmap/2026-04-18-stage-isolation.md)
+    for Phase-2 (native namespaces + Landlock + seccomp, v0.8).
+
+    Opt out with `--isolate=none --unsafe-no-isolation`. In CI, pass
+    `--require-isolation` (or `NOETHER_REQUIRE_ISOLATION=1`) to turn
+    the `auto → none` fallback into a hard error when bwrap is missing.
+
+    Distro-packaged `nix` at `/usr/bin/nix` can't run under isolation
+    (dynamically linked against host libs that aren't bound) — the
+    executor refuses cleanly. Install via Determinate / upstream so
+    `nix` lives in `/nix/store`.
 
 ---
 

--- a/docs/architecture/stage-identity.md
+++ b/docs/architecture/stage-identity.md
@@ -187,6 +187,8 @@ line**: a bugfix that changes `implementation_hash` changes `StageId` but never
 pick up implementation fixes automatically.
 
 > **Naming note.** Prior to v0.6.0 this field was called `canonical_id` and the
-> type was `CanonicalId`. Both the old name (as a JSON field alias and a
-> deprecated type alias) and the new one are accepted in v0.6.x; the old
-> names are removed in v0.7.0.
+> type was `CanonicalId`. As of v0.7.1 the Rust type alias is gone, but the
+> JSON field name `canonical_id` is still accepted as a deserialisation
+> alias for `signature_id` so v0.5.x-authored stage JSONs keep loading.
+> The wire-format alias will be removed in v0.8; authors writing new
+> specs should use `signature_id` directly.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,84 @@ uses [Semantic Versioning](https://semver.org/).
 > [Pre-release history](#pre-release-history) for reference — don't map
 > them to crates.io versions.
 
+> **Authoritative source.** The root-level
+> [`CHANGELOG.md`](https://github.com/alpibrusl/noether/blob/main/CHANGELOG.md)
+> is the canonical changelog from v0.7.0 forward. This doc summarises
+> the same entries for MkDocs navigation; the full detail + rationale
+> lives at the root.
+
+---
+
+## [0.7.1] — 2026-04-19
+
+Small release: extract isolation into its own crate + ship a standalone sandbox binary for non-Rust consumers.
+
+- **New crate `noether-isolation`** — extracted from `noether-engine::executor::isolation`. Small dependency footprint (`noether-core` + `serde` + `thiserror` + `tracing`). `IsolationPolicy` is now Serde-enabled with a round-trip test pinning the wire format. `noether-engine` re-exports from this crate so existing callers see no API change.
+- **New binary `noether-sandbox`** — ~300 LOC glue. Reads an `IsolationPolicy` on stdin (or `--policy-file <path>`), takes argv after `--`, runs the inner command inside bubblewrap. Flags: `--isolate=auto|bwrap|none`, `--require-isolation` (mirrors the engine-side env var), 1 MiB stdin cap, `128 + signum` exit codes for signal deaths. Intended for Python/Node/Go/shell callers (notably agentspec) that want the sandbox primitive without a Rust toolchain.
+- **`ro_binds` wire format** switched from tuple `[[host, sandbox]]` to named-struct `[{"host": ..., "sandbox": ...}]` before external consumers pinned the shape.
+
+## [0.7.0] — 2026-04-19
+
+M2 close-out: property DSL parity with the "what does this stage guarantee?" use case, resolver at every graph-ingest entry point, store enforces its Active-per-signature invariant, stage subprocesses execute inside a real sandbox by default. The v1.x stability contract ([STABILITY.md](https://github.com/alpibrusl/noether/blob/main/STABILITY.md)) applies from this release.
+
+### Added — sandbox isolation
+
+`noether run --isolate=auto` (default from v0.7) wraps every stage subprocess in bubblewrap: UID mapped to `nobody` (65534), unshared user/pid/mount/uts/ipc/cgroup namespaces, `/nix/store` RO, sandbox-private `/work` tmpfs, `--cap-drop ALL`, `--new-session`, env cleared to a short allowlist, network namespace unshared unless `Effect::Network` is declared. When network is on, `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, `/etc/ssl/certs` bind read-only so DNS and TLS actually work. `bwrap` resolved from trusted system paths first (`/run/current-system/sw/bin`, `/nix/var/nix/profiles/default/bin`, `/usr/bin`, `/usr/local/bin`) before falling back to `$PATH`.
+
+CLI flags: `--isolate=auto|bwrap|none` (+ `NOETHER_ISOLATION`), `--unsafe-no-isolation`, `--require-isolation` (+ `NOETHER_REQUIRE_ISOLATION=1` for CI fail-closed).
+
+Adversarial escape-test suite (`tests/isolation_escape.rs`) runs real bwrap+python and verifies `setuid(0)`, `chroot("/")`, reading `/etc/shadow`, reading `~/.ssh/*`, and DNS with `network:false` all fail.
+
+**Caveat**: isolation requires nix installed under `/nix/store` (upstream or Determinate). Distro-packaged `/usr/bin/nix` is dynamically linked against host libs that aren't bound; the executor refuses cleanly with a clear message.
+
+Phase 2 (v0.8): native `unshare` + Landlock + seccomp, same `IsolationPolicy`, ~10× lower startup. Roadmap: [`docs/roadmap/2026-04-18-stage-isolation.md`](roadmap/2026-04-18-stage-isolation.md).
+
+### Added — property DSL expansion
+
+Five new `Property` variants on top of v0.6 `SetMember` / `Range`:
+
+- `FieldLengthEq { left_field, right_field }` — equal length. Strings: UTF-8 code-point count. Arrays: element count. Objects: key count.
+- `FieldLengthMax { subject_field, bound_field }` — subject length ≤ bound length.
+- `SubsetOf { subject_field, super_field }` — element / (key, value) / contiguous substring subset. Three branches per JSON kind, each pinned by a dedicated test.
+- `Equals { left_field, right_field }` — JSON-value equality.
+- `FieldTypeIn { field, allowed: Vec<JsonKind> }` — runtime JSON type in the allowed set. `JsonKind` is a typed enum; wire format stays snake-case strings.
+
+`Property::Unknown` is the forward-compat escape; `Property::shadowed_known_kind()` distinguishes "genuinely unknown kind" (safe skip) from "typo inside a known kind" (rejected at ingest via `ValidationError::ShadowedKnownKind`). Every stdlib stage carries ≥3 properties.
+
+### Changed — resolver runs at every graph-ingest entry point
+
+`resolve_pinning` + the new `resolve_deprecated_stages` (in `noether_engine::lagrange::deprecation`) now runs from every entry point that ingests a graph: `noether run`, `compose`, `build`, `serve`, the scheduler, the grid broker, and the grid worker. `composition_id` is always computed **before** resolution per the M1/#28 "canonical form is identity" contract.
+
+New `DeprecationReport { rewrites, events }` distinguishes routine rewrites from anomalies (`ChainEvent::CycleDetected`, `MaxHopsExceeded`) explicitly.
+
+### Changed — store enforces ≤1 Active per signature
+
+`MemoryStore::put` / `upsert` and `JsonFileStore` equivalents auto-deprecate any existing Active stage whose `signature_id` matches an incoming Active. Shared `noether_store::invariant` module; every auto-deprecation emits structured `tracing::warn!`.
+
+### Changed — stage identity split
+
+Two content-addressed IDs per stage: `signature_id = SHA-256(name + input + output + effects)` (stable across bugfix-only impl rewrites) and `implementation_id` aka `StageId = SHA-256(signature_id + implementation_hash)`. Graphs pin by `signature_id` by default (`Pinning::Signature`); `Pinning::Both` requires exact impl match.
+
+### Added — `noether stage verify --with-properties`
+
+Default now checks both signatures and declarative properties against declared examples. Pass `--signatures-only` for the v0.6 behaviour.
+
+### Added — STABILITY.md
+
+Formal 1.x compatibility contract — what's stable on the wire, what's additive, what's deprecated, what can change.
+
+### Breaking changes
+
+- `NixExecutor::register` (unsafe default) removed. Synthesized-stage registration goes through `NixExecutor::register_with_effects`; `CompositeExecutor::register_synthesized` takes an `EffectSet` argument.
+- `IsolationPolicy::from_effects` no longer takes a `work_host: PathBuf` argument (sandbox defaults to a private tmpfs; opt-in via `.with_work_host(...)`).
+- `resolve_deprecated_stages` moved from `noether_cli::commands::resolver_utils` to `noether_engine::lagrange::deprecation` (now `pub`). Return type changed to `DeprecationReport`.
+- `Stage.canonical_id` accepted on the wire but removed from the Rust type — use `signature_id`. JSON alias stays through 0.7.x.
+
+### Known limitations / deferred
+
+- Filesystem-scoped effect variants (`Effect::FsRead(path)` / `FsWrite(path)`) — v0.8, paired with Phase-2 isolation.
+- `validate_against_types` punts on the five new relational property variants. Structural checks land with M3 refinement types.
+
 ---
 
 ## [0.6.0] — 2026-04-18

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,19 @@
 
 **Typed, content-addressed pipelines — reproducible by construction, LLM-assisted by option.**
 
-Decompose computation into stages with structural type signatures. The type checker verifies graph *topology* before execution — it does not prove stage bodies correct. Run stages in a Nix-pinned runtime for byte-identical reproduction. Replay any run from its composition hash.
+Decompose computation into stages with structural type signatures. The type checker verifies graph *topology* before execution — it does not prove stage bodies correct. Run stages in a Nix-pinned runtime for byte-identical reproduction, sandboxed by default (v0.7+) via bubblewrap. Replay any run from its composition hash.
 
-!!! warning "Reproducibility is not isolation"
-    The Nix-pinned runtime fixes the language and library versions so the
-    same stage produces the same output. It does **not** sandbox the
-    subprocess: stages run with host-user privileges and can read the
-    filesystem, make network calls, and read environment variables. Do not
-    run stages you did not write without reading [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md).
+!!! tip "Reading this as an AI agent?"
+    Start at [`AGENTS.md`](https://github.com/alpibrusl/noether/blob/main/AGENTS.md) and query playbooks via `noether agent-docs`. Dense, intent-keyed, machine-readable. The rest of these docs are human-facing narrative.
+
+!!! info "Trust model — v0.7+"
+    The Nix-pinned runtime is the **reproducibility boundary**; the
+    bubblewrap sandbox (enabled by default via `--isolate=auto`) is the
+    **isolation boundary**. Stages run under a fresh user namespace,
+    mapped UID `nobody`, sandbox-private `/work` tmpfs, `--cap-drop ALL`,
+    network namespace unshared unless the stage declares `Effect::Network`.
+    Pass `--require-isolation` in CI to turn the `auto → none` fallback
+    into a hard error. See [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md) for the full model, including the distro-nix caveat.
 
 ```bash
 cargo install noether-cli
@@ -134,16 +139,35 @@ graph TD
 Four layers — agent interface, composition engine, stage store, execution.
 Details: **[Architecture overview →](architecture/overview.md)**
 
-## What's new in v0.2
+## What's new in v0.7
 
-- **`Let` operator** — carry original-input fields through `Sequential`
-  pipelines (solves the canonical scan → hash → diff pattern).
-- **`def execute(input)` validated** at `stage add` — no more cryptic
-  `NoneType` errors at run time.
-- **Stage ID prefix resolution in graphs** — 8-char IDs work everywhere.
-- **Hosted public registry** at `registry.alpibru.com` — stdlib + ~400
-  curated stages, anonymous read.
-- **`stage sync <dir>`** for bulk import · **`stage list --signed-by`** /
-  `--lifecycle` / `--full-ids` filters · **stdin piping** to `noether run`.
+- **Sandbox by default** — `noether run --isolate=auto` wraps every
+  stage subprocess in bubblewrap: fresh namespaces, UID mapped to
+  `nobody`, sandbox-private `/work` tmpfs, `--cap-drop ALL`, network
+  unshared unless `Effect::Network` is declared. `--require-isolation`
+  turns the `auto → none` fallback into a hard error for CI.
+- **`noether-isolation` crate** — the sandbox primitive extracted from
+  `noether-engine` for non-Rust consumers. Stable Serde-enabled
+  `IsolationPolicy` wire format (v0.7.1).
+- **`noether-sandbox` binary** — ~300 LOC glue that reads an
+  `IsolationPolicy` JSON + argv and runs the command under bwrap.
+  What agentspec-shaped callers use instead of building their own
+  sandbox.
+- **Property DSL expansion** — seven declarative property kinds
+  (`SetMember`, `Range`, `FieldLengthEq`, `FieldLengthMax`,
+  `SubsetOf`, `Equals`, `FieldTypeIn`) with typed `JsonKind` and
+  ingest-time rejection of typo'd property kinds.
+- **Resolver everywhere** — signature-pinned graph nodes resolve to
+  concrete implementation IDs before every execution path (CLI,
+  compose, serve, scheduler, grid-broker, grid-worker, registry).
+  `composition_id` is computed pre-resolution so the same source
+  graph produces a stable id across days.
+- **Stage identity split** — `signature_id` + `implementation_id`.
+  Graphs pin by signature; bugfix-only impl rewrites don't break
+  pinned references.
+- **Agent-facing docs** — [`AGENTS.md`](https://github.com/alpibrusl/noether/blob/main/AGENTS.md)
+  at the repo root + 5 intent-keyed playbooks at
+  [`docs/agents/`](https://github.com/alpibrusl/noether/tree/main/docs/agents)
+  + `noether agent-docs` CLI subcommand.
 
 Full list: **[Changelog →](changelog.md)**.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,9 +21,27 @@ Current implementation status and future directions for Noether.
 
 ---
 
+## Milestones (post-phase 9)
+
+Noether shifted from sequential "phase" numbering to milestone tracking with the v0.5 release. Milestones correspond to the [Rock-Solid Plan](roadmap/2026-04-18-rock-solid-plan.md).
+
+| Milestone | Name | Status | Shipped as | Key deliverables |
+|---|---|---|---|---|
+| M1 | Semantics + Canonical Form | ✅ Done | v0.5.0 | `canonicalise` for every composition op, pre-resolution `composition_id` contract, `laws.rs` property tests |
+| M2 | Stability + Versioning + Property Predicates | ✅ Done | v0.6.0 + v0.7.0 | Stage identity split (`signature_id` + `implementation_id`), graph-level pinning, declarative properties DSL (7 kinds), resolver pass, `stage verify --with-properties`, STABILITY.md, store ≤1-Active-per-signature invariant |
+| M2.4 | Stage execution isolation — Phase 1 | ✅ Done | v0.7.0 | Bubblewrap sandbox by default, UID mapping to `nobody`, sandbox-private `/work` tmpfs, trusted `bwrap` path discovery, `--require-isolation` CI gate, DNS/TLS binds when network declared, adversarial escape-test suite |
+| M2.5 | Property DSL expansion | ✅ Done | v0.7.0 | `FieldLengthEq` / `FieldLengthMax` / `SubsetOf` / `Equals` / `FieldTypeIn`, typed `JsonKind` enum, shadowed-kind ingest rejection |
+| M2.x | `noether-isolation` crate extraction | ✅ Done | v0.7.1 | Standalone crate + `noether-sandbox` binary for non-Rust consumers (agentspec, future Python/Node/Go bindings) |
+| M3 | Optimizer + Richer Types | ⏳ Next | targeting v0.8.0 | Graph optimizer (`fuse_pure_sequential`, `hoist_invariant`, `dead_branch`, `memoize_pure`), parametric polymorphism on stage signatures, row polymorphism on records, refinement types with runtime check |
+| M3.x | Filesystem-scoped effects | ⏳ Planned | targeting v0.8.0 | `Effect::FsRead(path)` / `FsWrite(path)` variants so the sandbox can grant targeted filesystem access per stage |
+| M4 | Stdlib Curation + Vertical Depth + 1.0 | ⏳ Planned | targeting 1.0.0 | Stdlib audit, vertical depth in a chosen domain, freeze |
+| Phase 2 isolation | Native namespaces + Landlock + seccomp | ⏳ Planned | targeting v0.8.0 | Replace bwrap subprocess with direct `unshare` + Landlock + seccomp; same `IsolationPolicy` surface, ~10× lower startup |
+
+---
+
 ## Near-term improvements
 
-These are gaps in the current implementation, not new phases:
+Smaller tech-debt items tracked outside the milestone cadence:
 
 | Item | Description |
 |---|---|
@@ -31,7 +49,8 @@ These are gaps in the current implementation, not new phases:
 | `NixExecutor::warmup()` caller | Warmup is implemented but never called at CLI startup |
 | `get_live` CLI integration | `RemoteStageStore::get_live` is never called from the CLI |
 | Scheduler `registry_url` docs | The scheduler's remote-store config is undocumented outside source code |
-| `noether-cloud` CI | No GitHub Actions workflow for the cloud repo yet |
+| Registry unconditional LLM-provider init | `routes::compositions::run` constructs a `reqwest::blocking::Client` even when no LLM env is set, which blocks HTTP-level integration testing from `#[tokio::test]` in noether-cloud. Make provider construction lazy or env-gated |
+| `validate_against_types` for relational property variants | Structural checks (length-on-numeric, equals-on-disjoint-types) currently punt at registration; land naturally with M3 refinement types |
 
 ---
 

--- a/docs/tutorial/concepts.md
+++ b/docs/tutorial/concepts.md
@@ -57,7 +57,7 @@ See [architecture/type-system.md](../architecture/type-system.md) for the full t
 
 ## 3. Effects are declared, not inferred at run time
 
-Every stage's signature carries an `EffectSet`:
+Every stage's signature carries an `EffectSet`. The kinds the engine currently recognises:
 
 - `Pure` — deterministic, no side effects.
 - `Fallible` — can return an error value.
@@ -65,6 +65,10 @@ Every stage's signature carries an `EffectSet`:
 - `Llm` — calls an LLM provider.
 - `Cost` — consumes paid credits (LLM tokens, API quota).
 - `NonDeterministic` — reads time, entropy, or process state.
+- `Process` — spawns a subprocess.
+- `Unknown` — effects haven't been declared (typically pre-`noether stage add` validation).
+
+The canonical list lives in `noether_core::effects::EffectKind`.
 
 Effects are authored in the stage spec, not inferred from the source. The **composition engine** sums the effects of every stage in the graph before execution and compares against the allowed set:
 

--- a/docs/tutorial/concepts.md
+++ b/docs/tutorial/concepts.md
@@ -1,0 +1,139 @@
+# Core concepts: a 5-minute mental model
+
+Before the walkthrough, a short tour of the four ideas Noether is built on. Every page of docs after this one assumes you've read this one.
+
+If you've ever used Git, Nix, or a typed functional language, most of this will feel familiar. If you haven't, the analogies still work — read past them.
+
+---
+
+## 1. A stage is a computation with a content-addressed identity
+
+A stage is a small, reusable unit of computation with:
+
+- a name,
+- an **input type**,
+- an **output type**,
+- a set of declared **effects** (more on these in §3),
+- and an implementation — inline Rust, a Python function, a Bash script.
+
+The stage's identity isn't its name. It's a SHA-256 hash of
+`{ name, input, output, effects, implementation_hash }`. Two stages with the same hash are **provably the same computation** — on any machine, forever. Rename the stage, change the input type, change the implementation, and you get a *different* stage with a *different* hash. The old one still resolves; it just no longer matches.
+
+```bash
+noether stage list
+# …
+# 7b2f9a1c http_get      (signature id: a3…)
+# …
+```
+
+The left column is the `StageId` (full hash). The right column in parens is the `SignatureId` — a stable identity for the *interface* independent of the implementation. Graphs typically pin by `SignatureId` so a bugfix in the implementation is picked up automatically; they can pin by `StageId` when they need the exact byte-level implementation.
+
+> **Why this matters.** It means you can't "yank" a stage. The bytes that produced yesterday's result are either still resolvable (then today's re-run is identical) or the reference is a dangling hash (then you get a clear error, not a silent regression).
+
+See [architecture/stage-identity.md](../architecture/stage-identity.md) for the canonicalisation rules.
+
+---
+
+## 2. Types are structural, not nominal
+
+Noether doesn't have classes or interfaces you need to declare conformance to. A type is just its shape.
+
+The type `Record { a: Number, b: Text, c: Bool }` is a subtype of `Record { a: Number, b: Text }` — not because someone said so, but because every value of the first shape is, mechanically, also a value of the second shape. This is called **width subtyping**.
+
+```
+Record { a: Number, b: Text, c: Bool }   is subtype of   Record { a: Number, b: Text }
+List<Number>                             is subtype of   List<Any>
+Any                                      is subtype of   T     (for any T)
+T                                        is subtype of   Any   (for any T)
+```
+
+The last two — `Any` being bidirectional — is the escape hatch. Use it sparingly: it turns off the type checker at that edge.
+
+The type checker runs before any stage executes. If stage `A` produces `Record { body: Text, status: Number }` and you wire it into stage `B` that expects `Record { html: Text }`, the checker reports the mismatch **at compose time**, not at run time. No network call happens. No Python process spawns.
+
+See [architecture/type-system.md](../architecture/type-system.md) for the full type grammar.
+
+---
+
+## 3. Effects are declared, not inferred at run time
+
+Every stage's signature carries an `EffectSet`:
+
+- `Pure` — deterministic, no side effects.
+- `Fallible` — can return an error value.
+- `Network` — makes outbound HTTP/DNS calls.
+- `Llm` — calls an LLM provider.
+- `Cost` — consumes paid credits (LLM tokens, API quota).
+- `NonDeterministic` — reads time, entropy, or process state.
+
+Effects are authored in the stage spec, not inferred from the source. The **composition engine** sums the effects of every stage in the graph before execution and compares against the allowed set:
+
+```bash
+noether run graph.json --allow-effects pure,fallible,network
+```
+
+If the graph's effect closure contains `Llm` and you didn't allow it, the run is rejected with exit 2, before any work happens. Same shape for capabilities (filesystem access, network reachability) and for the optional cost budget (`--budget-cents`).
+
+> **Why this matters.** It makes graphs auditable. A composition that claims to be `Pure` is mechanically forbidden from making a network call — not by convention, by refusal to execute.
+
+---
+
+## 4. A composition is a typed graph, not a script
+
+When you write a pipeline in a scripting language, the type discipline is whatever the author remembered. In Noether, the composition is itself a data structure — a **Lagrange graph** — with operators like `Sequential`, `Parallel`, `Branch`, `Fanout`, `Merge`, `Retry`, and `Let`. Each operator has a well-defined type rule.
+
+A minimal graph running one stage:
+
+```json
+{
+  "description": "one-stage graph",
+  "version": "0.1.0",
+  "root": {
+    "op": "Stage",
+    "id": "a3c9…"
+  }
+}
+```
+
+A two-stage pipeline:
+
+```json
+{
+  "description": "fetch and count",
+  "version": "0.1.0",
+  "root": {
+    "op": "Sequential",
+    "stages": [
+      { "op": "Stage", "id": "a3c9…" },
+      { "op": "Stage", "id": "7d11…" }
+    ]
+  }
+}
+```
+
+The canonical form of this graph gets a `composition_id` (SHA-256 of the JCS-serialised root). That id is stable across cosmetic rewrites — nested `Sequential`s flatten, `Parallel` branch order is normalised — so two graphs that compute the same thing get the same id.
+
+The engine runs the checker against the graph, builds an `ExecutionPlan`, and only then dispatches the stages. Every execution writes a trace indexed by the composition id, so `noether trace <id>` reproduces the full story.
+
+See [architecture/composition-engine.md](../architecture/composition-engine.md) for the operator semantics.
+
+---
+
+## Reproducibility vs isolation (important distinction)
+
+Noether pins two separate things:
+
+| Boundary | What it pins | Tool |
+|---|---|---|
+| **Reproducibility** | The runtime: Python/Node versions, libc, every transitive package | Nix (`/nix/store`) |
+| **Isolation** | The stage's view of the host: filesystem, network, env vars | bubblewrap (`bwrap`), Linux only, default from v0.7 |
+
+The Nix boundary means "same inputs produce same outputs on any machine." It does **not** mean "a malicious stage can't read your SSH key." That's what isolation is for. From v0.7 onwards, stages run in a bubblewrap sandbox by default (`--isolate=auto`, falls back to `none` with a warning if bwrap isn't installed). See [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md) for the full threat model.
+
+---
+
+## What to read next
+
+- **[Walkthrough — citecheck as stages](index.md)** — the hands-on tutorial.
+- **[Compose with an LLM](llm-compose.md)** — let the agent author a graph from a problem statement.
+- **[When things go wrong](when-things-go-wrong.md)** — how to read Noether errors.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -27,18 +27,24 @@ You don't need to have followed the ACLI tutorial — this one stands alone. But
 
 ## Quick-start
 
-Install Noether. Pre-built binaries are on the [releases page](https://github.com/alpibrusl/noether/releases/tag/v0.1.0); choose your platform, extract, put on PATH:
+Install Noether. Pre-built binaries are on the [releases page](https://github.com/alpibrusl/noether/releases/latest); choose your platform, extract, put on PATH. The archive name includes the version, so check the latest release and substitute it in:
 
 ```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/alpibrusl/noether/releases/latest/download/noether-v0.1.0-aarch64-apple-darwin.tar.gz | tar xz
+# macOS (Apple Silicon) — replace v0.7.1 with the current release tag
+curl -L https://github.com/alpibrusl/noether/releases/latest/download/noether-v0.7.1-aarch64-apple-darwin.tar.gz | tar xz
 chmod +x noether && mv noether ~/.local/bin/
 
 # Linux (x86_64)
-curl -L https://github.com/alpibrusl/noether/releases/latest/download/noether-v0.1.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl -L https://github.com/alpibrusl/noether/releases/latest/download/noether-v0.7.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
 chmod +x noether && mv noether ~/.local/bin/
 
 # Windows: download the -x86_64-pc-windows-msvc.zip
+```
+
+Or install via cargo:
+
+```bash
+cargo install noether-cli
 ```
 
 Verify:

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,4 +1,7 @@
-# Tutorial: turn `citecheck` into verified Noether stages
+# Walkthrough: turn `citecheck` into verified Noether stages
+
+!!! warning "This walkthrough runs ahead of the current CLI"
+    Parts of this page — `noether lint`, `noether run --stage <name>`, `noether skill`, and the `{"sequence": …, "parallel": …, "bind": …}` graph shape — describe an older / aspirational CLI surface. The real v0.7.x commands and Lagrange graph format are documented in [Core concepts](concepts.md) and [When things go wrong](when-things-go-wrong.md); a working end-to-end narrative is in [Compose with an LLM](llm-compose.md). A rewrite of this page against the current CLI is pending — track it on the project roadmap. Read this page as narrative for now, not as commands to copy.
 
 In the [ACLI tutorial](https://alpibrusl.github.io/acli/tutorial/) we built `citecheck`, a CLI that verifies citations in Markdown. The logic was straightforward but monolithic: one Python file, `verify()` calls `_fetch()` calls `_extract_text()` calls `_contains_claim()`.
 

--- a/docs/tutorial/llm-compose.md
+++ b/docs/tutorial/llm-compose.md
@@ -1,0 +1,175 @@
+# Compose with an LLM: from problem to running graph
+
+The [walkthrough](index.md) shows you how to author stages and graphs by hand. This page is the other mode: describe the problem in English, let the LLM assemble a graph from existing stages (and, if needed, synthesise new ones), have the type checker verify it, and run it. Everything the LLM produces is a regular Noether graph — there's no shortcut around type checking, signing, or effect policy.
+
+!!! warning "You need an LLM provider"
+    This flow requires credentials for one of the supported providers. `noether compose` picks them up from env in this priority order: `VERTEX_AI_*` > `ANTHROPIC_API_KEY` > `OPENAI_API_KEY` > `MISTRAL_API_KEY`. If none are set, `compose` exits with a clear provider-missing error.
+
+---
+
+## The shape of the command
+
+```
+noether compose [FLAGS] "<problem description>"
+```
+
+Key flags:
+
+| Flag | What it does |
+|---|---|
+| `--dry-run` | Produce the graph, type-check it, skip execution. Use this first. |
+| `--input '<json>'` | Pipeline input. Alternatively pipe JSON on stdin. |
+| `--model <name>` | Pin the LLM (default: `VERTEX_AI_MODEL` env → `gemini-2.5-flash`). |
+| `--verbose` | Show the candidate list, prompt, and each attempt's raw response. |
+| `--force` | Ignore the cached composition and call the LLM again. |
+| `--budget-cents N` | Reject graphs whose estimated cost exceeds N cents. |
+| `--allow-effects <list>` | Restrict the effect closure. Default: all allowed. |
+
+---
+
+## Step 1 — start with `--dry-run`
+
+Never run a first-draft composition without looking at it.
+
+```bash
+noether compose --dry-run \
+  "count how many times the word 'rust' appears in a text" \
+  --input '{"text": "rust rust rust"}'
+```
+
+Output (abbreviated):
+
+```json
+{
+  "ok": true,
+  "command": "compose",
+  "result": {
+    "composition_id": "8f3a…",
+    "attempts": 1,
+    "from_cache": false,
+    "synthesized": [],
+    "graph": {
+      "description": "count occurrences of 'rust'",
+      "version": "0.1.0",
+      "root": {
+        "op": "Stage",
+        "id": "count_substring_signature_id_hex"
+      }
+    },
+    "output": null,
+    "trace": null,
+    "warnings": []
+  },
+  "meta": { "version": "0.7.1", "duration_ms": 842 }
+}
+```
+
+Read `result.graph.root`. That's the graph the agent picked. If it's wrong — wrong stage, wrong wiring, wrong operator — re-run with a sharper problem statement before burning a real execution.
+
+`composition_id` is computed on the pre-resolution graph. The same `problem` against the same stdlib produces the same id; changes to which implementation is Active don't perturb it.
+
+---
+
+## Step 2 — understand what synthesis means
+
+If the agent can't find an existing stage that does the job, it **synthesises** a new one — writes Python, type-checks the signature, runs the declared examples through `noether stage test`, and registers the result. The `synthesized` array in the envelope tells you what was created:
+
+```json
+"synthesized": [
+  {
+    "stage_id": "c41f2…",
+    "name": "weighted_mean",
+    "language": "python",
+    "attempts": 2,
+    "is_new": true
+  }
+]
+```
+
+That stage is now in your store. The next composition with the same need hits it via search and doesn't call the LLM. You can inspect it:
+
+```bash
+noether stage get c41f2
+noether stage test c41f2        # re-run the declared examples
+noether stage verify c41f2 --properties   # check any declared properties hold
+```
+
+Synthesised stages are signed with your local signing key (generated on first run at `~/.noether/signing_key`). Their lifecycle starts at `Draft`; promote to `Active` with `noether stage activate <id>` when you're confident.
+
+---
+
+## Step 3 — guard with budget and effects
+
+Once the dry-run looks right, run for real. Two guards are worth setting up front:
+
+```bash
+noether compose \
+  --budget-cents 5 \
+  --allow-effects pure,fallible,network,llm,cost \
+  "pull the H1 titles off example.com and classify them" \
+  --input '{"url": "https://example.com"}'
+```
+
+- `--budget-cents 5` rejects any composition whose pre-flight cost estimate exceeds 5¢. Costs are declared on each stage in the spec; `Llm`/`Cost`-tagged stages carry per-call estimates.
+- `--allow-effects` is the effect closure. If the graph needs `Network` but you only passed `pure,llm`, the run fails with exit 2, before any execution.
+
+Both guards apply at pre-flight and at runtime. If an LLM call mid-graph tips over `--budget-cents`, the executor halts with `cost budget exceeded at runtime`.
+
+---
+
+## Step 4 — trace the run
+
+Every real execution writes a trace to `~/.noether/traces/<composition_id>.json`:
+
+```bash
+noether trace 8f3a…
+```
+
+Output includes per-stage input, output, duration, and effects observed. When a synthesised stage behaves unexpectedly, the trace is the first thing to read — it's the ground truth, stderr is a summary.
+
+---
+
+## When composition fails
+
+`noether compose` returns a non-zero exit on three distinct failure modes. Each has a different remedy:
+
+| Exit | Typical message | What went wrong | Remedy |
+|---|---|---|---|
+| 2 | `composition failed: …` | LLM couldn't produce a type-checkable graph in 3 attempts | Re-run with `--verbose`; refine the problem statement; check that the stdlib actually has stages close to what you're asking for |
+| 2 | `X effect violation(s)` | Graph's effect closure includes something `--allow-effects` forbids | Either allow the effect or ask the LLM for a simpler approach |
+| 2 | `composition exceeds cost budget` | Pre-flight estimate exceeds `--budget-cents` | Raise the budget or accept a cheaper graph |
+| 3 | `execution failed: …` | Graph type-checked and ran, but a stage returned an error | Read the trace; often a missing provider credential or an input the stage didn't anticipate |
+
+The detailed exit-code contract lives in [when things go wrong](when-things-go-wrong.md).
+
+---
+
+## Reading the verbose transcript
+
+`--verbose` exposes three phases the agent goes through:
+
+1. **Semantic search** — the top-20 stage candidates for the problem. If none of them look close to what you meant, the LLM will have a harder time.
+2. **Prompt** — the exact prompt sent to the LLM. Includes candidate list, type system description, operator reference.
+3. **Response(s)** — each attempt's raw response and the type-check result. On failure, the next attempt carries the error back to the LLM.
+
+```bash
+noether compose --verbose --dry-run "<problem>" 2>&1 | less
+```
+
+If you see the LLM confidently emitting a graph that references stage names that *aren't* in the candidate list, you've found an improvement opportunity: either add a stage to the stdlib that covers the missing capability, or refine the problem to stay within what's indexed.
+
+---
+
+## Caching
+
+`noether compose` keeps a per-problem cache at `~/.noether/compose_cache.json`. A repeat call with the same problem + same input shape + same stdlib state returns the cached graph without calling the LLM. The `from_cache: true` field in the envelope tells you when that happened. `--force` bypasses the cache.
+
+Cache invalidates when the stdlib changes (new stages could have changed the agent's choice). It does not invalidate on unrelated store activity.
+
+---
+
+## What to read next
+
+- **[Walkthrough — citecheck as stages](index.md)** — the manual-authoring path, for when `compose` isn't appropriate (e.g., you need specific stages the LLM wouldn't pick).
+- **[When things go wrong](when-things-go-wrong.md)** — reading errors from both `compose` and `run`.
+- **[Agent playbook: compose-a-graph](../agents/compose-a-graph.md)** — the dense reference version of this page, intended for agents calling `noether compose` from another tool.

--- a/docs/tutorial/llm-compose.md
+++ b/docs/tutorial/llm-compose.md
@@ -91,7 +91,10 @@ That stage is now in your store. The next composition with the same need hits it
 ```bash
 noether stage get c41f2
 noether stage test c41f2        # re-run the declared examples
-noether stage verify c41f2 --properties   # check any declared properties hold
+noether stage verify c41f2      # v0.7+: checks Ed25519 signature AND declared
+                                # properties by default. Pass --signatures to
+                                # restrict to signatures only, or --properties
+                                # to restrict to properties only.
 ```
 
 Synthesised stages are signed with your local signing key (generated on first run at `~/.noether/signing_key`). Their lifecycle starts at `Draft`; promote to `Active` with `noether stage activate <id>` when you're confident.

--- a/docs/tutorial/when-things-go-wrong.md
+++ b/docs/tutorial/when-things-go-wrong.md
@@ -162,7 +162,7 @@ From v0.7, stages run in a bubblewrap sandbox by default. The relevant failure m
 | `bwrap resolved via $PATH` (warning) | bwrap found outside a system-owned path | Install to `/usr/bin` or a trusted Nix profile. Flags a PATH-planting risk |
 | `nix is installed at /usr/bin/nix (outside /nix/store)` | Distro-packaged Nix needs host libs the sandbox can't bind | Install via the Determinate/upstream installer (places `nix` under `/nix/store`), or run with `--isolate=none` |
 | `refusing to run without isolation` | `--require-isolation` / `NOETHER_REQUIRE_ISOLATION=1` set, bwrap unavailable | Install bwrap; or drop the flag if the strict requirement doesn't apply |
-| Network declared but DNS fails inside the sandbox | `/etc/resolv.conf` / `/etc/hosts` / `/etc/nsswitch.conf` missing on host | The sandbox binds these via `--ro-bind-try` — if they don't exist on the host, DNS won't resolve |
+| Network effect declared but DNS silently fails inside the sandbox | Missing `/etc/resolv.conf` / `/etc/hosts` / `/etc/nsswitch.conf` on host | The sandbox binds these via `--ro-bind-try`, which is a *no-op* when the host file is absent (rather than an error). Symptom: connects by IP work but names don't. Fix: create the missing file(s) on the host (a one-line `/etc/resolv.conf` with `nameserver 1.1.1.1` is enough for a smoke test) |
 
 See [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md) for the full isolation model.
 

--- a/docs/tutorial/when-things-go-wrong.md
+++ b/docs/tutorial/when-things-go-wrong.md
@@ -1,0 +1,209 @@
+# When things go wrong: reading Noether errors
+
+Noether commands exit with one of four codes, and every failure is a structured ACLI envelope on stdout with a short error line on stderr. This page is the human-paced version of what to do when you see a non-zero exit.
+
+| Exit | Class | Happened at |
+|---|---|---|
+| `0` | Success | — |
+| `1` | Parse / IO / resolution | Before the checker got the graph |
+| `2` | Validation / policy | After the checker, before execution |
+| `3` | Runtime | During execution |
+
+The short rule: **1 = your file or your store, 2 = your policy or your types, 3 = the stage itself**.
+
+---
+
+## Exit 1 — the graph never reached the executor
+
+The checker didn't get a chance to run. Usually the file didn't parse, or a stage reference didn't resolve.
+
+```
+$ noether run graph.json
+{ "ok": false, "error": { "code": "…", "message": "stage reference: ambiguous prefix 7b2f" } }
+```
+
+Common shapes and what they mean:
+
+| Message fragment | Cause | Remedy |
+|---|---|---|
+| `failed to read <path>` | The file doesn't exist or isn't readable | Check the path; `ls` the parent directory |
+| `invalid graph JSON` | The Lagrange parser rejected the file | Verify every node has an `op` field; every operator's required fields are present |
+| `stage reference: not found` | The `id` in the graph doesn't match any store entry | `noether stage list`; if using a remote registry, check `NOETHER_REGISTRY` |
+| `stage reference: ambiguous prefix` | A shortened id matches more than one stage | Use a longer prefix (≥12 hex chars) or the full 64-char id |
+| `pinning resolution: unknown signature` | `Stage { pinning: Signature }` but no Active stage with that `signature_id` | Activate a Draft with that signature, or change the graph to `Pinning: Both` with a specific implementation id |
+| `pinning resolution: multiple Active` | Store violates "≤1 Active per signature" — rare | `noether stage activate` on the intended one auto-deprecates the others |
+| `failed to hash composition graph: …` | The graph contains something JCS can't canonicalise. Rare — effectively only triggered by hand-crafted pathological input | Inspect and rebuild the graph |
+
+The `stage reference` errors are by far the most common. When you copy an id from someone else's example and it doesn't resolve, the usual cause is that the stage exists only in their store.
+
+---
+
+## Exit 2 — the graph parsed, but policy or types rejected it
+
+This is the checker doing its job. Nothing ran. The ACLI `error.message` is usually `"<N> violation(s):\n  <detail lines>"`.
+
+### Type errors
+
+```
+type check failed:
+  input type Record { body: Text, status: Number } is not a subtype of
+  declared Record { html: Text } at edge (stage 7b2f → stage a3c9)
+```
+
+Read the edge. One side's output doesn't match the other side's input. Either fix the wiring (often a `Let` or `Parallel` can carry the missing field) or broaden a stage signature.
+
+See [concepts](concepts.md#2-types-are-structural-not-nominal) for the subtyping rules.
+
+### Effect policy violations
+
+```
+1 effect violation(s):
+  composition emits Llm, not in --allow-effects
+```
+
+Either allow the effect:
+
+```bash
+noether run graph.json --allow-effects pure,fallible,llm,network,cost
+```
+
+…or drop the stage that emits it. You can list the stages contributing each effect with `noether run --dry-run graph.json` — the envelope includes the inferred effect breakdown.
+
+### Capability violations
+
+```
+1 capability violation(s):
+  stage 7b2f9a1c requires capability Network, not in allow list
+```
+
+Capabilities are coarser than effects — they're what the sandbox grants. Pass `--allow-capabilities network,fs-read,…` to widen them.
+
+### Signature violations
+
+```
+1 signature violation(s):
+  stage a3c9… has ed25519_signature but signer_public_key is not trusted
+```
+
+Either add the signer's pubkey to the trust store, or rebuild the graph from stages you trust. The stdlib is signed with a deterministic key derived from the Noether version string — it's reproducible from source.
+
+### Cost budget rejected pre-flight
+
+```
+composition exceeds cost budget: 12¢ > 5¢
+```
+
+Raise `--budget-cents` or compose a cheaper graph. The estimate comes from each stage's declared cost; `Llm` stages carry per-call estimates.
+
+---
+
+## Exit 3 — the graph ran, a stage returned an error
+
+Everything passed pre-flight and the graph actually started. A stage then failed. The error line tells you which and why, the trace tells you what it got as input.
+
+```
+{ "ok": false, "error": {
+    "code": "…",
+    "message": "StageFailed: 7b2f9a1c: http_get: connection refused"
+  }
+}
+```
+
+| Error variant | Cause | Remedy |
+|---|---|---|
+| `StageFailed: <id>: <stderr>` | User code raised an exception or exited non-zero | Read the stderr fragment; often a missing `# requires:` dependency, an unexpected input shape, or an LLM API error |
+| `TimedOut: <id>: <N>s` | Stage exceeded `NixConfig::timeout_secs` (default 30s) | Raise `NOETHER_STAGE_TIMEOUT_SECS`, or profile the stage — 30s is generous for a typed unit |
+| `StageNotFound: <id>` | No executor had an implementation | Check the store; for `noether compose` output, synthesis registration should be automatic |
+| `cost budget exceeded at runtime: spent N¢ of M¢` | Runtime cost overran | Raise the budget; inspect the trace to see which stage consumed it |
+
+### `noether trace` is the ground truth
+
+```bash
+noether trace <composition_id>
+```
+
+Every graph execution writes a trace to `~/.noether/traces/`. Each entry has per-stage input, output, duration, observed effects, and (on failure) the error record.
+
+```json
+{
+  "composition_id": "…",
+  "duration_ms": 142,
+  "stages": [
+    {
+      "stage_id": "…",
+      "name": "html_to_text",
+      "input": { "html": "…" },
+      "output": "…",
+      "duration_ms": 5,
+      "effects_observed": ["Pure"]
+    },
+    {
+      "stage_id": "…",
+      "name": "llm_classify",
+      "input": { … },
+      "error": { "kind": "StageFailed", "message": "API rate limit" },
+      "duration_ms": 1200
+    }
+  ]
+}
+```
+
+When a user reports "noether did the wrong thing," the trace is the first artifact to ask for.
+
+---
+
+## Isolation-specific failures (v0.7+)
+
+From v0.7, stages run in a bubblewrap sandbox by default. The relevant failure modes:
+
+| Message | Cause | Remedy |
+|---|---|---|
+| `bubblewrap (bwrap) not found on PATH` | bwrap isn't installed | Install it (`apt install bubblewrap`, `brew install bubblewrap`, or via Nix). `--isolate=auto` falls back to `none` with a warning; `--isolate=bwrap` fails hard |
+| `bwrap resolved via $PATH` (warning) | bwrap found outside a system-owned path | Install to `/usr/bin` or a trusted Nix profile. Flags a PATH-planting risk |
+| `nix is installed at /usr/bin/nix (outside /nix/store)` | Distro-packaged Nix needs host libs the sandbox can't bind | Install via the Determinate/upstream installer (places `nix` under `/nix/store`), or run with `--isolate=none` |
+| `refusing to run without isolation` | `--require-isolation` / `NOETHER_REQUIRE_ISOLATION=1` set, bwrap unavailable | Install bwrap; or drop the flag if the strict requirement doesn't apply |
+| Network declared but DNS fails inside the sandbox | `/etc/resolv.conf` / `/etc/hosts` / `/etc/nsswitch.conf` missing on host | The sandbox binds these via `--ro-bind-try` — if they don't exist on the host, DNS won't resolve |
+
+See [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md) for the full isolation model.
+
+---
+
+## Stage-authoring failures
+
+These come from `noether stage add` rather than `run`:
+
+| Message | Cause | Remedy |
+|---|---|---|
+| `too few examples` | Spec has fewer examples than required (default ≥3) | Add examples — they're run as the primary validation |
+| `input type mismatch on example N` | The example's `input` isn't a value of the declared input type | Either fix the example or loosen the input type |
+| `output type mismatch on example N` | The implementation produced something not matching the declared output | The bug is in the implementation; inspect the actual output |
+| `property[i] shadowed_known_kind` | A declared property tries to override a known-kind property (e.g. `Pure`) | Either drop the shadowing or rename the property |
+| `stage id collision` | A stage with the same `StageId` already exists | Means identical bytes are already stored — often a no-op push, can be ignored |
+
+---
+
+## Diagnosis recipes
+
+### "My graph runs locally but not in CI"
+
+Likely isolation-related. CI containers often lack bwrap. Either install it or set `NOETHER_ISOLATION=none` in the CI env — but prefer fixing CI's isolation stack over widening production's posture.
+
+### "The trace shows a stage succeeded but the output is wrong"
+
+Check the stage's `examples` array in the spec. If the examples don't exercise the edge case you hit, add one covering it, then `noether stage add` the updated spec. The old stage lifecycle auto-deprecates to the new one (same `SignatureId`, new `StageId`).
+
+### "`noether compose` keeps picking the wrong stage"
+
+Run with `--verbose`. The top-20 candidate list shows what the semantic index thought relevant. If the correct stage wasn't in the top 20, its description/examples/tags don't match your problem statement — either refine the problem or improve the stage's searchable metadata.
+
+### "I can't reproduce someone else's trace"
+
+Content addressing guarantees that identical stages + identical graph + identical input produce identical output — **provided the same implementations resolve on both machines**. If the other side is pinning by `SignatureId`, a different Active implementation could have been picked. Ask for their `composition_id` and the full stage IDs used; the trace has both.
+
+---
+
+## What to read next
+
+- **[Concepts](concepts.md)** — the mental model the error messages refer to.
+- **[Walkthrough](index.md)** — hands-on examples of the commands covered here.
+- **[Agent playbook: debug-a-failed-graph](../agents/debug-a-failed-graph.md)** — the dense reference version of this page, for agents.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,11 @@ nav:
     - CLI Commands: cli/commands.md
     - ACLI Output Format: cli/acli.md
     - Stdlib Catalogue: stdlib/catalogue.md
-  - Tutorial: tutorial/index.md
+  - Tutorial:
+    - Core concepts: tutorial/concepts.md
+    - Walkthrough — citecheck as stages: tutorial/index.md
+    - Compose with an LLM: tutorial/llm-compose.md
+    - When things go wrong: tutorial/when-things-go-wrong.md
   - Examples:
     - Demo Gallery: demo.md
     - Example Index: examples/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,13 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started/index.md
+  - For AI Agents:
+    - Overview — AGENTS.md philosophy: agents/index.md
+    - Compose a graph: agents/compose-a-graph.md
+    - Find an existing stage: agents/find-an-existing-stage.md
+    - Synthesize a new stage: agents/synthesize-a-new-stage.md
+    - Express a property: agents/express-a-property.md
+    - Debug a failed graph: agents/debug-a-failed-graph.md
   - Guides:
     - Building Custom Stages: guides/custom-stages.md
     - Composition Graphs: guides/composition-graphs.md


### PR DESCRIPTION
## Summary

Two related docs changes in one PR:

1. **Audit of existing mkdocs against v0.7.1 state** (commit 7692e06) — catches content that had drifted since Phase 9 / the v0.7 isolation release.
2. **Three new human-tutorial pages** (commit 0e4e017) — turns Tutorial from a single-page shim into a proper section.

No source code changes.

## Audit pass (commit 7692e06)

| Page | Change |
|---|---|
| `docs/index.md` | "Reproducibility is not isolation" warning replaced with v0.7 trust-model callout (Nix = reproducibility boundary, bwrap = isolation boundary, defaults from `--isolate=auto`, distro-nix caveat); "What's new in v0.2" section replaced with "What's new in v0.7"; AGENTS.md redirect added |
| `docs/architecture/nix-execution.md` | New `info` callout spelling out reproducibility-and-isolation-are-separate-boundaries for the L1 chapter |
| `docs/architecture/stage-identity.md` | Fixed the `canonical_id` removal claim (alias still accepted through v0.7.x; removal slated for v0.8, not v0.7.0) |
| `docs/tutorial/index.md` | `v0.1.0` install URLs updated to `releases/latest` + v0.7.1 as example version; `cargo install noether-cli` path added |
| `docs/roadmap.md` | Milestones table added (M1 / M2 / M2.4 / M2.5 / M2.x / M3 / M3.x / M4 / Phase-2-isolation) alongside the existing phases |
| `docs/changelog.md` | 0.7.0 and 0.7.1 entries added with a callout pointing at root CHANGELOG.md as authoritative |
| `mkdocs.yml` | "For AI Agents" nav section added (was added in #38 but not committed to this audit) |
| `docs/agents/index.md` | New MkDocs landing page explaining the two-doc-set philosophy |

## New tutorial pages (commit 0e4e017)

- **`tutorial/concepts.md`** — 5-minute mental model. Content-addressed identity (`StageId` vs `SignatureId`), structural types + width subtyping, effects as declared-not-inferred, composition graph shape, reproducibility vs isolation.
- **`tutorial/llm-compose.md`** — end-to-end `noether compose` workflow: `--dry-run` first, reading the `synthesized` array, guarding with `--budget-cents` / `--allow-effects`, reading traces, the `--verbose` transcript, the compose cache.
- **`tutorial/when-things-go-wrong.md`** — narrative exit-code reference (1 = parse/IO/resolution, 2 = validation/policy, 3 = runtime). Mirrors the agent playbook but paced for a human reader, with diagnosis recipes at the bottom (CI vs local, reproducing someone else's trace, `compose` picking the wrong stage, etc.).

`mkdocs.yml` nav restructured so Tutorial is now a 4-page section.

### Honest caveat on the existing walkthrough

`tutorial/index.md` (the `citecheck` walkthrough) uses several commands and graph shapes that don't match the current v0.7.x CLI — `noether lint`, `noether run --stage <name>`, `noether skill`, the `{"sequence": …, "parallel": …, "bind": …}` Lagrange shape. Per the repo's "trust code not docs" posture, I didn't silently paper over this: the page gains a `warning` admonition at the top pointing readers at the new pages with verified commands, and the walkthrough body is marked as pending rewrite. Flagging this openly here for follow-up.

## Test plan

- [x] `mkdocs build` succeeds on the new pages with no new warnings (pre-existing warnings on `../../STABILITY.md` / `../../SECURITY.md` links are unchanged by this PR)
- [x] New nav section renders
- [ ] `mkdocs serve` local smoke
- [ ] Reviewer: sanity-check the concepts page — it's the most load-bearing of the three and the one most likely to be read cold

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>