### PR TITLE
feat(effects): filesystem-scoped Effect::FsRead/FsWrite (M3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+### Added — filesystem-scoped effects (M3.x, [#39](https://github.com/alpibrusl/noether/issues/39) follow-up)
+
+Two new variants on `noether_core::effects::Effect`:
+
+- `Effect::FsRead { path: PathBuf }` — stage reads a specific host path.
+- `Effect::FsWrite { path: PathBuf }` — stage writes to a specific host path.
+
+`EffectKind::FsRead` / `EffectKind::FsWrite` mirror the variants; `Effect::kind()` and `EffectKind::fmt` know about them. CLI `--allow-effects` accepts `fs-read` / `fs-write` tokens.
+
+### Changed — `IsolationPolicy::from_effects` now drives bind mounts from effects
+
+The function now scans the `EffectSet` for path-bearing filesystem effects:
+
+- `FsRead(p)` appends `RoBind { host: p, sandbox: p }` to `ro_binds`.
+- `FsWrite(p)` appends `RwBind { host: p, sandbox: p }` to `rw_binds`.
+
+`/nix/store` is still unconditionally bound read-only (Nix-pinned runtimes need it). Multiple effects of the same variant produce multiple binds — declaring `FsRead(/etc)` and `FsRead(/usr/share)` yields two `--ro-bind` entries. The mount-order contract from [#39](https://github.com/alpibrusl/noether/pull/47) (rw → ro → work_host) still holds when binds are effect-driven.
+
+### Closes the gap #39 flagged
+
+When `#39` landed, `from_effects` produced empty `rw_binds` — the `EffectSet` vocabulary simply had no way to express "stage writes to /tmp/out". Consumers (agentspec's `filesystem: scoped`, agent-coding runtimes) had to construct `IsolationPolicy` by hand. With this milestone, a stage can declare its filesystem surface in the signature and `from_effects` does the right thing without caller intervention.
+
+This is a deliberate trust-widening surface on the effect side. Binding `/home/user` RW still grants broad host access — the rustdoc on the new variants keeps the same framing as `RwBind`: the crate cannot validate whether a declared path is sensible to share; that's a caller-authored policy decision.
+
+### Back-compat
+
+- Existing stages that don't declare `FsRead` / `FsWrite` are bit-identical on the wire. Their `StageId` is unchanged.
+- Adding a new filesystem effect to an existing stage changes that stage's `StageId` (as it should — the behaviour just changed).
+- Wire format: `{"effect": "FsRead", "path": "/etc"}` matches the existing `#[serde(tag = "effect")]` shape the other variants use. Non-Rust consumers (the Python bindings agentspec will grow against `noether-sandbox`) get a uniform schema.
+
 ## 0.7.3 — 2026-04-20
 
 Release-pipeline repair. **No source changes in this version — it exists to re-publish crates and ship a new set of release tarballs through the fixed workflow.**

--- a/crates/noether-cli/src/main.rs
+++ b/crates/noether-cli/src/main.rs
@@ -70,7 +70,8 @@ enum Commands {
         #[arg(long)]
         allow_capabilities: Option<String>,
         /// Comma-separated list of effect kinds to allow
-        /// (pure, fallible, llm, network, non-deterministic, cost, unknown).
+        /// (pure, fallible, fs-read, fs-write, llm, network,
+        /// non-deterministic, cost, process, unknown).
         /// Default: all effects are allowed.
         #[arg(long)]
         allow_effects: Option<String>,
@@ -500,6 +501,8 @@ fn parse_effect_policy(raw: Option<&str>) -> EffectPolicy {
             let kinds = s.split(',').filter_map(|token| match token.trim() {
                 "pure" => Some(EffectKind::Pure),
                 "fallible" => Some(EffectKind::Fallible),
+                "fs-read" | "fsread" => Some(EffectKind::FsRead),
+                "fs-write" | "fswrite" => Some(EffectKind::FsWrite),
                 "llm" => Some(EffectKind::Llm),
                 "network" => Some(EffectKind::Network),
                 "non-deterministic" | "nondeterministic" => Some(EffectKind::NonDeterministic),

--- a/crates/noether-core/src/effects/effect.rs
+++ b/crates/noether-core/src/effects/effect.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "effect")]
@@ -8,6 +9,28 @@ pub enum Effect {
         cents: u64,
     },
     Fallible,
+    /// Stage reads a specific host path. Use an absolute path; the
+    /// sandbox binds it at the same location inside the sandbox (via
+    /// a read-only bind mount). Multiple read paths are declared as
+    /// separate `FsRead` entries — one per path.
+    ///
+    /// `from_effects` on the isolation policy turns each `FsRead(p)`
+    /// into a `RoBind { host: p, sandbox: p }`.
+    FsRead {
+        path: PathBuf,
+    },
+    /// Stage writes to a specific host path. Use an absolute path;
+    /// the sandbox binds it RW at the same location inside. This is
+    /// a deliberate trust widening — the sandbox cannot validate
+    /// whether binding (say) `/home/user` RW is sensible. Callers
+    /// that need this are declaring the trust decision explicitly
+    /// via this effect.
+    ///
+    /// `from_effects` on the isolation policy turns each `FsWrite(p)`
+    /// into an `RwBind { host: p, sandbox: p }`.
+    FsWrite {
+        path: PathBuf,
+    },
     Llm {
         model: String,
     },
@@ -28,6 +51,8 @@ pub enum Effect {
 pub enum EffectKind {
     Cost,
     Fallible,
+    FsRead,
+    FsWrite,
     Llm,
     Network,
     NonDeterministic,
@@ -43,6 +68,8 @@ impl Effect {
         match self {
             Effect::Cost { .. } => EffectKind::Cost,
             Effect::Fallible => EffectKind::Fallible,
+            Effect::FsRead { .. } => EffectKind::FsRead,
+            Effect::FsWrite { .. } => EffectKind::FsWrite,
             Effect::Llm { .. } => EffectKind::Llm,
             Effect::Network => EffectKind::Network,
             Effect::NonDeterministic => EffectKind::NonDeterministic,
@@ -58,6 +85,8 @@ impl std::fmt::Display for EffectKind {
         let s = match self {
             EffectKind::Cost => "cost",
             EffectKind::Fallible => "fallible",
+            EffectKind::FsRead => "fs-read",
+            EffectKind::FsWrite => "fs-write",
             EffectKind::Llm => "llm",
             EffectKind::Network => "network",
             EffectKind::NonDeterministic => "non-deterministic",
@@ -146,5 +175,69 @@ mod tests {
         let json = serde_json::to_string(&es).unwrap();
         let deserialized: EffectSet = serde_json::from_str(&json).unwrap();
         assert_eq!(es, deserialized);
+    }
+
+    #[test]
+    fn fs_effects_round_trip_through_json() {
+        // M3.x: path-bearing FsRead / FsWrite variants must round-trip
+        // cleanly through the `#[serde(tag = "effect")]` shape, and
+        // coexist with the existing effect variants (so a stage can
+        // declare `{Pure, FsRead(/etc), FsWrite(/tmp/out)}` and hit
+        // every branch of `from_effects`).
+        let es = EffectSet::new([
+            Effect::Pure,
+            Effect::FsRead {
+                path: PathBuf::from("/etc/ssl/certs"),
+            },
+            Effect::FsWrite {
+                path: PathBuf::from("/tmp/agent-output"),
+            },
+        ]);
+        let json = serde_json::to_string(&es).unwrap();
+        // Contract: the wire shape uses the same tag key as every
+        // other Effect variant. Downstream deserialisers (e.g. the
+        // Python bindings the agentspec PR will grow) see a uniform
+        // `{"effect": "FsRead", "path": "..."}` shape.
+        assert!(
+            json.contains(r#""effect":"FsRead""#),
+            "expected FsRead tag in wire: {json}"
+        );
+        assert!(
+            json.contains(r#""effect":"FsWrite""#),
+            "expected FsWrite tag in wire: {json}"
+        );
+        let deserialized: EffectSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(es, deserialized);
+    }
+
+    #[test]
+    fn fs_effect_kinds_map_one_to_one() {
+        let read = Effect::FsRead {
+            path: PathBuf::from("/a"),
+        };
+        let write = Effect::FsWrite {
+            path: PathBuf::from("/b"),
+        };
+        assert_eq!(read.kind(), EffectKind::FsRead);
+        assert_eq!(write.kind(), EffectKind::FsWrite);
+        // Display for CLI surface (`--allow-effects fs-read,fs-write`).
+        assert_eq!(EffectKind::FsRead.to_string(), "fs-read");
+        assert_eq!(EffectKind::FsWrite.to_string(), "fs-write");
+    }
+
+    #[test]
+    fn distinct_fs_read_paths_are_distinct_elements() {
+        // EffectSet is a BTreeSet. Two FsRead effects with different
+        // paths must be stored as two elements — otherwise declaring
+        // "read /etc AND read /home" would collapse to one.
+        let es = EffectSet::new([
+            Effect::FsRead {
+                path: PathBuf::from("/etc"),
+            },
+            Effect::FsRead {
+                path: PathBuf::from("/home"),
+            },
+        ]);
+        assert_eq!(es.iter().count(), 2);
     }
 }

--- a/crates/noether-isolation/src/lib.rs
+++ b/crates/noether-isolation/src/lib.rs
@@ -290,9 +290,24 @@ impl IsolationPolicy {
     /// [`Self::with_work_host`].
     pub fn from_effects(effects: &EffectSet) -> Self {
         let has_network = effects.iter().any(|e| matches!(e, Effect::Network));
+        // M3.x: path-scoped filesystem effects drive bind-mount
+        // generation. `Effect::FsRead(p)` → `RoBind { p, p }`,
+        // `Effect::FsWrite(p)` → `RwBind { p, p }`. Multiple entries
+        // of each variant produce multiple binds. `/nix/store` is
+        // always bound read-only because Nix-pinned runtimes need to
+        // resolve regardless of declared effects.
+        let mut ro_binds = vec![RoBind::new("/nix/store", "/nix/store")];
+        let mut rw_binds = Vec::new();
+        for effect in effects.iter() {
+            match effect {
+                Effect::FsRead { path } => ro_binds.push(RoBind::new(path.clone(), path.clone())),
+                Effect::FsWrite { path } => rw_binds.push(RwBind::new(path.clone(), path.clone())),
+                _ => {}
+            }
+        }
         Self {
-            ro_binds: vec![RoBind::new("/nix/store", "/nix/store")],
-            rw_binds: Vec::new(),
+            ro_binds,
+            rw_binds,
             work_host: None,
             network: has_network,
             env_allowlist: vec![
@@ -765,6 +780,108 @@ mod tests {
         assert!(
             work_bind_idx > ro_ssh_idx,
             "work_host must render last so its /work mapping wins"
+        );
+    }
+
+    #[test]
+    fn fs_read_effect_becomes_ro_bind() {
+        // M3.x: a stage declaring `Effect::FsRead(p)` should see `p`
+        // bound read-only at the same path inside the sandbox, no
+        // caller intervention required. Pairs with the CHANGELOG's
+        // "effects drive policy" framing.
+        let policy = IsolationPolicy::from_effects(&EffectSet::new([
+            Effect::Pure,
+            Effect::FsRead {
+                path: PathBuf::from("/etc/ssl/certs"),
+            },
+        ]));
+        let bound = policy
+            .ro_binds
+            .iter()
+            .find(|b| b.host == Path::new("/etc/ssl/certs"))
+            .expect("FsRead path must appear in ro_binds");
+        assert_eq!(bound.sandbox, Path::new("/etc/ssl/certs"));
+        assert!(policy.rw_binds.is_empty(), "FsRead must not trigger RW");
+    }
+
+    #[test]
+    fn fs_write_effect_becomes_rw_bind() {
+        let policy = IsolationPolicy::from_effects(&EffectSet::new([
+            Effect::Pure,
+            Effect::FsWrite {
+                path: PathBuf::from("/tmp/agent-output"),
+            },
+        ]));
+        let bound = policy
+            .rw_binds
+            .iter()
+            .find(|b| b.host == Path::new("/tmp/agent-output"))
+            .expect("FsWrite path must appear in rw_binds");
+        assert_eq!(bound.sandbox, Path::new("/tmp/agent-output"));
+        // /nix/store is still in ro_binds; FsWrite shouldn't disturb
+        // the baseline read-only mounts.
+        assert!(policy
+            .ro_binds
+            .iter()
+            .any(|b| b.sandbox == Path::new("/nix/store")));
+    }
+
+    #[test]
+    fn multiple_fs_effects_produce_multiple_binds() {
+        // A stage can declare several FsRead / FsWrite paths. Each
+        // becomes its own bind entry — the BTreeSet semantics of
+        // EffectSet keep distinct-path effects distinct.
+        let policy = IsolationPolicy::from_effects(&EffectSet::new([
+            Effect::FsRead {
+                path: PathBuf::from("/etc"),
+            },
+            Effect::FsRead {
+                path: PathBuf::from("/usr/share"),
+            },
+            Effect::FsWrite {
+                path: PathBuf::from("/tmp/out"),
+            },
+            Effect::FsWrite {
+                path: PathBuf::from("/var/log/agent"),
+            },
+        ]));
+        let ro_paths: Vec<&Path> = policy.ro_binds.iter().map(|b| b.host.as_path()).collect();
+        assert!(ro_paths.contains(&Path::new("/etc")));
+        assert!(ro_paths.contains(&Path::new("/usr/share")));
+        assert!(ro_paths.contains(&Path::new("/nix/store")));
+        let rw_paths: Vec<&Path> = policy.rw_binds.iter().map(|b| b.host.as_path()).collect();
+        assert!(rw_paths.contains(&Path::new("/tmp/out")));
+        assert!(rw_paths.contains(&Path::new("/var/log/agent")));
+    }
+
+    #[test]
+    fn bwrap_command_emits_fs_effect_binds() {
+        // End-to-end: FsRead / FsWrite declared in the effect set
+        // should show up as --ro-bind / --bind argv entries. This
+        // pins the full pipeline from Effect → Policy → argv.
+        let policy = IsolationPolicy::from_effects(&EffectSet::new([
+            Effect::FsRead {
+                path: PathBuf::from("/etc/ssl/certs"),
+            },
+            Effect::FsWrite {
+                path: PathBuf::from("/tmp/agent-output"),
+            },
+        ]));
+        let cmd = build_bwrap_command(Path::new("/usr/bin/bwrap"), &policy, &["python3".into()]);
+        let argv: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
+
+        let ro_idx = argv
+            .windows(3)
+            .position(|w| w[0] == "--ro-bind" && w[1] == "/etc/ssl/certs")
+            .expect("FsRead should render as --ro-bind");
+        let rw_idx = argv
+            .windows(3)
+            .position(|w| w[0] == "--bind" && w[1] == "/tmp/agent-output")
+            .expect("FsWrite should render as --bind");
+        // Mount-order contract still holds with effect-driven binds.
+        assert!(
+            rw_idx < ro_idx,
+            "rw_binds must still render before ro_binds when both come from effects"
         );
     }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,7 +33,7 @@ Noether shifted from sequential "phase" numbering to milestone tracking with the
 | M2.5 | Property DSL expansion | ✅ Done | v0.7.0 | `FieldLengthEq` / `FieldLengthMax` / `SubsetOf` / `Equals` / `FieldTypeIn`, typed `JsonKind` enum, shadowed-kind ingest rejection |
 | M2.x | `noether-isolation` crate extraction | ✅ Done | v0.7.1 | Standalone crate + `noether-sandbox` binary for non-Rust consumers (agentspec, future Python/Node/Go bindings) |
 | M3 | Optimizer + Richer Types | ⏳ Next | targeting v0.8.0 | Graph optimizer (`fuse_pure_sequential`, `hoist_invariant`, `dead_branch`, `memoize_pure`), parametric polymorphism on stage signatures, row polymorphism on records, refinement types with runtime check |
-| M3.x | Filesystem-scoped effects | ⏳ Planned | targeting v0.8.0 | `Effect::FsRead(path)` / `FsWrite(path)` variants so the sandbox can grant targeted filesystem access per stage |
+| M3.x | Filesystem-scoped effects | ✅ Done | unreleased (next tag) | `Effect::FsRead(path)` / `FsWrite(path)` variants wired through `IsolationPolicy::from_effects` so path-scoped binds fall out of the signature — closes the gap [#39](https://github.com/alpibrusl/noether/issues/39) flagged around `from_effects` being unable to drive `rw_binds` |
 | M4 | Stdlib Curation + Vertical Depth + 1.0 | ⏳ Planned | targeting 1.0.0 | Stdlib audit, vertical depth in a chosen domain, freeze |
 | Phase 2 isolation | Native namespaces + Landlock + seccomp | ⏳ Planned | targeting v0.8.0 | Replace bwrap subprocess with direct `unshare` + Landlock + seccomp; same `IsolationPolicy` surface, ~10× lower startup |
 


### PR DESCRIPTION
## Summary

Closes the M3.x milestone: `Effect::FsRead(path)` and `Effect::FsWrite(path)` variants wired through `IsolationPolicy::from_effects` so path-scoped bind mounts fall out of the stage signature automatically.

This completes the gap #39 flagged when `rw_binds` landed — the plumbing to honour scoped RW binds existed, but the effect vocabulary had no way to drive them. Consumers (agentspec's `filesystem: scoped` mode, agent-coding runtimes) now get a clean delegation path: declare the filesystem surface in effects, let the sandbox derive the binds.

## Surface changes

**`noether_core::effects::Effect`**
- `FsRead { path: PathBuf }` — stage reads a specific host path.
- `FsWrite { path: PathBuf }` — stage writes to a specific host path.
- Mirrored in `EffectKind::FsRead` / `EffectKind::FsWrite`.
- `Display` returns `"fs-read"` / `"fs-write"`.

**`noether_isolation::IsolationPolicy::from_effects`**
- Scans effects, adds `RoBind { host: p, sandbox: p }` per `FsRead(p)`.
- Scans effects, adds `RwBind { host: p, sandbox: p }` per `FsWrite(p)`.
- `/nix/store` baseline preserved. Mount order `rw → ro → work_host` unchanged.

**`noether-cli`**
- `--allow-effects` accepts `fs-read` / `fs-write` (plus `fsread` / `fswrite` aliases).
- Flag help text updated with the full kind list.

## Scope-limited per the milestone

- No semantic path validation (absolute vs relative, existence, overlap) — bwrap's own failure mode is clearer than anything wrapped here.
- No change to `infer_effects` — filesystem access is declared, not inferred, by design.
- No deprecation or rename of existing `Effect::Process`.

## Trust framing

Same posture as #47's `RwBind`: the crate cannot validate whether a declared path is sensible to share. `FsWrite(/home/user)` grants the stage the caller's entire home; `FsWrite(project/)` is the whole point of an agent-coding tool. Both use the same mechanism — the decision lives with the caller, and the rustdoc says so.

## Tests

- **noether-core** +3: serde round-trip with both new variants, kind→Display mapping pin, BTreeSet distinct-path guarantee.
- **noether-isolation** +4: FsRead → RoBind, FsWrite → RwBind (with /nix/store preservation), multiple paths → multiple binds, end-to-end argv-level pin that both effect-driven binds reach bwrap in the right order.

## Test plan

- [x] `cargo test --workspace` — all green (core 129 → 132, isolation 14 → 18, no regressions elsewhere)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Roadmap updated: M3.x ✅ Done
- [x] CHANGELOG Unreleased entry documenting semantics + trust framing + back-compat

## Related

- #39 — the `rw_binds` issue whose "no `FsWrite(path)` variant to drive it" caveat this closes
- #47 — the `rw_binds` PR this builds directly on

Follow-ups (separate PRs):
- agentspec can now flip `filesystem: scoped` to drive `rw_binds` through effects instead of direct policy construction.
- Main M3 milestone (optimizer + richer types) — this was the `M3.x` sub-track.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>