### PR TITLE
chore: v0.7.3 — republish to repair crates.io drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.7.3 — 2026-04-20
+
+Release-pipeline repair. **No source changes in this version — it exists to re-publish crates and ship a new set of release tarballs through the fixed workflow.**
+
+### Fixed — release-workflow drift ([#51](https://github.com/alpibrusl/noether/issues/51), [#52](https://github.com/alpibrusl/noether/pull/52))
+
+The `publish-crates` job has been silently failing since v0.7.1 because `noether-engine` depends on `noether-isolation` (introduced in v0.7.0) but the publish chain never included it. Every release cut since shipped green Build jobs, red Publish job — tags landed on GitHub while crates.io stayed behind at 0.7.0 for `noether-engine` / `noether-cli` / `noether-scheduler`, with `noether-isolation` and `noether-sandbox` never published at all.
+
+The v0.7.3 workflow:
+
+- Publishes in the correct dep order: `core → isolation → store → engine → cli → scheduler → sandbox`.
+- Ships a `noether-sandbox-<version>-<linux-target>.tar.gz` tarball on the GitHub release for each Linux target. Built on every target as a compile-check; only packaged on Linux because bubblewrap is Linux-only.
+
+### Downstream impact
+
+If you were pinned via `cargo install noether-cli` or `cargo install noether-scheduler` before v0.7.3, you were stuck on 0.7.0 and missing everything from v0.7.1 (`noether-isolation` crate, `noether-sandbox` binary) and v0.7.2 (`rw_binds`, executor panic-to-error conversions, tutorial pages, coverage CI). A `cargo install --force` after the v0.7.3 publish lifts you to the full current state.
+
 ## 0.7.2 — 2026-04-20
 
 Maintenance release — one small feature, hardening, docs audit, CI coverage.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/noether"


### PR DESCRIPTION
## Summary

No source changes. v0.7.3 exists to push the full current state through the release pipeline that PR #52 just fixed.

**Before this:** crates.io had `noether-engine` / `noether-cli` / `noether-scheduler` at 0.7.0 (stuck since the v0.7.1 publish job first failed against the missing `noether-isolation` dep). `noether-isolation` and `noether-sandbox` were never published.

**After merge + tag push:** all seven crates — `core`, `isolation`, `store`, `engine`, `cli`, `scheduler`, `sandbox` — go out at 0.7.3 in dep order. `noether-sandbox-v0.7.3-<linux-target>.tar.gz` also lands as a release asset for the first time.

## Diff

- `Cargo.toml` — workspace version 0.7.2 → 0.7.3
- `CHANGELOG.md` — 0.7.3 section explaining the drift + `cargo install --force` recovery path

## Test plan

- [x] `cargo build --workspace` — clean at 0.7.3
- [ ] CI green (waiting)
- [ ] After merge: tag v0.7.3, push, watch the release workflow publish all seven crates

## Post-merge

Tag + release notes + push → release workflow runs → the full set hits crates.io for the first time since v0.7.0. Then ping alpibrupa on #39 / #51 with the crates.io links so the agentspec `filesystem: scoped` flip can proceed.

Closes nothing directly — #51 closes when the post-merge tag ships everything successfully.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>