### PR TITLE
reliability: convert CLI-reachable unwrap()/expect() to Result (#42)

### DIFF
--- a/crates/noether-engine/src/executor/nix.rs
+++ b/crates/noether-engine/src/executor/nix.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 //! Nix-based executor for synthesized stages.
 //!
 //! Runs stage implementations as subprocesses using `nix run nixpkgs#<runtime>`,
@@ -634,35 +637,36 @@ impl NixExecutor {
     fn extract_pip_requirements(code: &str) -> Option<String> {
         for line in code.lines() {
             let trimmed = line.trim();
-            if trimmed.starts_with("# requires:") {
-                let reqs = trimmed.strip_prefix("# requires:").unwrap().trim();
-                if reqs.is_empty() {
-                    continue;
-                }
-                let valid: Vec<String> = reqs
-                    .split(',')
-                    .map(|s| s.trim())
-                    .filter(|s| !s.is_empty())
-                    .filter(|s| match validate_pip_spec(s) {
-                        Ok(()) => true,
-                        Err(reason) => {
-                            eprintln!(
-                                "[noether] rejected `# requires:` entry {s:?} ({reason}); skipping"
-                            );
-                            false
-                        }
-                    })
-                    .map(|s| s.to_string())
-                    .collect();
-
-                if valid.is_empty() {
-                    eprintln!(
-                        "[noether] all `# requires:` entries rejected (raw={reqs:?}); falling back to default Nix runtime"
-                    );
-                    return None;
-                }
-                return Some(valid.join(", "));
+            let Some(reqs_raw) = trimmed.strip_prefix("# requires:") else {
+                continue;
+            };
+            let reqs = reqs_raw.trim();
+            if reqs.is_empty() {
+                continue;
             }
+            let valid: Vec<String> = reqs
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .filter(|s| match validate_pip_spec(s) {
+                    Ok(()) => true,
+                    Err(reason) => {
+                        eprintln!(
+                            "[noether] rejected `# requires:` entry {s:?} ({reason}); skipping"
+                        );
+                        false
+                    }
+                })
+                .map(|s| s.to_string())
+                .collect();
+
+            if valid.is_empty() {
+                eprintln!(
+                    "[noether] all `# requires:` entries rejected (raw={reqs:?}); falling back to default Nix runtime"
+                );
+                return None;
+            }
+            return Some(valid.join(", "));
         }
         None
     }

--- a/crates/noether-engine/src/executor/runner.rs
+++ b/crates/noether-engine/src/executor/runner.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use super::{ExecutionError, StageExecutor};
 use crate::executor::pure_cache::PureStageCache;
 use crate::lagrange::CompositionNode;
@@ -157,6 +160,11 @@ fn execute_node<E: StageExecutor + Sync>(
             // Execute all branches concurrently. Each branch gets its own
             // trace list; the Pure cache is NOT shared across parallel branches
             // to avoid any locking overhead.
+            //
+            // A panicking worker thread surfaces as a typed
+            // `ExecutionError::StageFailed` rather than propagating the
+            // panic — CLI callers rely on `Result` propagation to emit
+            // structured ACLI errors with non-zero exit codes.
             let branch_results = std::thread::scope(|s| {
                 let handles: Vec<_> = branch_data
                     .iter()
@@ -178,7 +186,20 @@ fn execute_node<E: StageExecutor + Sync>(
                     .collect();
                 handles
                     .into_iter()
-                    .map(|h| h.join().expect("parallel branch panicked"))
+                    .zip(branch_data.iter())
+                    .map(|(h, (name, _, _))| match h.join() {
+                        Ok(tuple) => tuple,
+                        Err(_panic) => (
+                            *name,
+                            Err(ExecutionError::StageFailed {
+                                stage_id: StageId(format!("parallel:{name}")),
+                                message: format!(
+                                    "parallel branch {name:?} panicked during execution"
+                                ),
+                            }),
+                            Vec::new(),
+                        ),
+                    })
                     .collect::<Vec<_>>()
             });
 
@@ -270,6 +291,9 @@ fn execute_node<E: StageExecutor + Sync>(
             let bindings_vec: Vec<(&str, &CompositionNode)> =
                 bindings.iter().map(|(n, b)| (n.as_str(), b)).collect();
 
+            // A panicking binding thread surfaces as a typed
+            // `ExecutionError::StageFailed` rather than propagating the
+            // panic (same rationale as Parallel above).
             let binding_results = std::thread::scope(|s| {
                 let handles: Vec<_> = bindings_vec
                     .iter()
@@ -285,7 +309,18 @@ fn execute_node<E: StageExecutor + Sync>(
                     .collect();
                 handles
                     .into_iter()
-                    .map(|h| h.join().expect("Let binding panicked"))
+                    .zip(bindings_vec.iter())
+                    .map(|(h, (name, _))| match h.join() {
+                        Ok(tuple) => tuple,
+                        Err(_panic) => (
+                            *name,
+                            Err(ExecutionError::StageFailed {
+                                stage_id: StageId(format!("let:{name}")),
+                                message: format!("let binding {name:?} panicked during execution"),
+                            }),
+                            Vec::new(),
+                        ),
+                    })
                     .collect::<Vec<_>>()
             });
 
@@ -533,6 +568,45 @@ mod tests {
         };
         let result = run_composition(&node, &json!("in"), &executor, "test").unwrap();
         assert_eq!(result.output, json!(["r1", "r2"]));
+    }
+
+    /// Executor that panics for a configured stage id. Used to exercise the
+    /// parallel/Let branch panic-to-error conversion.
+    struct PanickingExecutor {
+        panic_on: String,
+    }
+
+    impl StageExecutor for PanickingExecutor {
+        fn execute(&self, stage_id: &StageId, _input: &Value) -> Result<Value, ExecutionError> {
+            if stage_id.0 == self.panic_on {
+                panic!("intentional test panic");
+            }
+            Ok(Value::Null)
+        }
+    }
+
+    #[test]
+    fn parallel_branch_panic_becomes_execution_error() {
+        // A panicking stage inside a parallel branch must surface as a typed
+        // ExecutionError — not propagate the panic up to the CLI process.
+        let executor = PanickingExecutor {
+            panic_on: "boom".into(),
+        };
+        let node = CompositionNode::Parallel {
+            branches: BTreeMap::from([
+                ("left".into(), stage("boom")),
+                ("right".into(), stage("ok")),
+            ]),
+        };
+        let result = run_composition(&node, &json!({}), &executor, "test");
+        assert!(
+            matches!(
+                result,
+                Err(ExecutionError::StageFailed { ref message, .. })
+                    if message.contains("panicked")
+            ),
+            "expected StageFailed with panic marker, got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/noether-engine/src/index/cache.rs
+++ b/crates/noether-engine/src/index/cache.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use super::embedding::{Embedding, EmbeddingError, EmbeddingProvider};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -169,6 +172,19 @@ impl CachedEmbeddingProvider {
                     std::thread::sleep(inter_batch_delay);
                 }
                 let part = self.inner.embed_batch(slice)?;
+                // A well-behaved provider returns exactly one embedding per
+                // input text. A misbehaving one (truncated response, rate-
+                // limit short-read, etc.) would desync `consumed` against
+                // `miss_indices` and leave some cache slots unfilled — the
+                // final `cache.get(h).expect(..)` used to panic here. Bail
+                // as a typed provider error instead.
+                if part.len() != slice.len() {
+                    return Err(EmbeddingError::Provider(format!(
+                        "embed_batch returned {} embeddings for {} inputs",
+                        part.len(),
+                        slice.len()
+                    )));
+                }
                 for (j, emb) in part.into_iter().enumerate() {
                     let idx = miss_indices[consumed + j];
                     self.cache.insert(hashes[idx].clone(), emb);
@@ -179,10 +195,20 @@ impl CachedEmbeddingProvider {
             }
         }
 
-        Ok(hashes
-            .iter()
-            .map(|h| self.cache.get(h).cloned().expect("just inserted"))
-            .collect())
+        let mut out = Vec::with_capacity(hashes.len());
+        for h in &hashes {
+            match self.cache.get(h).cloned() {
+                Some(e) => out.push(e),
+                None => {
+                    return Err(EmbeddingError::Provider(
+                        "embedding cache missing an entry after batch fill; provider or cache \
+                         layer returned inconsistent results"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(out)
     }
 
     /// Backward-compatible wrapper: no inter-batch sleep, single final flush.
@@ -193,5 +219,44 @@ impl CachedEmbeddingProvider {
         chunk_size: usize,
     ) -> Result<Vec<Embedding>, EmbeddingError> {
         self.embed_batch_cached_paced(texts, chunk_size, std::time::Duration::ZERO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Provider that returns fewer embeddings than requested on the first
+    /// batch — simulates a misbehaving remote that truncates responses.
+    struct ShortBatchProvider;
+
+    impl EmbeddingProvider for ShortBatchProvider {
+        fn dimensions(&self) -> usize {
+            4
+        }
+        fn embed(&self, _text: &str) -> Result<Embedding, EmbeddingError> {
+            Ok(vec![0.0; 4])
+        }
+        fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Embedding>, EmbeddingError> {
+            // Deliberately drop the last entry.
+            Ok(texts
+                .iter()
+                .take(texts.len().saturating_sub(1))
+                .map(|_| vec![0.0; 4])
+                .collect())
+        }
+    }
+
+    #[test]
+    fn short_batch_becomes_provider_error_not_panic() {
+        let tmp = std::env::temp_dir().join("noether-cache-short-batch-test.json");
+        let _ = std::fs::remove_file(&tmp);
+        let mut cp = CachedEmbeddingProvider::new(Box::new(ShortBatchProvider), tmp);
+        let texts = ["a", "b", "c"];
+        let r = cp.embed_batch_cached(&texts, 8);
+        assert!(
+            matches!(r, Err(EmbeddingError::Provider(ref m)) if m.contains("embed_batch returned")),
+            "expected Provider error, got: {r:?}"
+        );
     }
 }

--- a/crates/noether-engine/src/index/embedding.rs
+++ b/crates/noether-engine/src/index/embedding.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use sha2::{Digest, Sha256};
 
 pub type Embedding = Vec<f32>;

--- a/crates/noether-engine/src/index/mod.rs
+++ b/crates/noether-engine/src/index/mod.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 pub mod cache;
 pub mod embedding;
 pub mod search;

--- a/crates/noether-engine/src/index/search.rs
+++ b/crates/noether-engine/src/index/search.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use super::embedding::Embedding;
 use noether_core::stage::StageId;
 

--- a/crates/noether-engine/src/index/text.rs
+++ b/crates/noether-engine/src/index/text.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use noether_core::stage::Stage;
 
 /// Generate text for the signature index: "input_type -> output_type".

--- a/docs/engineering/unwrap-audit-issue-42.md
+++ b/docs/engineering/unwrap-audit-issue-42.md
@@ -1,0 +1,61 @@
+# `unwrap()` / `expect()` audit — issue #42
+
+Scope: `crates/noether-engine/src/executor/runner.rs`,
+`crates/noether-engine/src/executor/nix.rs`, and
+`crates/noether-engine/src/index/**`.
+
+Each row is a single call site in the in-scope files. Test-module
+unwraps (`#[cfg(test)]`) are not listed — `clippy::unwrap_used` is
+suppressed for test code via a module-level `#![cfg_attr(test,
+allow(clippy::unwrap_used))]`, which is considered acceptable for
+assertion-style tests.
+
+| File | Line (approx) | Call | Classification | Notes |
+|---|---|---|---|---|
+| `executor/runner.rs` | ~120 | `.find(...).unwrap_or(&"items")` | Safe (not unwrap) | `unwrap_or` — infallible fallback. |
+| `executor/runner.rs` | ~152 | `obj.get(name).cloned().unwrap_or_else(...)` | Safe (not unwrap) | `unwrap_or_else` — infallible fallback. |
+| `executor/runner.rs` | ~190 | `h.join().expect("parallel branch panicked")` | **Converted** | Now match on `h.join()` and emit `ExecutionError::StageFailed` with a `parallel:<name>` synthetic stage id when a branch thread panics. |
+| `executor/runner.rs` | ~235 | `obj.get(...).cloned().unwrap_or(Value::Null)` | Safe (not unwrap) | `unwrap_or` — infallible fallback. |
+| `executor/runner.rs` | ~265 | `last_err.unwrap_or(ExecutionError::RetryExhausted { .. })` | Safe (not unwrap) | `unwrap_or` — infallible fallback. |
+| `executor/runner.rs` | ~300 | `h.join().expect("Let binding panicked")` | **Converted** | Same treatment as the Parallel branch — `let:<name>` synthetic stage id. |
+| `executor/runner.rs` | ~382 | `serde_json::to_vec(value).unwrap_or_default()` | Safe (not unwrap) | `unwrap_or_default` — `serde_json::to_vec` on an in-memory `Value` is effectively total; an empty-bytes hash on a hypothetical failure is acceptable for a trace-only hash. |
+| `executor/runner.rs` | ~424 | `.unwrap_or("remote reported ok=false without error message")` | Safe (not unwrap) | `unwrap_or` — infallible fallback. |
+| `executor/nix.rs` | ~160 | `std::env::var_os("PATH")?` | Safe (not unwrap) | Returns `Option` via `?`. |
+| `executor/nix.rs` | ~182 | `std::env::var("HOME").unwrap_or_else(...)` | Safe (not unwrap) | `unwrap_or_else` — falls back to `/tmp`. |
+| `executor/nix.rs` | ~341 | `serde_json::to_string(input).unwrap_or_default()` | Safe (not unwrap) | `unwrap_or_default` — stdin passes an empty string on the (practically impossible) serialise failure; the child then reports a parse error. |
+| `executor/nix.rs` | ~355 | `script.to_str().unwrap_or("/dev/null")` | Safe (not unwrap) | `unwrap_or` — invalid-UTF-8 script paths fall through and fail cleanly at `Command::new`. |
+| `executor/nix.rs` | ~567 | `script.to_str().unwrap_or("/dev/null")` | Safe (not unwrap) | Same as above. |
+| `executor/nix.rs` | ~637 | `trimmed.strip_prefix("# requires:").unwrap().trim()` | **Converted** | Rewritten with `let Some(reqs_raw) = trimmed.strip_prefix(...)` so the unwrap disappears altogether. |
+| `index/cache.rs` | ~184 | `.expect("just inserted")` | **Converted** | Replaced with a `match`ed lookup that returns `EmbeddingError::Provider`. A companion length check on `embed_batch` responses catches the real failure mode — a short-read from a misbehaving remote provider — before it gets to this call site. |
+| `index/cache.rs` | ~90 | `flush()` in `Drop` | Safe (not unwrap) | `Drop` impl does not unwrap — it ignores `std::fs::write` failures on purpose; noisy drop-time errors would worsen, not improve, the crash path. |
+| `index/embedding.rs` | — | (none in production code) | — | Only test-module unwraps. |
+| `index/search.rs` | — | (none in production code) | — | Only test-module unwraps. |
+| `index/text.rs` | — | (none in production code) | — | No unwraps. |
+| `index/mod.rs` | — | (none in production code) | — | Only test-module unwraps; floating-point `partial_cmp(...).unwrap_or(Equal)` pattern used in sort comparators is `unwrap_or`, not `unwrap`. |
+
+## Modules with `#![warn(clippy::unwrap_used)]` applied
+
+All in-scope modules were cleaned end-to-end and now carry the warn
+attribute at module scope:
+
+- `executor/runner.rs`
+- `executor/nix.rs`
+- `index/mod.rs`
+- `index/cache.rs`
+- `index/embedding.rs`
+- `index/search.rs`
+- `index/text.rs`
+
+## Out-of-scope observations
+
+A broader audit (outside issue #42) would want to look at:
+
+- `executor/runtime.rs`, `executor/budget.rs`, `executor/stages/*` —
+  several `unwrap()` sites tied to stage-stdlib helpers. These run in
+  the same CLI `noether run` code path but were not in the issue scope.
+- `planner.rs` / `checker.rs` — a handful of invariant-enforced
+  `expect` calls on graph traversal. Panics here imply a malformed
+  post-resolver graph; worth their own follow-up.
+- `noether-cli` / `noether-grid-*` / `noether-scheduler` — explicitly
+  out-of-scope per the issue. Their panics need a separate tracking
+  issue.


### PR DESCRIPTION
## Summary

Three call sites in the executor + index hot paths could turn a
malformed-input or misbehaving-provider situation into a process
panic rather than a typed ACLI error. This PR converts them to
`Result` propagation so `noether run` and `noether compose` emit
a structured ACLI error with a non-zero exit instead of
unwinding out of the process.

Does not touch `noether-cli`, `noether-grid-*`, `noether-scheduler`,
or `noether-core` / `noether-store` — those panics are explicitly
out of scope per the issue.

## What was converted

- **`executor/runner.rs`** — the Parallel and Let scoped-thread joins
  used `.expect("... panicked")`. A panicking stage inside a branch
  used to propagate out of `run_composition` as an unwinding panic.
  Now converted to `ExecutionError::StageFailed` against a synthetic
  `parallel:<name>` / `let:<name>` stage id.
- **`index/cache.rs`** — `embed_batch_cached_paced` trusted
  `inner.embed_batch` to return exactly one embedding per input.
  A short-read from a rate-limited remote provider desynced the
  miss-index counter and tripped a later `.expect("just inserted")`.
  Added a length check that surfaces as `EmbeddingError::Provider`
  and rewrote the final collect with a graceful error path.
- **`executor/nix.rs`** — the `# requires:` parser called
  `strip_prefix(...).unwrap()` immediately after a `starts_with`
  check. Invariant-safe, but the pattern is fragile. Rewrote with
  `let Some(...) = strip_prefix` so the unwrap disappears.

## What was deliberately left

- `unwrap_or` / `unwrap_or_else` / `unwrap_or_default` call sites —
  these can't panic by construction.
- The `serde_json::to_vec(value).unwrap_or_default()` in `hash_value`
  (runner.rs) — `serde_json::to_vec` on an in-memory `Value` is
  effectively total; the fallback path is a trace-only hash where
  an empty-bytes digest is acceptable.
- Thread-join panic-message formatting — kept minimal; the composition
  trace already carries the per-stage failure metadata.
- Every out-of-scope `unwrap()` in `executor/runtime.rs`,
  `executor/stages/*`, `planner.rs`, and `checker.rs`.
  Flagged in the audit doc as follow-up work.

See `docs/engineering/unwrap-audit-issue-42.md` for the row-by-row
classification of every remaining `unwrap`-family call site in the
in-scope files.

## Acceptance-criteria mapping

| Criterion | Where addressed |
|---|---|
| CLI-reachable panics from malformed stage output become typed ACLI errors with non-zero exit + structured JSON | `runner.rs` panic-to-`ExecutionError::StageFailed` conversion. CLI already maps `ExecutionError` → `acli_error(..)` + `exit(3)` in `noether-cli/src/commands/run.rs`. |
| `clippy::unwrap_used` warn-level at module scope in cleaned modules | `#![warn(clippy::unwrap_used)]` added to `runner.rs`, `nix.rs`, `index/mod.rs`, `index/cache.rs`, `index/embedding.rs`, `index/search.rs`, `index/text.rs`. Paired with `#![cfg_attr(test, allow(clippy::unwrap_used))]` since tests keep using `unwrap()` for assertion-style failures. |
| Audit table committed under `docs/engineering/` | `docs/engineering/unwrap-audit-issue-42.md`. |

## Test plan

- [x] `cargo test --workspace` — all tests pass (284 in noether-engine, +2 new regression tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (pre-commit hook mirror)
- [x] `cargo fmt --check` clean
- [x] New regression tests:
  - `executor::runner::tests::parallel_branch_panic_becomes_execution_error`
  - `index::cache::tests::short_batch_becomes_provider_error_not_panic`

Closes #42.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>