### PR TITLE
ci: add cargo-llvm-cov coverage reporting (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,56 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
         run: cargo test --doc -p noether-core -p noether-store
+
+  coverage:
+    name: Coverage (cargo-llvm-cov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      # Collect coverage per crate so each upload carries a flag. The
+      # selection mirrors the `test` job — only crates whose tests run on
+      # CI today are instrumented. `codecov.yml` targets reference these
+      # flags. First run on main produces the baseline; do not assert a
+      # specific percentage in PR descriptions.
+      - name: Coverage — noether-core
+        run: |
+          cargo llvm-cov -p noether-core \
+            --lcov --output-path coverage-core.lcov \
+            --ignore-filename-regex '(tests?/|examples/)'
+      - name: Coverage — noether-store
+        run: |
+          cargo llvm-cov -p noether-store \
+            --lcov --output-path coverage-store.lcov \
+            --ignore-filename-regex '(tests?/|examples/)'
+      - name: Coverage — noether-engine
+        run: |
+          cargo llvm-cov -p noether-engine --lib \
+            --lcov --output-path coverage-engine.lcov \
+            --ignore-filename-regex '(tests?/|examples/)'
+      - name: Upload noether-core coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage-core.lcov
+          flags: core
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload noether-store coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage-store.lcov
+          flags: store
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload noether-engine coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage-engine.lcov
+          flags: engine
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,128 @@
+# Codecov config — wired by ci/issue-43-coverage (closes #43).
+#
+# Coverage is collected in .github/workflows/ci.yml, job `coverage`, via
+# `cargo llvm-cov`. The first run on main produces the baseline — the
+# numbers in this file are initial targets, not observed values.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    # Wait until the coverage job has uploaded before posting the PR
+    # comment so reviewers see numbers, not a pending state.
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    # Project-wide gate: total line coverage must not regress by more
+    # than 1 percentage point against `main`. First run establishes the
+    # baseline; informational until then.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+      # Stable crates — the composition engine's trusted core. Worth a
+      # fixed floor, not just a regression gate.
+      core:
+        target: 80%
+        threshold: 1%
+        flags:
+          - core
+      engine:
+        target: 80%
+        threshold: 1%
+        flags:
+          - engine
+      store:
+        target: 80%
+        threshold: 1%
+        flags:
+          - store
+
+    # Patch coverage: new lines touched by a PR should be reasonably
+    # tested. `auto` makes this advisory at first — we'll tighten once
+    # the baseline settles.
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Component management lets codecov split the workspace report by crate
+# without requiring per-crate flag uploads. `flags` above still work for
+# status gates; `component_management` drives the UI breakdown and the
+# informational (non-blocking) targets for the research-stage crates.
+component_management:
+  individual_components:
+    - component_id: core
+      name: noether-core
+      paths:
+        - crates/noether-core/**
+    - component_id: engine
+      name: noether-engine
+      paths:
+        - crates/noether-engine/**
+    - component_id: store
+      name: noether-store
+      paths:
+        - crates/noether-store/**
+    # Research-stage crates — the v0.4 grid and the cron scheduler have
+    # sparse tests today (noether-scheduler and noether-grid-worker are
+    # binary-only; noether-grid-broker has one e2e test). Floor is set
+    # low and informational so the first baseline isn't a red wall; the
+    # floor tightens once tests land.
+    - component_id: grid-broker
+      name: noether-grid-broker
+      paths:
+        - crates/noether-grid-broker/**
+      statuses:
+        - type: project
+          target: 60%
+          informational: true
+    - component_id: grid-worker
+      name: noether-grid-worker
+      paths:
+        - crates/noether-grid-worker/**
+      statuses:
+        - type: project
+          target: 60%
+          informational: true
+    - component_id: scheduler
+      name: noether-scheduler
+      paths:
+        - crates/noether-scheduler/**
+      statuses:
+        - type: project
+          target: 60%
+          informational: true
+
+# Exclude generated/test-only files from the report so uncovered error
+# paths aren't diluted. Mirrors the --ignore-filename-regex used in CI.
+ignore:
+  - "**/tests/**"
+  - "**/examples/**"
+  - "crates/noether-cli/**"       # needs Nix at runtime; not run under cov
+  - "crates/noether-sandbox/**"   # needs bwrap; not run under cov
+  - "crates/noether-isolation/**" # covered separately when tests expand
+
+flags:
+  core:
+    paths:
+      - crates/noether-core/
+    carryforward: true
+  engine:
+    paths:
+      - crates/noether-engine/
+    carryforward: true
+  store:
+    paths:
+      - crates/noether-store/
+    carryforward: true
+
+comment:
+  layout: "header, diff, components, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Wires `cargo-llvm-cov` into CI and adds a `codecov.yml` with the thresholds called out in #43. No Rust source changes — coverage is collected on what the existing `test` job already runs; the first CI run on `main` produces the baseline.

Closes #43.

## What the new job does

New `coverage` job in `.github/workflows/ci.yml`:

- Installs `cargo-llvm-cov` via `taiki-e/install-action@cargo-llvm-cov` (prebuilt binary — faster than `cargo install`, same result).
- Runs coverage per crate so each upload carries a flag: `noether-core`, `noether-store`, `noether-engine --lib`. This mirrors exactly what the `test` job runs — adding crates that don't have CI-safe tests today (Nix-dependent, bwrap-dependent, or bin-only with no tests) would turn the baseline into noise.
- Uploads three lcov files to Codecov via `codecov/codecov-action@v4` under `flags: core | store | engine`.
- `--ignore-filename-regex '(tests?/|examples/)'` on every run so the report isn't diluted by test helpers.

## Thresholds in `codecov.yml`

| Where | Target | Regression gate |
|---|---|---|
| Project total | auto (baseline) | fail on -1pp vs `main` |
| `noether-core` (flag: `core`) | 80% | -1pp |
| `noether-engine` (flag: `engine`) | 80% | -1pp |
| `noether-store` (flag: `store`) | 80% | -1pp |
| `noether-grid-broker` | 60% | **informational only** |
| `noether-grid-worker` | 60% | **informational only** |
| `noether-scheduler` | 60% | **informational only** |

The three research-flagged crates are advisory, not blocking. Reasons, honestly:

- `noether-scheduler` and `noether-grid-worker` are `src/main.rs`-only — no lib target, no tests today.
- `noether-grid-broker` has one integration test (`tests/dispatch_e2e.rs`) that spawns the broker binary and a stub worker; it isn't run under coverage in this PR (coverage runs match the `test` job, which doesn't run it either).

So the 60% floor for those three is aspirational until tests land, and `informational: true` makes codecov display the number without gating merges on it. Once tests land in those crates, flip `informational: true` off.

Patch coverage is set to `auto` for the same reason — tightening it before we have a baseline would just produce false positives on the first few PRs.

## What this deliberately doesn't do

- No new tests — per the issue, the first run produces the baseline; we don't chase numbers with synthetic coverage.
- No Rust source changes. `Cargo.lock` / `Cargo.toml` untouched.
- No `--workspace` coverage yet. The issue's code example shows `--workspace`, but `cargo test --workspace` currently fails on CI for this repo (`noether-cli` tests want Nix, sandbox tests want bwrap). Widening the coverage run belongs to a separate PR that also widens `test`.

## For the issue author / repo owner

- **You'll need to add `CODECOV_TOKEN` as a repo secret before the first merge-to-`main` run** — the action step reads `${{ secrets.CODECOV_TOKEN }}` and `fail_ci_if_error: false` will let it no-op quietly if the secret is missing, but the upload won't actually happen. (Public repos on codecov.io can sometimes upload tokenless, but it's flaky; the token is safer.)
- The baseline number only becomes real after the first run on `main`. Don't merge if that number surprises you — we can tighten the 80% targets downward (or upward) once we see reality.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('codecov.yml'))"` — clean
- [x] `cargo fmt --check` — clean (no Rust touched, but the pre-commit hook runs it)
- [ ] First CI run on this branch — watch the `coverage` job, confirm lcov upload succeeds (or fails cleanly if the token isn't set yet)
- [ ] Merge to `main` — confirm Codecov picks up the baseline and the PR-comment layout renders

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>