### PR TITLE
feat(llm): delegate CLI dispatch to llm-here-core (noether-grid migration)

### DIFF
--- a/crates/noether-engine/Cargo.toml
+++ b/crates/noether-engine/Cargo.toml
@@ -14,7 +14,7 @@ description = "Noether composition engine: Lagrange graph AST, type checker, pla
 # SQLite KV store, LLM providers, semantic index, and registry client.
 # When building for wasm32 (browser target), compile with --no-default-features.
 default = ["native"]
-native = ["dep:reqwest", "dep:rusqlite", "dep:arrow", "dep:base64"]
+native = ["dep:reqwest", "dep:rusqlite", "dep:arrow", "dep:base64", "dep:llm-here-core"]
 
 [dependencies]
 noether-core = { path = "../noether-core", version = "0.7" }
@@ -36,6 +36,10 @@ rusqlite = { version = "0.39.0", features = ["bundled"], optional = true }
 arrow = { version = "58", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.22", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
+# CLI detection + dispatch delegated to llm-here (shared across caloron,
+# agentspec, and noether-grid — see docs/research/llm-here.md). Pinned to
+# a tag until llm-here lands on crates.io.
+llm-here-core = { git = "https://github.com/alpibrusl/llm-here", tag = "v0.4.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/crates/noether-engine/src/llm/cli_provider.rs
+++ b/crates/noether-engine/src/llm/cli_provider.rs
@@ -1,103 +1,85 @@
-//! Generic subprocess-based LLM provider.
+//! Subscription CLI LLM provider — delegates to `llm-here-core`.
 //!
 //! Covers Claude Desktop / Claude CLI, Gemini CLI, Cursor Agent, and
-//! OpenCode — the four "subscription CLIs" a developer commonly has
-//! logged in on a workstation. Each has its own argv shape but they
-//! all share the same execution contract:
+//! OpenCode — the four subscription CLIs a developer commonly has
+//! logged in on a workstation. Each `CliProvider` instance wraps one
+//! of those and implements [`LlmProvider`] by composing messages into
+//! a single prompt, then handing dispatch to the shared
+//! `llm-here-core::dispatch` module.
 //!
-//!   - spawn the binary with a fixed flag set + the prompt as argv;
-//!   - stdin is closed (these tools read their prompt from `-p`);
-//!   - exit 0 + non-empty stdout = success;
-//!   - anything else = `LlmError::Provider` with stderr text.
+//! ## Why delegate
 //!
-//! ## Why a single generic provider
+//! Three sibling projects (caloron-noether, agentspec, this) used to
+//! re-implement "which CLI is installed, what's the argv shape, how do
+//! I timeout the subprocess." They drifted — caloron discovered the
+//! 25-second-under-Nix-30-second timeout cap first, this codebase
+//! backported it later, and agentspec still carried its own copy.
+//! `llm-here` is the consolidation; see
+//! [`docs/research/llm-here.md`](../../../docs/research/llm-here.md).
 //!
-//! caloron-noether already implements this multi-provider fallback in
-//! Python (`stages/phases/_llm.py`) and learned the hard edge cases —
-//! the 25-second timeout cap to stay under Nix's default 30-second
-//! kill, the `SKIP_CLI` escape hatch for sandboxed environments where
-//! CLI auth isn't mounted, the exact argv incantation per tool. This
-//! module ports those lessons into the Rust engine so noether-grid
-//! workers get the same behaviour, for free, with the same failure
-//! modes. See `docs/research/llm-here.md` for the long-term plan to
-//! unify all three implementations behind one shared tool.
+//! ## What this module owns
 //!
-//! ## Sandbox handling
+//! - The `LlmProvider` trait impl (noether-specific).
+//! - `Message`/`Role` → single-prompt composition. llm-here takes a
+//!   single prompt string; multi-message chat history is collapsed
+//!   here into one text block with role prefixes.
+//! - System-prompt routing: claude gets it as a native
+//!   `--append-system-prompt` flag (via llm-here v0.4+); other CLIs
+//!   get it inlined into the prompt with a `SYSTEM: …` prefix.
+//! - `NOETHER_LLM_SKIP_CLI` check (belt-and-braces — llm-here also
+//!   honours this as one of four aliases, but we short-circuit here
+//!   to match the original behaviour exactly).
 //!
-//! When `NOETHER_LLM_SKIP_CLI=1` is set, every CLI provider refuses to
-//! advertise itself as available (`available() == false`). Intended
-//! for stages that run inside the Nix executor, which mounts a
-//! restricted `$HOME` that doesn't carry the operator's CLI auth
-//! state — without this gate, a subscription CLI stalls waiting for
-//! interactive login and gets SIGKILL'd by the runner.
+//! ## What llm-here owns
 //!
-//! ## Timeout
-//!
-//! Default `timeout_secs = 25`. Deliberately under Nix's 30-second
-//! default stage kill so a stalled CLI reports `Provider(timeout)`
-//! instead of the stage runner's less useful "process killed" error.
-//! Callers outside the Nix executor can bump it up via
-//! `CliConfig::timeout_secs`.
+//! - PATH lookup for each binary.
+//! - Exact argv construction (the `-p` flag, `-y` for gemini, etc.).
+//! - Subprocess spawn + wall-clock timeout + child-kill on expiry.
+//! - Exit-status → error translation.
+
+use std::time::Duration;
+
+use llm_here_core::dispatch::{run_cli_provider, DispatchOptions, RealCommandRunner};
+use llm_here_core::providers::ProviderId;
 
 use super::{LlmConfig, LlmError, LlmProvider, Message, Role};
 
 // ── Per-CLI definitions ─────────────────────────────────────────────────────
 
-/// A static description of one CLI tool: the binary name, the argv
-/// template, and how system prompts are passed (if at all). Used by
-/// [`CliProvider::new`] to pick a concrete tool.
+/// A static description of one CLI tool. Each spec maps 1:1 to a
+/// [`ProviderId`] in the `llm-here-core::providers::REGISTRY`.
 #[derive(Debug, Clone, Copy)]
 pub struct CliSpec {
-    /// The executable name to look up on `PATH` (and to invoke).
+    /// The executable name expected on `PATH`. Matches the binary
+    /// llm-here-core looks up — keep in sync with
+    /// `llm_here_core::providers::REGISTRY` entries.
     pub binary: &'static str,
     /// Provider slug the broker routes on (matches
     /// `Effect::Llm { model: "<slug>" }` exactly).
     pub provider_slug: &'static str,
     /// Default model slug the worker advertises when none is configured.
     pub default_model: &'static str,
-    /// How this CLI takes its prompt on the argv.
-    pub prompt_style: PromptStyle,
-    /// Shape of the system-prompt flag. `None` = the CLI has no system
-    /// prompt support and any system-role messages are concatenated
-    /// into the user prompt.
-    pub system_flag: Option<&'static str>,
+    /// Corresponding id in the shared registry.
+    pub(crate) id: ProviderId,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum PromptStyle {
-    /// `-p <prompt>` positional flag (claude, gemini, cursor-agent).
-    DashP,
-    /// `run <prompt>` subcommand (opencode).
-    RunSubcommand,
-}
-
-/// Concrete per-CLI specs. Argv shapes are identical to what
-/// caloron's `_llm.py` uses — keep in sync when either side changes.
 pub mod specs {
     use super::*;
 
     /// Claude Desktop / Claude CLI — `claude -p PROMPT`.
-    ///
-    /// The `--dangerously-skip-permissions` flag is what caloron uses
-    /// to bypass the interactive tool-use prompt that otherwise
-    /// appears even in non-interactive mode. Without it the CLI
-    /// blocks waiting for "do you want to allow this?".
     pub const CLAUDE: CliSpec = CliSpec {
         binary: "claude",
         provider_slug: "anthropic-cli",
         default_model: "claude-desktop",
-        prompt_style: PromptStyle::DashP,
-        system_flag: Some("--append-system-prompt"),
+        id: ProviderId::ClaudeCli,
     };
 
-    /// Google Gemini CLI — `gemini -y -p PROMPT`. `-y` auto-accepts
-    /// the first-run consent prompt.
+    /// Google Gemini CLI — `gemini -y -p PROMPT`.
     pub const GEMINI: CliSpec = CliSpec {
         binary: "gemini",
         provider_slug: "google-cli",
         default_model: "gemini-desktop",
-        prompt_style: PromptStyle::DashP,
-        system_flag: None,
+        id: ProviderId::GeminiCli,
     };
 
     /// Cursor Agent CLI — `cursor-agent -p PROMPT --output-format text`.
@@ -105,8 +87,7 @@ pub mod specs {
         binary: "cursor-agent",
         provider_slug: "cursor-cli",
         default_model: "cursor-desktop",
-        prompt_style: PromptStyle::DashP,
-        system_flag: None,
+        id: ProviderId::CursorCli,
     };
 
     /// OpenCode CLI — `opencode run PROMPT`.
@@ -114,8 +95,7 @@ pub mod specs {
         binary: "opencode",
         provider_slug: "opencode",
         default_model: "opencode-default",
-        prompt_style: PromptStyle::RunSubcommand,
-        system_flag: None,
+        id: ProviderId::Opencode,
     };
 
     /// All specs, in the fallback order caloron settled on.
@@ -127,18 +107,21 @@ pub mod specs {
 /// Tunables for one [`CliProvider`] instance.
 #[derive(Debug, Clone)]
 pub struct CliConfig {
-    /// Override the binary path. Defaults to `spec.binary` (PATH lookup).
-    pub binary: Option<String>,
-    /// Wall-clock timeout for a single completion. Default 25s so a
-    /// stalled CLI reports a timeout before Nix's 30s stage kill.
+    /// Wall-clock timeout for a single completion. Default 25 s so a
+    /// stalled CLI reports a timeout before Nix's 30 s stage kill.
     pub timeout_secs: u64,
+    /// Pass `--dangerously-skip-permissions` to `claude`. Default `true`
+    /// to preserve prior behaviour (noether-grid has always set this for
+    /// claude). No ambient env is read; callers can flip it off
+    /// per-instance.
+    pub dangerous_claude: bool,
 }
 
 impl Default for CliConfig {
     fn default() -> Self {
         Self {
-            binary: None,
             timeout_secs: 25,
+            dangerous_claude: true,
         }
     }
 }
@@ -147,6 +130,10 @@ impl Default for CliConfig {
 /// `NOETHER_LLM_SKIP_CLI=1` inside a sandboxed environment (the Nix
 /// executor being the obvious one) where subscription CLIs would
 /// stall waiting for auth state that isn't mounted.
+///
+/// llm-here honours this env var natively (as one of four aliases),
+/// but we check here too so `CliProvider::available()` short-circuits
+/// before hitting the PATH lookup.
 pub fn cli_providers_suppressed() -> bool {
     std::env::var("NOETHER_LLM_SKIP_CLI")
         .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
@@ -155,8 +142,8 @@ pub fn cli_providers_suppressed() -> bool {
 
 // ── The provider ────────────────────────────────────────────────────────────
 
-/// LLM provider that delegates each completion to a subscription CLI.
-/// Stateless — each call spawns a fresh subprocess.
+/// LLM provider that delegates each completion to a subscription CLI
+/// via `llm-here-core`. Stateless — each call spawns a fresh subprocess.
 pub struct CliProvider {
     spec: CliSpec,
     config: CliConfig,
@@ -173,17 +160,20 @@ impl CliProvider {
 
     /// The binary this provider will invoke.
     pub fn binary(&self) -> &str {
-        self.config.binary.as_deref().unwrap_or(self.spec.binary)
+        self.spec.binary
     }
 
     /// True when this CLI is installed on the host and CLI providers
-    /// aren't globally suppressed. Does NOT verify auth state — we
-    /// find that out at first dispatch.
+    /// aren't globally suppressed. Uses llm-here's detection so the
+    /// availability check is identical to what dispatch will do.
     pub fn available(&self) -> bool {
         if cli_providers_suppressed() {
             return false;
         }
-        binary_runs(self.binary())
+        llm_here_core::detect()
+            .providers
+            .iter()
+            .any(|p| p.id == self.spec.id.as_str())
     }
 
     pub fn spec(&self) -> CliSpec {
@@ -199,40 +189,32 @@ impl LlmProvider for CliProvider {
             ));
         }
 
-        let (system_text, dialogue) = split_system_from_dialogue(messages);
-        let prompt = compose_prompt(&dialogue, &system_text, self.spec.system_flag);
+        let (system, dialogue) = split_system_from_dialogue(messages);
+        let has_native_system_flag = matches!(self.spec.id, ProviderId::ClaudeCli);
+        let prompt = compose_prompt(&dialogue, system.as_deref(), has_native_system_flag);
 
-        let mut cmd = std::process::Command::new(self.binary());
-        match self.spec.prompt_style {
-            PromptStyle::DashP => {
-                // Tool-specific extra flags — keep aligned with
-                // caloron's _llm.py; if either side changes, update both.
-                if self.spec.binary == "claude" {
-                    cmd.arg("--dangerously-skip-permissions");
-                }
-                if self.spec.binary == "gemini" {
-                    cmd.arg("-y");
-                }
-                if let (Some(flag), Some(sys)) = (self.spec.system_flag, system_text.as_ref()) {
-                    cmd.arg(flag).arg(sys);
-                }
-                if !config.model.is_empty()
-                    && config.model != self.spec.default_model
-                    && config.model != "unknown"
-                {
-                    cmd.arg("--model").arg(&config.model);
-                }
-                cmd.arg("-p").arg(&prompt);
-                if self.spec.binary == "cursor-agent" {
-                    cmd.arg("--output-format").arg("text");
-                }
-            }
-            PromptStyle::RunSubcommand => {
-                cmd.arg("run").arg(&prompt);
-            }
+        let opts = DispatchOptions {
+            timeout: Duration::from_secs(self.config.timeout_secs),
+            dangerous_claude: self.config.dangerous_claude && self.spec.id == ProviderId::ClaudeCli,
+            // Pass through the per-stage model when it differs from the
+            // spec's default, matching the pre-migration behaviour. Treat
+            // the placeholder "unknown" as "no override" (upstream callers
+            // sometimes pass it as a sentinel).
+            model: model_override(&config.model, self.spec.default_model),
+            // Only claude consumes this today; other CLIs ignore it and
+            // get the system text inlined into the main prompt above.
+            system_prompt: if has_native_system_flag { system } else { None },
+        };
+
+        let report = run_cli_provider(self.spec.id, &prompt, &opts, &RealCommandRunner);
+
+        if report.ok {
+            Ok(report.text.unwrap_or_default())
+        } else {
+            Err(LlmError::Provider(report.error.unwrap_or_else(|| {
+                "llm-here dispatch failed without an error message".into()
+            })))
         }
-
-        run_with_timeout(cmd, self.config.timeout_secs)
     }
 }
 
@@ -256,69 +238,31 @@ fn split_system_from_dialogue(messages: &[Message]) -> (Option<String>, Vec<Stri
     (system, dialogue)
 }
 
-/// Final prompt string passed as the tool's last argv. Tools that can
-/// carry a system prompt via flag (claude) get the dialogue only;
-/// others get `SYSTEM: …\n\n` prepended so the instructions aren't
-/// lost.
+/// Compose the final prompt. When the target CLI has no native
+/// system-prompt flag, we inline the system text with a `SYSTEM: …`
+/// prefix so instructions aren't lost. Claude CLI (the only one with a
+/// native flag today) gets dialogue only.
 fn compose_prompt(
     dialogue: &[String],
-    system: &Option<String>,
-    system_flag: Option<&str>,
+    system: Option<&str>,
+    has_native_system_flag: bool,
 ) -> String {
     let body = dialogue.join("\n\n");
-    match (system, system_flag) {
-        (Some(sys), None) => format!("SYSTEM: {sys}\n\n{body}"),
+    match (system, has_native_system_flag) {
+        (Some(sys), false) => format!("SYSTEM: {sys}\n\n{body}"),
         _ => body,
     }
 }
 
-/// `binary --version` succeeds. Fast, cheap, doesn't need auth state.
-fn binary_runs(binary: &str) -> bool {
-    std::process::Command::new(binary)
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-fn run_with_timeout(mut cmd: std::process::Command, timeout_secs: u64) -> Result<String, LlmError> {
-    let timeout = std::time::Duration::from_secs(timeout_secs);
-    let (tx, rx) = std::sync::mpsc::channel();
-    let child = std::thread::spawn(move || {
-        let out = cmd
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output();
-        let _ = tx.send(out);
-    });
-
-    let out = match rx.recv_timeout(timeout) {
-        Ok(Ok(o)) => o,
-        Ok(Err(e)) => return Err(LlmError::Provider(format!("CLI spawn failed: {e}"))),
-        Err(_) => {
-            return Err(LlmError::Provider(format!(
-                "CLI exceeded {timeout_secs}s timeout"
-            )))
-        }
-    };
-    let _ = child.join();
-
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(LlmError::Provider(format!(
-            "CLI exit {}: {}",
-            out.status.code().unwrap_or(-1),
-            stderr.trim()
-        )));
+/// Translate noether's per-config model to llm-here's optional model
+/// override. Keeps the pre-migration semantics: empty / default / the
+/// "unknown" sentinel all mean "no override".
+fn model_override(model: &str, default: &str) -> Option<String> {
+    if model.is_empty() || model == default || model == "unknown" {
+        None
+    } else {
+        Some(model.to_string())
     }
-    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if stdout.is_empty() {
-        return Err(LlmError::Provider("CLI produced empty output".into()));
-    }
-    Ok(stdout)
 }
 
 // ── Back-compat shims ──────────────────────────────────────────────────────
@@ -338,44 +282,75 @@ pub fn new_claude_cli() -> CliProvider {
 mod tests {
     use super::*;
 
-    fn provider_for(spec: CliSpec, binary_override: &str) -> CliProvider {
-        CliProvider::with_config(
-            spec,
-            CliConfig {
-                binary: Some(binary_override.into()),
-                timeout_secs: 2,
-            },
-        )
+    #[test]
+    fn compose_prompt_inlines_system_when_no_native_flag() {
+        let body = compose_prompt(&["USER: hello".into()], Some("be terse"), false);
+        assert!(body.contains("SYSTEM: be terse"));
+        assert!(body.contains("USER: hello"));
     }
 
     #[test]
-    fn missing_binary_is_not_available() {
-        for spec in specs::ALL {
-            let p = provider_for(*spec, "/nonexistent/never-here-xyz");
-            assert!(!p.available(), "should be unavailable for {}", spec.binary);
-        }
+    fn compose_prompt_omits_inline_system_when_native_flag_exists() {
+        let body = compose_prompt(&["USER: hi".into()], Some("be terse"), true);
+        assert!(!body.contains("SYSTEM:"));
+        assert!(body.contains("USER: hi"));
     }
 
     #[test]
-    fn missing_binary_completion_returns_provider_error() {
-        let p = provider_for(specs::CLAUDE, "/nonexistent/never-here-xyz");
-        let err = p
-            .complete(
-                &[Message::user("hi")],
-                &LlmConfig {
-                    model: "claude-desktop".into(),
-                    ..Default::default()
-                },
-            )
-            .unwrap_err();
-        assert!(matches!(err, LlmError::Provider(_)));
+    fn compose_prompt_handles_empty_system() {
+        let body = compose_prompt(&["USER: hi".into()], None, false);
+        assert_eq!(body, "USER: hi");
+    }
+
+    #[test]
+    fn split_separates_system_and_dialogue() {
+        let messages = vec![
+            Message::system("be terse"),
+            Message::user("hi"),
+            Message::assistant("hello"),
+            Message::user("bye"),
+        ];
+        let (system, dialogue) = split_system_from_dialogue(&messages);
+        assert_eq!(system.as_deref(), Some("be terse"));
+        assert_eq!(dialogue.len(), 3);
+        assert!(dialogue[0].starts_with("USER: hi"));
+        assert!(dialogue[1].starts_with("ASSISTANT: hello"));
+        assert!(dialogue[2].starts_with("USER: bye"));
+    }
+
+    #[test]
+    fn split_joins_multiple_system_messages() {
+        let messages = vec![
+            Message::system("rule one"),
+            Message::system("rule two"),
+            Message::user("hi"),
+        ];
+        let (system, _) = split_system_from_dialogue(&messages);
+        let s = system.unwrap();
+        assert!(s.contains("rule one"));
+        assert!(s.contains("rule two"));
+    }
+
+    #[test]
+    fn model_override_empty_or_default_returns_none() {
+        assert_eq!(model_override("", "claude-desktop"), None);
+        assert_eq!(model_override("claude-desktop", "claude-desktop"), None);
+        assert_eq!(model_override("unknown", "claude-desktop"), None);
+    }
+
+    #[test]
+    fn model_override_non_default_returns_some() {
+        assert_eq!(
+            model_override("claude-opus-4-1", "claude-desktop"),
+            Some("claude-opus-4-1".into())
+        );
     }
 
     #[test]
     fn skip_cli_env_suppresses_all_providers() {
         let prev = std::env::var("NOETHER_LLM_SKIP_CLI").ok();
         std::env::set_var("NOETHER_LLM_SKIP_CLI", "1");
-        let p = provider_for(specs::CLAUDE, "/bin/true");
+        let p = CliProvider::new(specs::CLAUDE);
         assert!(!p.available());
         let err = p
             .complete(
@@ -397,29 +372,17 @@ mod tests {
     }
 
     #[test]
-    fn compose_prompt_inlines_system_when_no_flag() {
-        let body = compose_prompt(&["USER: hello".into()], &Some("be terse".into()), None);
-        assert!(body.contains("SYSTEM: be terse"));
-        assert!(body.contains("USER: hello"));
-    }
-
-    #[test]
-    fn compose_prompt_omits_inline_system_when_flag_exists() {
-        let body = compose_prompt(
-            &["USER: hi".into()],
-            &Some("be terse".into()),
-            Some("--append-system-prompt"),
-        );
-        assert!(!body.contains("SYSTEM:"));
-        assert!(body.contains("USER: hi"));
-    }
-
-    #[test]
     fn all_specs_have_distinct_binaries_and_slugs() {
         let binaries: std::collections::HashSet<_> = specs::ALL.iter().map(|s| s.binary).collect();
         let slugs: std::collections::HashSet<_> =
             specs::ALL.iter().map(|s| s.provider_slug).collect();
         assert_eq!(binaries.len(), specs::ALL.len());
         assert_eq!(slugs.len(), specs::ALL.len());
+    }
+
+    #[test]
+    fn each_spec_maps_to_a_distinct_provider_id() {
+        let ids: std::collections::HashSet<_> = specs::ALL.iter().map(|s| s.id).collect();
+        assert_eq!(ids.len(), specs::ALL.len());
     }
 }


### PR DESCRIPTION
## Summary

- Replaces in-tree subprocess dispatch in `crates/noether-engine/src/llm/cli_provider.rs` with a thin adapter over [alpibrusl/llm-here](https://github.com/alpibrusl/llm-here) (v0.4.0, pinned via git dep).
- **Public API is unchanged** for external consumers (`providers.rs`, `noether-grid-worker/main.rs`, any downstream) — `specs::{CLAUDE,GEMINI,CURSOR,OPENCODE,ALL}`, `CliProvider::{new,with_config,binary,available,spec}`, `cli_providers_suppressed`, the `LlmProvider` impl all work identically.
- **Net −33 LOC** in `cli_provider.rs` but the real win is deduplication: the dispatch logic now lives in one place, shared with caloron-noether and agentspec (both of which have open migration issues against their own copies).

Closes the noether-grid slice of [#46](https://github.com/alpibrusl/noether/issues/46).

## ⚠️  Deploy note

Artifact deploy is in flight on v0.7.3 — **do not merge during the rollout.** This PR is an internal refactor; it doesn't change any external API, so when the deploy settles it can land on main without a version bump.

## What moves to llm-here

- PATH lookup for each binary (now `llm_here_core::detect`).
- Exact argv construction per CLI — `-p`, `-y`, `--output-format text`, `--dangerously-skip-permissions`, `--append-system-prompt`, `--model`.
- Subprocess spawn + wall-clock timeout + child-kill on expiry (via `wait-timeout` inside llm-here).
- Exit-status → error translation.

## What stays in noether

- The `LlmProvider` trait impl.
- `Message`/`Role` → single-prompt composition with role prefixes (llm-here takes a single prompt string).
- System-prompt routing: claude gets `--append-system-prompt` via llm-here v0.4; other CLIs get `SYSTEM: …` inlined into the prompt (identical to prior behaviour).
- `NOETHER_LLM_SKIP_CLI` short-circuit (llm-here also honours it as one of four aliases, but we check here too for behavioural parity).

## Minor internal changes

- `CliSpec` gained `id: ProviderId` field (`pub(crate)`) mapping to llm-here's registry. Existing public fields (`binary`, `provider_slug`, `default_model`) unchanged.
- `CliSpec.system_flag` and `prompt_style` fields removed — no external references (confirmed via grep), only used by the old dispatch code.
- `CliConfig.binary: Option<String>` (custom binary override) removed — no production callers, only tests. Upstream binary names are owned by llm-here's registry.
- `CliConfig.dangerous_claude: bool` added (default `true`) so the previously-hardcoded `--dangerously-skip-permissions` for claude is now a per-instance choice. Default behaviour preserved.

## Tests

10 unit tests replace the previous 5:

- `compose_prompt_*` (3) — no-native-flag inlining, native-flag omission, empty system.
- `split_separates_system_and_dialogue` + `split_joins_multiple_system_messages`.
- `model_override_empty_or_default_returns_none` + `model_override_non_default_returns_some`.
- `skip_cli_env_suppresses_all_providers` — same behavioural guarantee as before.
- `all_specs_have_distinct_binaries_and_slugs` — regression guard.
- `each_spec_maps_to_a_distinct_provider_id` — new guard covering the `id` field addition.

## Verification

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace` — **583 tests pass, 0 fail** on this branch.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] End-to-end smoke against live providers not run in CI; llm-here-core v0.3 was smoke-tested against live Mistral API during its own development (526ms round-trip, correct output).

## Test plan

- [ ] Reviewer: confirm `cargo test --workspace` passes locally on a machine with the four subscription CLIs installed (claude, gemini, cursor-agent, opencode).
- [ ] Reviewer: grep for `CliConfig::binary` references in any downstream alpibrusl/* repos not in this workspace.
- [ ] Reviewer: once `llm-here` lands on crates.io, switch the git dep in `crates/noether-engine/Cargo.toml` to a version number (`llm-here-core = "0.4"`).
- [ ] Maintainer: merge after v0.7.3 deploy completes.

## Related

- [alpibrusl/llm-here v0.4.0](https://github.com/alpibrusl/llm-here/releases/tag/v0.4.0) — surface extension landed specifically to cover this migration's needs (system_prompt, CLI model).
- [alpibrusl/noether#46](https://github.com/alpibrusl/noether/issues/46) — the meta-tracker for cross-repo consolidation.
- [alpibrusl/agentspec#28](https://github.com/alpibrusl/agentspec/issues/28) — parallel migration, unblocked since llm-here v0.1.
- [alpibrusl/caloron-noether#21](https://github.com/alpibrusl/caloron-noether/issues/21) — parallel migration, unblocked since llm-here v0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)