### PR TITLE
ci(release): ship noether-sandbox tarballs + publish isolation/sandbox to crates.io (#51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           cargo build -p noether-cli --release --target ${{ matrix.target }}
           cargo build -p noether-scheduler --release --target ${{ matrix.target }}
+          cargo build -p noether-sandbox --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
@@ -85,12 +86,33 @@ jobs:
           echo "ASSET_CLI=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "ASSET_SCHED=$sched" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      # noether-sandbox is only packaged for Linux targets: bubblewrap
+      # is Linux-only, so shipping a sandbox tarball for macOS or Windows
+      # would deliver a binary that fails at runtime with
+      # `IsolationError::BackendUnavailable`. The build step above still
+      # compiles it on every target — that serves as a cross-platform
+      # compile-check so a future sandbox change that breaks macOS /
+      # Windows builds shows up in CI.
+      - name: Package (Linux-only — sandbox)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          DIR=target/${{ matrix.target }}/release
+          SANDBOX_ARCHIVE=noether-sandbox-${VERSION}-${{ matrix.target }}.tar.gz
+          tar czf "$SANDBOX_ARCHIVE" -C "$DIR" noether-sandbox
+          echo "ASSET_SANDBOX=$SANDBOX_ARCHIVE" >> $GITHUB_ENV
+
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
+          # ASSET_SANDBOX is only set on Linux targets (see Package
+          # step above). On macOS / Windows this expands to an empty
+          # line, which action-gh-release tolerates.
           files: |
             ${{ env.ASSET_CLI }}
             ${{ env.ASSET_SCHED }}
+            ${{ env.ASSET_SANDBOX }}
           generate_release_notes: true
 
   publish-crates:
@@ -101,16 +123,32 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # Dependency order (any publish that runs ahead of its deps will
+      # fail with "no matching package" — this is what broke v0.7.1 and
+      # v0.7.2 when noether-isolation was missing from the list):
+      #   core        — no internal deps
+      #   isolation   — depends on core
+      #   store       — depends on core
+      #   engine      — depends on core + store + isolation
+      #   cli         — depends on core + store + engine
+      #   scheduler   — depends on core + engine
+      #   sandbox     — depends on core + isolation
+      # `sleep 30` between each gives the crates.io index enough time
+      # to index the previous publish before the next resolve.
       - name: Publish crates (in dependency order)
         run: |
-          cargo publish -p noether-core  --no-verify
+          cargo publish -p noether-core        --no-verify
           sleep 30
-          cargo publish -p noether-store --no-verify
+          cargo publish -p noether-isolation   --no-verify
           sleep 30
-          cargo publish -p noether-engine --no-verify
+          cargo publish -p noether-store       --no-verify
           sleep 30
-          cargo publish -p noether-cli   --no-verify
+          cargo publish -p noether-engine      --no-verify
           sleep 30
-          cargo publish -p noether-scheduler --no-verify
+          cargo publish -p noether-cli         --no-verify
+          sleep 30
+          cargo publish -p noether-scheduler   --no-verify
+          sleep 30
+          cargo publish -p noether-sandbox     --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Closes the workflow side of #51. Two gaps in `release.yml`:

## Tarballs

`noether-sandbox` is now built on every target and packaged as a **Linux-only** tarball. Rationale: bubblewrap is Linux-only, so a `noether-sandbox-v…-apple-darwin.tar.gz` would ship a binary that fails at runtime with `IsolationError::BackendUnavailable`. The build step still compiles it on macOS and Windows (via the matrix) so future cross-platform breakage surfaces in CI; the package + upload steps skip those targets via `if: runner.os == 'Linux'`. `ASSET_SANDBOX` stays unset on non-Linux; `action-gh-release` tolerates the empty line.

## crates.io publish order

Inserted `noether-isolation` after `noether-core` and `noether-sandbox` at the end. The current order has been silently failing since v0.7.1 — `cargo publish -p noether-engine` blows up with \`no matching package named 'noether-isolation' found\` because engine depends on isolation and isolation was never published. The new chain:

```
core → isolation → store → engine → cli → scheduler → sandbox
```

Added a comment block documenting the dep graph so the next crate added knows where it slots in.

## What this does NOT fix

The broken state on crates.io today — engine/cli/scheduler stuck at 0.7.0, isolation/sandbox never published — is pre-existing. This PR fixes the *next* release cut. Republishing the in-between state (either by cutting v0.7.3 right after this merges or by one-time manual `cargo publish` runs) is a deliberate decision the maintainer should make; issue #51 tracks it.

## Test plan

- [x] YAML syntax clean (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Windows Package step no longer references `noether-sandbox.exe` — verified by diff
- [ ] End-to-end verification happens on the next tagged release; no way to dry-run the release workflow without a tag

## Related

- #51 — issue this closes (workflow side)
- #39 / #47 — rw_binds feature that motivated the question
- #37 — original sandbox extraction PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>