### PR TITLE
chore: prep v0.7.2 — fix stage verify flag-drift + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.7.2 — 2026-04-20
+
+Maintenance release — one small feature, hardening, docs audit, CI coverage.
+
 ### Added — `IsolationPolicy.rw_binds` ([#39](https://github.com/alpibrusl/noether/issues/39))
 
 Optional `Vec<RwBind>` on `IsolationPolicy`, mirroring `ro_binds`. Consumers with a richer filesystem trust model (agentspec's `filesystem: scoped`, the "agent operates on my `~/projects/foo` RW" pattern) can now declare read-write bind mounts without routing through `work_host` — which is reserved for the single sandbox scratch dir.
@@ -13,9 +17,31 @@ Optional `Vec<RwBind>` on `IsolationPolicy`, mirroring `ro_binds`. Consumers wit
 - `build_bwrap_command` emits `--bind <host> <sandbox>` per entry, in a documented order: **`rw_binds` → `ro_binds` → `work_host`.** RW first lets a narrower RO entry shadow a broader RW parent (the `workdir RW, .ssh RO` case); `work_host` renders last so its `/work` mapping wins.
 - `from_effects` does **not** produce `rw_binds`. The `EffectSet` vocabulary has no `FsWrite(path)` variant to drive it, so any `RwBind` is a caller-authored trust decision. The `RwBind` rustdoc spells this out — the crate can't validate whether binding `/home/user` RW is sensible; that responsibility lives with the caller.
 
-### Notes for downstream consumers
-
 agentspec's `TrustSpec.filesystem: scoped` mode can now delegate to `noether-sandbox` via a policy carrying explicit `rw_binds` — see [agentspec #22](https://github.com/alpibrusl/agentspec/pull/22) for the integration path.
+
+### Changed — CLI-reachable `unwrap()` / `expect()` in executor + index converted to `Result` ([#42](https://github.com/alpibrusl/noether/issues/42))
+
+Thread-join panics in `Parallel` and `Let` branches no longer propagate as process-level panics; they surface as typed `ExecutionError::StageFailed` with synthetic `parallel:<name>` / `let:<name>` stage ids so the ACLI envelope shape stays structured. The `CachedEmbeddingProvider` short-read panic was hardened into a typed `EmbeddingError::Provider` with an upstream length check that catches the real failure mode before the in-memory cache lookup. `NixExecutor::extract_pip_requirements` lost its `strip_prefix(...).unwrap()` via an `if let Some(...) = ... else { continue }` rewrite.
+
+Seven in-scope modules now carry `#![warn(clippy::unwrap_used)]` with the standard `#[cfg_attr(test, allow(...))]` pairing, preventing regression on newly-added panics. An audit table — one row per `unwrap`/`expect` call site in the in-scope files — lives at `docs/engineering/unwrap-audit-issue-42.md`, distinguishing converted vs invariant-safe. Out-of-scope hot paths (`executor/runtime.rs`, `executor/budget.rs`, `executor/stages/*`, `planner.rs`, `checker.rs`, grid/scheduler/cli crates) are flagged for a follow-up.
+
+### Changed — `noether stage verify` flag-name drift cleaned up
+
+Earlier release notes and three agent playbooks referred to `--with-properties` / `--signatures-only` flags that never landed. The real v0.7.0+ CLI uses `--signatures` (restricts to signature checks) and `--properties` (restricts to property checks); invoking `stage verify` with no flag runs both. The docs, CHANGELOG, roadmap, and `Stage::check_properties` rustdoc now match the shipped CLI.
+
+No code change — the drift was docs-only. Called out here so readers of the v0.7.0 entry don't trip over the old wording.
+
+### Docs — mkdocs audit + human tutorial section ([#41](https://github.com/alpibrusl/noether/pull/41))
+
+Systematic pass over `docs/` to catch content that had drifted against v0.7.x state. The `docs/index.md` trust-model callout, `nix-execution.md` reproducibility-vs-isolation admonition, and `stage-identity.md` `canonical_id`-removal phrasing all got corrected. Added a milestones table to `roadmap.md` (M1 / M2 / M2.4 / M2.5 / M2.x / M3) alongside the existing phase table, and 0.7.0 + 0.7.1 entries to `docs/changelog.md` with a pointer at root CHANGELOG.md as authoritative.
+
+New three-page human tutorial section: `concepts.md` (5-minute mental model — stage identity, structural types, effects, composition, reproducibility vs isolation), `llm-compose.md` (end-to-end `noether compose` workflow), `when-things-go-wrong.md` (exit-code contract, isolation failures, diagnosis recipes). The existing `citecheck` walkthrough gains a front-of-page warning admonition flagging that the body uses CLI shapes (`noether lint`, `--stage`, `noether skill`, pre-Lagrange graph format) that never landed — rewrite deferred.
+
+### CI — coverage reporting via cargo-llvm-cov ([#43](https://github.com/alpibrusl/noether/issues/43))
+
+New `coverage` job in CI runs `cargo-llvm-cov` on `noether-core`, `noether-engine --lib`, and `noether-store`, uploads to Codecov. `codecov.yml` at repo root defines thresholds: 80% blocking on the three stable crates, 60% informational (non-blocking) on `noether-grid-broker` / `noether-grid-worker` / `noether-scheduler` to avoid red-walling the baseline against known-empty data.
+
+**Operators:** add `CODECOV_TOKEN` as a repo secret before relying on Codecov dashboards; `fail_ci_if_error: false` is set so missing token silently no-ops the upload step rather than red-lining CI.
 
 ## 0.7.1 — 2026-04-19
 
@@ -142,9 +168,11 @@ Composition graphs pin by `signature_id` by default (new `Pinning::Signature` on
 
 Stages on the wire now carry both `id` and `signature_id` fields. `canonical_id` is accepted on deserialization as a deprecated alias for `signature_id` (removal scheduled for 0.7.x) for v0.6.x back-compat.
 
-### Added — `noether stage verify --with-properties`
+### Added — properties checked by default in `noether stage verify`
 
-`noether stage verify <id>` now checks both signatures and declarative properties (against the stage's own `examples`) by default. Pass `--signatures-only` for the v0.6 behaviour.
+`noether stage verify <id>` now checks both the Ed25519 signature and the declarative properties (against the stage's own `examples`) by default. Passing `--signatures` restricts the run to signature checks; `--properties` restricts to properties. Passing both (or neither) runs both checks, as does the default invocation.
+
+(Early drafts of these release notes referred to `--with-properties` / `--signatures-only`. Those flag names never landed — the shipped CLI uses `--signatures` / `--properties` as described above.)
 
 ### Added — [STABILITY.md](STABILITY.md)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/noether"

--- a/crates/noether-core/src/stage/schema.rs
+++ b/crates/noether-core/src/stage/schema.rs
@@ -133,10 +133,11 @@ pub struct Stage {
 
     /// Declarative properties the stage claims to satisfy for every
     /// `(input, output)` pair. Checked against examples at registration
-    /// time (`noether stage verify --with-properties`) and optionally
-    /// at runtime. Types say *what shape* the output has; properties
-    /// say *which values* it may actually take. See
-    /// [`crate::stage::property`] for the DSL.
+    /// time (`noether stage verify` — or `noether stage verify --properties`
+    /// to restrict the run to property checks) and optionally at runtime.
+    /// Types say *what shape* the output has; properties say *which
+    /// values* it may actually take. See [`crate::stage::property`] for
+    /// the DSL.
     ///
     /// Not part of the content hash — a stage's properties can be
     /// strengthened in a follow-up release without forcing a new
@@ -177,7 +178,8 @@ impl Stage {
     /// through on under-specified stages.
     ///
     /// This is the CI-time check the M2 roadmap promises. `noether
-    /// stage verify --with-properties` wraps this with CLI reporting.
+    /// stage verify` (or `--properties` to restrict) wraps this with
+    /// CLI reporting.
     pub fn check_properties(&self) -> Result<(), CheckPropertiesError> {
         if self.properties.is_empty() {
             return Ok(());

--- a/docs/agents/express-a-property.md
+++ b/docs/agents/express-a-property.md
@@ -30,7 +30,7 @@ Attach one or more declarative property claims to a stage so its behaviour is ve
 4. **Validate at registration**:
    ```bash
    noether stage add spec.json          # ingest rejects unsatisfiable / typo'd properties
-   noether stage verify <id> --with-properties   # re-run properties against every example
+   noether stage verify <id> --properties        # re-run only the property checks against every example
    ```
 
 5. **Re-check against runtime traces** (optional but encouraged in CI):

--- a/docs/agents/find-an-existing-stage.md
+++ b/docs/agents/find-an-existing-stage.md
@@ -28,7 +28,7 @@ Find a stage already in the store that matches a given type signature or intent,
    Returns the full `Stage` struct: signature, effects, examples, properties, capabilities, cost estimate.
 4. **Verify behaviourally** when the stakes are high — run the stage's own declared examples through the executor:
    ```bash
-   noether stage verify <id> --with-properties
+   noether stage verify <id>   # signatures + properties by default; --signatures / --properties restrict
    ```
 5. **Use the stage in a graph** by dropping its id (full or 8-char prefix) into a `CompositionNode::Stage`. Default pinning is `Signature` (the resolver picks the currently-Active implementation at execution time), stable across bugfix rewrites.
 

--- a/docs/agents/synthesize-a-new-stage.md
+++ b/docs/agents/synthesize-a-new-stage.md
@@ -42,7 +42,7 @@ Author a new stage from scratch — either (a) automatically via the Composition
    The CLI computes the content hash, signs the id with your key, validates examples against the declared signature, rejects typo'd property kinds (`Property::shadowed_known_kind`), and stores under the local tenant.
 3. **Verify**:
    ```bash
-   noether stage verify <id> --with-properties
+   noether stage verify <id>   # signatures + properties by default
    ```
    Runs every declared example through the executor and checks each property claim. Fails loudly if any example mismatches or a property is violated.
 4. **Promote to Active** if it was registered as Draft:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,9 +70,11 @@ New `DeprecationReport { rewrites, events }` distinguishes routine rewrites from
 
 Two content-addressed IDs per stage: `signature_id = SHA-256(name + input + output + effects)` (stable across bugfix-only impl rewrites) and `implementation_id` aka `StageId = SHA-256(signature_id + implementation_hash)`. Graphs pin by `signature_id` by default (`Pinning::Signature`); `Pinning::Both` requires exact impl match.
 
-### Added — `noether stage verify --with-properties`
+### Added — properties checked by default in `noether stage verify`
 
-Default now checks both signatures and declarative properties against declared examples. Pass `--signatures-only` for the v0.6 behaviour.
+Default now checks both Ed25519 signatures and declarative properties against declared examples. `--signatures` restricts to signatures; `--properties` restricts to properties. Default or both flags → both checks.
+
+(Early drafts of these notes referred to `--with-properties` / `--signatures-only`; those flag names never landed.)
 
 ### Added — STABILITY.md
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ Noether shifted from sequential "phase" numbering to milestone tracking with the
 | Milestone | Name | Status | Shipped as | Key deliverables |
 |---|---|---|---|---|
 | M1 | Semantics + Canonical Form | ✅ Done | v0.5.0 | `canonicalise` for every composition op, pre-resolution `composition_id` contract, `laws.rs` property tests |
-| M2 | Stability + Versioning + Property Predicates | ✅ Done | v0.6.0 + v0.7.0 | Stage identity split (`signature_id` + `implementation_id`), graph-level pinning, declarative properties DSL (7 kinds), resolver pass, `stage verify --with-properties`, STABILITY.md, store ≤1-Active-per-signature invariant |
+| M2 | Stability + Versioning + Property Predicates | ✅ Done | v0.6.0 + v0.7.0 | Stage identity split (`signature_id` + `implementation_id`), graph-level pinning, declarative properties DSL (7 kinds), resolver pass, `stage verify` checks signatures + properties by default, STABILITY.md, store ≤1-Active-per-signature invariant |
 | M2.4 | Stage execution isolation — Phase 1 | ✅ Done | v0.7.0 | Bubblewrap sandbox by default, UID mapping to `nobody`, sandbox-private `/work` tmpfs, trusted `bwrap` path discovery, `--require-isolation` CI gate, DNS/TLS binds when network declared, adversarial escape-test suite |
 | M2.5 | Property DSL expansion | ✅ Done | v0.7.0 | `FieldLengthEq` / `FieldLengthMax` / `SubsetOf` / `Equals` / `FieldTypeIn`, typed `JsonKind` enum, shadowed-kind ingest rejection |
 | M2.x | `noether-isolation` crate extraction | ✅ Done | v0.7.1 | Standalone crate + `noether-sandbox` binary for non-Rust consumers (agentspec, future Python/Node/Go bindings) |

--- a/docs/roadmap/2026-04-18-rock-solid-plan.md
+++ b/docs/roadmap/2026-04-18-rock-solid-plan.md
@@ -113,8 +113,9 @@ semantics are expressible, testable claims — not docstring prose.
   - Universally-quantified implications over examples:
     `for all examples, if input.battery.soc_percent is null then output is null`
   - No higher-order quantification, no type-class predicates in M2
-- `noether stage verify --with-properties` — runs stage against
-  property-based inputs plus the declared predicates
+- `noether stage verify` — checks the Ed25519 signature and the
+  declared properties against the stage's examples by default;
+  `--signatures` / `--properties` restrict to one side
 - Registry stores both IDs; clients resolve `signature → latest
   implementation` by default
 


### PR DESCRIPTION
## Summary

Two related things in one PR, ahead of cutting v0.7.2:

1. **Flag-drift fix.** The v0.7.0 CHANGELOG + three agent playbooks + rustdoc + roadmap referred to `noether stage verify --with-properties` / `--signatures-only` — neither flag ever landed. The shipped CLI uses `--signatures` / `--properties` (both restrictors; default runs both). Aligned docs to the code.
2. **v0.7.2 prep.** Workspace version 0.7.1 → 0.7.2. CHANGELOG Unreleased section promoted to \`0.7.2 — 2026-04-20\` with entries summarising the four merged PRs (#47 rw_binds, #42 unwrap audit, #41 docs audit+tutorial, #43 coverage CI) + this flag-drift fix.

## Why docs→code, not code→docs

Renaming the CLI to match the aspirational doc wording (\`--with-properties\` / \`--signatures-only\`) would break anyone already using v0.7.0 or v0.7.1 with the real flags. Lower-risk direction is to align the documentation — consistent with the repo's \"trust code, not docs\" posture.

No behaviour change. All tests green.

## Files (9)

- \`CHANGELOG.md\` — v0.7.0 entry + new 0.7.2 section
- \`docs/changelog.md\` — mirror update
- \`docs/roadmap.md\` — M2 milestone row
- \`docs/roadmap/2026-04-18-rock-solid-plan.md\` — design note
- \`docs/agents/{find-an-existing-stage,express-a-property,synthesize-a-new-stage}.md\` — real CLI shape
- \`crates/noether-core/src/stage/schema.rs\` — rustdoc
- \`Cargo.toml\` — workspace version 0.7.1 → 0.7.2

## Test plan

- [x] \`cargo test --workspace\` — all 25+ test suites green
- [x] \`cargo build --workspace\` — clean
- [ ] CI to confirm (fmt/clippy/tests/doc-tests/coverage)
- [ ] After merge: tag v0.7.2 + release notes

## Post-merge

Cutting the v0.7.2 tag right after this lands. alpibrupa is waiting to kick off the agentspec \`filesystem: scoped\` → noether-sandbox flip once the tag publishes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>