### PR TITLE
docs: v0.7.x parity pass — sandbox / filesystem / optimizer pages + property example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+### Docs — parity pass with v0.7.x features
+
+README, mkdocs, and the tutorial section had drifted behind the last four shipped deliverables. This pass closes the gap:
+
+- **README** — new "What's new in v0.7" section covering the sandbox default, `noether-isolation` / `noether-sandbox`, `rw_binds` + `Effect::FsRead` / `FsWrite`, the M3 optimizer (`canonical_structural` / `dead_branch` / `memoize_pure`), and the parametric-polymorphism foundation (unification module + `NType::Var`).
+- **`docs/architecture/optimizer.md`** — new page. Pipeline position, per-pass semantics with before/after, the `OptimizerPass` trait contract, `NOETHER_NO_OPTIMIZE` / `NOETHER_NO_MEMOIZE` opt-outs, how the remaining M3 passes (`fuse_pure_sequential`, `hoist_invariant`) need planner-level work not AST passes.
+- **`docs/guides/sandbox-isolation.md`** — new page. The `--isolate=` flag, what bwrap actually guarantees, caller-managed filesystem trust via `rw_binds` / `ro_binds` / `work_host`, common failure modes, Phase 1 → Phase 2 roadmap (v0.8 native namespaces + Landlock + seccomp).
+- **`docs/guides/filesystem-effects.md`** — new page. `Effect::FsRead(path)` / `FsWrite(path)` wire form, how `from_effects` derives `rw_binds` / `ro_binds` automatically, mount-order semantics, the trust framing (the crate can't validate whether a declared path is sensible — caller decision).
+- **`docs/agents/debug-a-failed-graph.md`** — isolation section reworked to distinguish Phase 1 (v0.7.x bwrap) from Phase 2 (v0.8 native namespaces, roadmapped) so agents parsing the playbook don't mistake current-shipped for final-state.
+- **`docs/tutorial/concepts.md`** — 3-sentence optimizer subsection pointing at the architecture page.
+- **`docs/tutorial/when-things-go-wrong.md`** — Phase 1 / Phase 2 framing on the isolation failure section with a forward-reference to the new sandbox guide.
+- **`examples/property-annotated/`** — new worked example. A `take_first_n` stage declaring three properties (`Range`, `FieldLengthMax`, `SubsetOf`) with four examples that exercise each. Demonstrates what the property DSL catches that the type system can't.
+- **`mkdocs.yml`** — 3 new nav entries: `Sandbox & Isolation` and `Filesystem-scoped Effects` under Guides; `Optimizer` under Concepts.
+
+No code changes. mkdocs build clean; existing pre-existing `../../STABILITY.md` / `../../SECURITY.md` warnings unchanged by this pass.
+
 ### Added — Robinson-style unification module (M3 parametric-polymorphism foundation)
 
 New `noether_core::types::unification` module ships the algorithm foundation for parametric polymorphism on stage signatures:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Full operator reference: **[Composition Graphs →](./docs/guides/composition-gr
 
 ---
 
+## What's new in v0.7
+
+- **Stage execution sandbox, default-on.** `--isolate=auto` wraps every Python / JavaScript / Bash stage subprocess in bubblewrap: fresh namespaces, UID-mapped to `nobody`, cap-drop ALL, sandbox-private `/work` tmpfs, network unshared unless the stage declares `Effect::Network`. `--require-isolation` (or `NOETHER_REQUIRE_ISOLATION=1`) turns the "bwrap not found → run unsandboxed" fallback into a hard error for CI and production. Details: **[guides/sandbox-isolation →](./docs/guides/sandbox-isolation.md)**.
+- **`noether-isolation` crate + `noether-sandbox` binary.** Extracted in v0.7.1 for non-Rust consumers. `IsolationPolicy` + `build_bwrap_command` as a library; `noether-sandbox` as a standalone binary that reads a policy as JSON on stdin and runs an arbitrary argv inside the sandbox. Covers agentspec's delegation path without embedding the engine.
+- **Scoped filesystem trust — `rw_binds` + `Effect::FsRead(path)` / `Effect::FsWrite(path)`.** `IsolationPolicy` now carries a `Vec<RwBind>` alongside the existing `ro_binds`, and `from_effects` derives both automatically from path-scoped filesystem effects declared in the stage signature. Mount order `rw → ro → work_host` lets a narrower RO shadow a broader RW parent (the canonical `workdir RW, .ssh RO` pattern). Details: **[guides/filesystem-effects →](./docs/guides/filesystem-effects.md)**.
+- **Graph optimizer (M3, v0.7.3).** New `noether_engine::optimizer` module runs between type-check and plan. Three semantics-preserving passes: `canonical_structural` (flatten nested Sequential, collapse singleton Sequential, fuse adjacent Retry), `dead_branch` (fold `Branch(Const(bool), …)` into the selected arm), `memoize_pure` (repeated `(stage_id, input)` pairs on Pure-tagged stages skip re-execution within a run). `NOETHER_NO_OPTIMIZE=1` and `NOETHER_NO_MEMOIZE=1` disable each independently. Details: **[architecture/optimizer →](./docs/architecture/optimizer.md)**.
+- **Parametric polymorphism foundation (M3, in progress).** `NType::Var(name)` variant + Robinson-style unification module (`noether_core::types::unification`) + `NType ↔ Ty` conversion layer. Today stage signatures can carry `Var` and type-check through the permissive subtype path. Unification binding propagation through `check_graph` and generic stdlib stages (`identity`, `head`, `tail`, `map`) are slice 2b and slice 3, tracked on the [roadmap](./docs/roadmap.md).
+
 ## What's new in v0.4
 
 - **`noether-grid`** — distributed execution for composition graphs.

--- a/docs/agents/debug-a-failed-graph.md
+++ b/docs/agents/debug-a-failed-graph.md
@@ -87,9 +87,14 @@ Output (abbreviated):
 
 The trace is the ground truth — stderr is a summary.
 
-## Isolation-specific failures (v0.7+)
+## Isolation-specific failures (Phase 1 — v0.7.x bwrap)
 
-If running with `--isolate=bwrap`:
+Noether's isolation layer ships in two phases:
+
+- **Phase 1 (v0.7.x, shipped)** — bubblewrap as a subprocess wrapper. Fresh namespaces, UID-mapped to `nobody`, cap-drop ALL, sandbox-private `/work` tmpfs, network unshared unless declared. Good enough for LLM-synthesized code you haven't audited; not a hardened multi-tenant boundary.
+- **Phase 2 (v0.8, roadmapped)** — replace the bwrap subprocess with in-process `unshare` + Landlock + seccomp. Same `IsolationPolicy` surface, ~10× lower startup, finer-grained syscall control. See issue [#44](https://github.com/alpibrusl/noether/issues/44) for the compliance-matrix work landing alongside.
+
+Failure modes below apply to Phase 1. With `--isolate=bwrap`:
 
 | Message | Cause | Remedy |
 | --- | --- | --- |

--- a/docs/architecture/optimizer.md
+++ b/docs/architecture/optimizer.md
@@ -1,0 +1,92 @@
+# Graph Optimizer
+
+`noether run` applies a small set of structural rewrites to the composition graph between type-check and plan generation. Each pass is **semantics-preserving** — the rewritten graph must produce the same output as the original for every input the original would accept.
+
+```
+parse → resolve → check_graph → [optimize] → plan → execute
+```
+
+By the time a pass sees the graph, the resolver has collapsed signature pins to implementation ids and the type checker has confirmed the wiring. The `composition_id` was computed much earlier on the pre-resolution canonical form, so optimizer rewrites **never shift the identity of the composition**. Traces and cross-run correlation stay stable.
+
+Pass ordering in `noether run` is fixed:
+
+1. **`canonical_structural`** — lift the M1 canonical-form rewrites.
+2. **`dead_branch`** — fold `Branch` nodes with a constant predicate.
+3. **`memoize_pure`** — wire the `PureStageCache` into the executor.
+
+`canonical_structural` runs first so later passes see the flattened form. Each pass is independently disable-able via environment variable (see below).
+
+## The passes
+
+### `canonical_structural`
+
+Delegates to `lagrange::canonical::canonicalise` — the same function that shapes the form we hash. Rules (all tested as M1 laws):
+
+- Flatten nested `Sequential`: `Sequential[Sequential[a, b], c]` → `Sequential[a, b, c]`
+- Collapse singleton `Sequential`: `Sequential[a]` → `a`
+- Fuse adjacent `Retry`: `Retry{ Retry{ s, 3, _ }, 2, _ }` → `Retry{ s, 6, _ }`
+
+Before this pass existed, the rewrites only shaped the hashed form — the executor still walked every wrapper, every trace entry recorded it. `noether compose` emits nested Sequentials defensively; lifting the canonicalisation to execution time turns those wrappers into no-ops.
+
+### `dead_branch`
+
+Folds `Branch { predicate: Const(bool), … }` into the selected arm:
+
+```
+Branch {                                       Branch {
+  predicate: Const(true),   →   if_true         predicate: Const(false),   →   if_false
+  if_true: <arm>,                                if_true: <arm>,
+  if_false: <arm>,                               if_false: <arm>,
+}                                              }
+```
+
+Recurses into the selected arm, so chained dead branches collapse in one pass iteration. Non-constant predicates (the common case, and the whole point of `Branch`) are left alone. Non-bool constants are a type-check bug, so the pass is deliberately defensive: no guessing a truthiness rule, just leave the node.
+
+Motivated by agent-generated graphs: `noether compose` occasionally emits `Branch(Const(true), real, fallback)` as a defensive shape even when the fallback can never run. Pruning lets the planner skip wiring the dead arm entirely.
+
+### `memoize_pure`
+
+Not an AST pass — an executor-level wiring. A `PureStageCache` is built from the store (pre-populated with every stage whose `EffectSet` contains `Effect::Pure`), then `run_composition_with_cache` uses it to short-circuit repeated `(stage_id, input_hash)` pairs within a single run.
+
+The cache is in-memory, per-run, never persisted. Non-Pure stages are rejected at `get`/`put` via the pure-id set; the feature can't accidentally memoize something non-deterministic.
+
+When the cache fires, the ACLI response includes a `memoize: { enabled, hits, misses }` block so operators can see what it saved.
+
+## Opt-outs
+
+Two independent env vars:
+
+| Env var | Effect |
+|---|---|
+| `NOETHER_NO_OPTIMIZE=1` (or `=true`) | Skip `canonical_structural` and `dead_branch`. Useful for trace debugging and bug repros where the literal authored graph must reach the executor. |
+| `NOETHER_NO_MEMOIZE=1` (or `=true`) | Skip the `PureStageCache` wiring. Useful for benchmarks where every dispatch must go through the executor. |
+
+The two are independent — you can disable memoization while keeping the AST passes, or vice versa.
+
+## Extending the optimizer
+
+New passes implement the `OptimizerPass` trait:
+
+```rust
+pub trait OptimizerPass {
+    fn name(&self) -> &'static str;
+    fn rewrite(&self, node: CompositionNode) -> (CompositionNode, bool);
+}
+```
+
+A pass must:
+
+- **Return `(node, false)` when nothing changed** — the fixpoint runner uses this to terminate.
+- **Recurse into child nodes** — the runner doesn't walk the tree for you.
+- **Preserve leaf stage identities** — never rename or replace a `Stage`'s `id` field. Structural rewrites are safe; identity rewrites break content addressing.
+
+The `optimize(node, passes, max_iterations)` runner iterates until no pass reports a change or the cap is hit. `DEFAULT_MAX_ITERATIONS = 16` — enough for deep graphs to converge twice over, low enough that an oscillating pass fails loudly via `OptimizerReport.hit_iteration_cap`.
+
+## Roadmap
+
+The M3 milestone originally listed four passes. Three are shipped (`canonical_structural`, `dead_branch`, `memoize_pure`). The remaining two need deeper design:
+
+- **`fuse_pure_sequential`** — adjacent Pure stages merged into a single execution step. In a content-addressed system, you can't create a new "fused" stage (it would need its own hash); the mechanism has to be plan-level, not AST-level.
+- **`hoist_invariant`** — pull loop-invariant work out of loops. Noether has no loop primitive yet, so this is blocked on a future milestone.
+
+See [`docs/roadmap.md`](../roadmap.md) for the full M3 picture.

--- a/docs/guides/filesystem-effects.md
+++ b/docs/guides/filesystem-effects.md
@@ -1,0 +1,96 @@
+# Filesystem-scoped Effects
+
+`Effect::FsRead(path)` and `Effect::FsWrite(path)` let a stage declare the specific host paths it reads from or writes to. `IsolationPolicy::from_effects` scans for them and generates the matching bind mounts automatically — no caller plumbing.
+
+Before these variants landed, the `EffectSet` vocabulary had nothing between "the stage doesn't touch the filesystem at all" and "the stage is `Process`-effectful, good luck". Consumers with a richer trust model (agentspec's `filesystem: scoped`, agent-coding runtimes that operate on a specific project directory) had to bypass the effect surface and build `IsolationPolicy` by hand. These variants close that gap.
+
+## Declaring the effects
+
+In a stage spec:
+
+```json
+{
+  "name": "read_config_file",
+  "signature": {
+    "input":  "Null",
+    "output": { "Record": { "config": "Text" } },
+    "effects": [
+      { "effect": "FsRead", "path": "/etc/agent/config.toml" }
+    ]
+  },
+  …
+}
+```
+
+or in Rust:
+
+```rust
+use noether_core::effects::{Effect, EffectSet};
+use std::path::PathBuf;
+
+let effects = EffectSet::new([
+    Effect::FsRead  { path: PathBuf::from("/etc/agent/config.toml") },
+    Effect::FsWrite { path: PathBuf::from("/tmp/agent-output") },
+]);
+```
+
+Each effect carries an absolute host path. Use separate entries for each path — the `EffectSet` is a `BTreeSet<Effect>` and distinct paths are distinct elements.
+
+## How it drives the policy
+
+`IsolationPolicy::from_effects` walks the set and emits binds:
+
+| Effect | Bind emitted |
+|---|---|
+| `Effect::FsRead { path: p }` | `RoBind { host: p, sandbox: p }` |
+| `Effect::FsWrite { path: p }` | `RwBind { host: p, sandbox: p }` |
+
+Paths appear at the same location inside the sandbox — the convention is 1:1 mapping so stage code doesn't need to know it's running under bwrap.
+
+`/nix/store` stays unconditionally bound read-only regardless of declared effects. Mount order `rw → ro → work_host` from [sandbox-isolation](./sandbox-isolation.md#caller-managed-filesystem-trust) is preserved, so a narrower RO effect can shadow a broader RW parent:
+
+```rust
+let effects = EffectSet::new([
+    Effect::FsWrite { path: PathBuf::from("/home/user/project") },
+    Effect::FsRead  { path: PathBuf::from("/home/user/project/.ssh") },
+]);
+```
+
+The sandbox emits `--bind /home/user/project /home/user/project` then `--ro-bind /home/user/project/.ssh /home/user/project/.ssh`. bwrap's later-wins-on-overlap rule keeps `.ssh` read-only inside a writable project dir.
+
+## What stays caller-managed
+
+`from_effects` doesn't automatically populate `work_host` — the scratch dir default is still `None` → sandbox-private tmpfs. Callers who need host-visible scratch opt in via `IsolationPolicy::with_work_host(path)`. That decision lives with the caller, not the effect vocabulary.
+
+## The trust framing
+
+The `FsRead` / `FsWrite` rustdoc spells out what the pattern around #39 made explicit for `RwBind`: **the crate cannot validate whether a declared path is sensible to share**. `FsWrite(/home/user)` is syntactically identical to `FsWrite(/tmp/project-output)` — both produce an RW bind. One is a terrible idea; one is the whole point of an agent-coding tool. The policy decision lives with the stage author.
+
+What the effect system *does* give you is a structured trust surface:
+
+- `EffectPolicy::restrict([EffectKind::FsRead])` — allow reads but no writes (via `--allow-effects fs-read`).
+- `EffectPolicy::restrict([EffectKind::FsRead, EffectKind::FsWrite])` — allow both.
+- No `--allow-effects` flag including `fs-write` — a stage declaring `FsWrite` is rejected at preflight, before any subprocess spawns.
+
+Combined with the sandbox, that's enough for a caller to say "I'll delegate to `noether-sandbox` only for stages whose effect surface stays within these kinds" without having to read every stage's implementation.
+
+## Relationship to `rw_binds` on `IsolationPolicy`
+
+Two layers:
+
+- **Effect surface** (`Effect::FsRead` / `FsWrite`) — declared in the stage signature, part of the content hash, visible to policy preflight.
+- **Policy surface** (`RoBind` / `RwBind` on `IsolationPolicy`) — the concrete mount instructions handed to bwrap.
+
+`from_effects` bridges them. Callers who need host paths that aren't declared in any stage's effects (e.g. adding a shared cache dir across multiple runs) can still extend the policy directly via `policy.rw_binds.push(...)` — the effect vocabulary drives the default, the policy API lets you go further if you know what you're doing.
+
+## When NOT to use these variants
+
+- **One-off scratch data inside `/work`.** That's what the sandbox-private tmpfs is for. Declaring `FsWrite(/work)` would be redundant (the policy's `--dir /work` already creates the writable tmpfs).
+- **Dynamic paths computed at run time.** `Effect::FsWrite(path)` is a signature-level claim — `path` is fixed when the stage is authored. A stage that writes to "wherever the user configures" needs a different surface; `Effect::FsWrite(/)` is not the right answer.
+- **Secret material.** If the stage needs access to `~/.ssh/id_rsa`, declare it and accept the trust widening, but probably pass the key as input data instead of binding the file. The effect surface is for what the stage *needs* at the filesystem layer; data should flow through the typed input.
+
+## See also
+
+- [guides/sandbox-isolation](./sandbox-isolation.md) — how `rw_binds` / `ro_binds` / `work_host` render to bwrap argv
+- [architecture/type-system](../architecture/type-system.md) — where effects fit in the signature
+- [agents/express-a-property](../agents/express-a-property.md) — the dense agent version of this narrative

--- a/docs/guides/sandbox-isolation.md
+++ b/docs/guides/sandbox-isolation.md
@@ -1,0 +1,85 @@
+# Sandbox & Isolation
+
+From v0.7 onwards, every Python / JavaScript / Bash stage subprocess runs inside a bubblewrap sandbox by default. This page covers the `--isolate` flag, what the sandbox actually guarantees, the caveats that bite in practice, and the Phase 2 roadmap.
+
+## The one-liner
+
+```bash
+noether run graph.json              # --isolate=auto: bwrap if available, else unsandboxed with a warning
+noether run graph.json --isolate=bwrap          # require bwrap; hard error if missing
+noether run graph.json --isolate=none --unsafe-no-isolation  # explicit opt-out, silences the warning
+noether run graph.json --require-isolation      # auto-to-none fallback becomes a hard error
+```
+
+`--isolate=auto` is the default. In CI or any environment where running a stage unsandboxed is never the right answer, set `NOETHER_REQUIRE_ISOLATION=1` (or pass `--require-isolation`).
+
+## What the sandbox does
+
+When `--isolate=bwrap` (or auto with bwrap found), the stage subprocess runs with:
+
+- `--unshare-all` — fresh user / pid / uts / ipc / mount / cgroup / network namespaces.
+- `--uid 65534 --gid 65534` — mapped to the conventional `nobody/nogroup` identity. The stage cannot observe the host user's real UID.
+- `--die-with-parent` — if the engine dies, the sandbox dies with it.
+- `--proc /proc`, `--dev /dev`, `--tmpfs /tmp` — minimal rootfs skeleton.
+- `--ro-bind /nix/store /nix/store` — Nix-pinned runtimes resolve inside the sandbox.
+- `--bind <work_host> /work` *or* `--dir /work` — a writable scratch. The default is a sandbox-private tmpfs; callers who need host visibility opt in via `IsolationPolicy::with_work_host`.
+- `--clearenv` — the environment is wiped, then the executor re-adds the allowlisted variables.
+- `--cap-drop ALL` — every capability dropped inside the sandbox.
+- `--share-net` — only when the stage declares `Effect::Network`. When network is shared, `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, and `/etc/ssl/certs` are `--ro-bind-try`'d so DNS and TLS still resolve.
+
+Two binaries expose the sandbox:
+
+- **`noether run`** — embeds the engine and applies the policy derived from each stage's `EffectSet`.
+- **`noether-sandbox`** — standalone binary (v0.7.1+). Reads an `IsolationPolicy` as JSON on stdin (or `--policy-file <path>`), runs the argv after `--` inside the sandbox. For Python / Node / Go / shell callers that want to delegate without embedding the crate.
+
+## What the sandbox does NOT guarantee
+
+- **It is Phase 1, not Phase 2.** The v0.7.x sandbox relies on bubblewrap as a subprocess wrapper. That's enough for LLM-synthesized stages you haven't audited and for "I don't want a runaway test writing to my home directory" — not enough for genuinely hostile code targeting shared-kernel multi-tenant hosts. The threat model is spelled out in [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md).
+- **It is Linux-only.** bwrap doesn't exist on macOS or Windows. The `noether-sandbox` binary compiles on those platforms (so cross-platform CI catches breakage) but fails at run time with `IsolationError::BackendUnavailable`. macOS / Windows release tarballs don't ship a sandbox binary.
+- **Nix must be on `/nix/store`.** Distro-packaged `nix` (e.g. the Debian `nix-bin` package installing `/usr/bin/nix`) links to shared libraries outside `/nix/store` that the sandbox can't bind. The sandbox fails with a clear message pointing at the Determinate / upstream installer (which places `nix` under `/nix/store`).
+- **Reproducibility is not isolation.** Two separate boundaries: Nix pins the runtime (same Python, same NumPy, same everything → same output), bubblewrap bounds the stage's view of the host (fs, net, env). They're orthogonal.
+
+## Caller-managed filesystem trust
+
+Two fields on `IsolationPolicy` let callers widen the default posture:
+
+- **`ro_binds: Vec<RoBind>`** — always includes `/nix/store`. `IsolationPolicy::from_effects` adds one per `Effect::FsRead(path)` declared on the stage.
+- **`rw_binds: Vec<RwBind>`** — empty by default. `from_effects` adds one per `Effect::FsWrite(path)`.
+
+Mount order is **`rw_binds → ro_binds → work_host`**. RW first lets a narrower RO shadow a broader RW parent:
+
+```
+rw_binds: [{ host: "/home/user/project", sandbox: "/home/user/project" }]
+ro_binds: [{ host: "/home/user/project/.ssh", sandbox: "/home/user/project/.ssh" }]
+```
+
+The whole project is writable, but `.ssh` inside it is RO — bwrap applies binds in argv order and the later one wins for overlapping subpaths.
+
+`rw_binds` is a deliberate trust widening. The crate cannot validate whether binding `/home/user` RW is sensible — that's a policy decision the caller is making. The rustdoc on `RwBind` says this in plain language.
+
+For how filesystem effects drive this automatically, see [guides/filesystem-effects](./filesystem-effects.md).
+
+## Common failure modes
+
+| Message on stderr | Cause | Remedy |
+|---|---|---|
+| `bubblewrap (bwrap) not found on PATH` with `--isolate=bwrap` | bwrap isn't installed | `apt install bubblewrap` / `brew install bubblewrap` / `nix profile install nixpkgs#bubblewrap` |
+| `bwrap resolved via $PATH` (warning) | bwrap found outside a trusted system path | Install to `/usr/bin` or a root-owned Nix profile. PATH-planting risk |
+| `nix is installed at /usr/bin/nix (outside /nix/store)` | Distro-packaged Nix | Install via the Determinate or upstream installer; or run with `--isolate=none` |
+| `refusing to run without isolation` | `--require-isolation` / `NOETHER_REQUIRE_ISOLATION=1` set, bwrap unavailable | Install bwrap or drop the flag |
+| Network declared but DNS silently fails inside the sandbox | `/etc/resolv.conf` / `/etc/hosts` / `/etc/nsswitch.conf` missing on host | The sandbox does `--ro-bind-try`; if the host file is absent it's a no-op. Create the missing file(s) — a one-line `/etc/resolv.conf` with `nameserver 1.1.1.1` is enough for a smoke test |
+
+`noether run` exits with code **1** for all of the above (parse / resolution / preflight). Full exit-code map lives in [tutorial/when-things-go-wrong](../tutorial/when-things-go-wrong.md).
+
+## Phase 2 roadmap
+
+**v0.7.x is Phase 1** — bubblewrap as a subprocess wrapper. Target for **v0.8** is Phase 2: replace the bwrap subprocess with in-process `unshare` + Landlock (for filesystem scoping) + seccomp (for syscall filtering). The `IsolationPolicy` surface stays — the policy you build today survives the switch. Expected win: ~10× lower startup overhead (no subprocess fork per stage) and finer-grained syscall control.
+
+Tracked on the [roadmap](../roadmap.md) under `Phase 2 isolation`. Issue [#44](https://github.com/alpibrusl/noether/issues/44) covers the compliance-matrix / threat-model-docs piece that lands alongside it.
+
+## See also
+
+- [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md) — full threat model
+- [guides/filesystem-effects](./filesystem-effects.md) — path-scoped `Effect::FsRead` / `FsWrite` driving the policy
+- [tutorial/when-things-go-wrong](../tutorial/when-things-go-wrong.md) — human-readable failure narrative
+- [agents/debug-a-failed-graph](../agents/debug-a-failed-graph.md) — the same terrain in machine-parseable form

--- a/docs/tutorial/concepts.md
+++ b/docs/tutorial/concepts.md
@@ -119,6 +119,8 @@ The canonical form of this graph gets a `composition_id` (SHA-256 of the JCS-ser
 
 The engine runs the checker against the graph, builds an `ExecutionPlan`, and only then dispatches the stages. Every execution writes a trace indexed by the composition id, so `noether trace <id>` reproduces the full story.
 
+**Between the checker and the planner, an optimizer applies semantics-preserving rewrites** — flatten nested `Sequential`, collapse singletons, fold `Branch` with a constant predicate, memoize Pure-tagged stages within a run. These never touch leaf stage identities, so the `composition_id` stays stable. Disable with `NOETHER_NO_OPTIMIZE=1` if you want the literal authored graph to reach the executor (useful for trace debugging). Details: [architecture/optimizer.md](../architecture/optimizer.md).
+
 See [architecture/composition-engine.md](../architecture/composition-engine.md) for the operator semantics.
 
 ---

--- a/docs/tutorial/when-things-go-wrong.md
+++ b/docs/tutorial/when-things-go-wrong.md
@@ -152,9 +152,11 @@ When a user reports "noether did the wrong thing," the trace is the first artifa
 
 ---
 
-## Isolation-specific failures (v0.7+)
+## Isolation-specific failures (Phase 1, v0.7.x)
 
-From v0.7, stages run in a bubblewrap sandbox by default. The relevant failure modes:
+From v0.7, stages run in a bubblewrap sandbox by default. This is Phase 1 — a subprocess wrapper around bwrap. **Phase 2** (v0.8, roadmapped) replaces the subprocess with in-process `unshare` + Landlock + seccomp; same `IsolationPolicy` surface, finer-grained syscall control, lower startup cost. See [guides/sandbox-isolation](../guides/sandbox-isolation.md) for the full sandbox story and the [roadmap](../roadmap.md) for Phase 2 timing.
+
+Failure modes below apply to Phase 1:
 
 | Message | Cause | Remedy |
 |---|---|---|

--- a/examples/property-annotated/README.md
+++ b/examples/property-annotated/README.md
@@ -1,0 +1,47 @@
+# `take_first_n` — a property-annotated stage
+
+A worked example of a stage that declares **three** properties the engine checks against the declared examples at `noether stage add` time (and can re-run later via `noether stage verify`).
+
+## What the stage does
+
+`take_first_n` takes a list and a count, returns the first `n` elements of the list:
+
+```
+{ items: List<Any>, n: Number } → List<Any>
+```
+
+## What properties are declared
+
+| Property | Kind | What it claims |
+|---|---|---|
+| `n` is non-negative | `Range` | `input.n ≥ 0` for every example |
+| Output no longer than input | `FieldLengthMax` | `len(output) ≤ len(input.items)` |
+| Every output element came from input | `SubsetOf` | every element in `output` appears in `input.items` |
+
+Together these rule out a broken implementation that (a) accepts a negative `n`, (b) invents elements that weren't in the input, or (c) returns more elements than it was given. None of those are caught by the type checker — they're value-level invariants, which is what the property DSL exists for.
+
+## Register and verify
+
+From this directory:
+
+```bash
+# Register the stage (properties are checked against examples at add-time)
+noether stage add take_first_n.json
+
+# Re-run the properties later (e.g. after a registry pull, in CI)
+noether stage verify <id-or-prefix>
+
+# Restrict to property checks only (skip signature verification)
+noether stage verify <id-or-prefix> --properties
+```
+
+A successful `stage add` means every declared example passes every declared property. If you edit an example so the output has more elements than the input, `stage add` refuses — the `FieldLengthMax` property catches the violation before the stage lands in the store.
+
+## Why properties beat runtime assertions
+
+Every example runs through the property checker at registration time. Violations can't ship. And unlike a unit test that sits in some parallel test suite, the properties travel with the stage spec — any consumer pulling the stage from a registry gets them automatically and can re-verify with `noether stage verify`.
+
+## Further reading
+
+- [`express-a-property`](../../docs/agents/express-a-property.md) — the dense agent-facing reference for picking property kinds and wiring field paths
+- [`architecture/type-system`](../../docs/architecture/type-system.md) — why properties sit alongside, not inside, the type system

--- a/examples/property-annotated/take_first_n.json
+++ b/examples/property-annotated/take_first_n.json
@@ -1,0 +1,53 @@
+{
+  "name": "take_first_n",
+  "description": "Return the first n elements of a list. The two bounds on the output length (non-negative n, output ≤ input) are declared as properties and checked against every example at `stage add` time.",
+  "input": {
+    "kind": "Record",
+    "value": {
+      "items": { "kind": "List", "value": { "kind": "Any" } },
+      "n": { "kind": "Number" }
+    }
+  },
+  "output": { "kind": "List", "value": { "kind": "Any" } },
+  "effects": [ { "effect": "Pure" } ],
+  "language": "rust",
+  "implementation": {
+    "language": "rust",
+    "code": "fn execute(input: &serde_json::Value) -> serde_json::Value {\n    let items = input.get(\"items\").and_then(|v| v.as_array()).cloned().unwrap_or_default();\n    let n = input.get(\"n\").and_then(|v| v.as_u64()).unwrap_or(0) as usize;\n    let taken: Vec<_> = items.into_iter().take(n).collect();\n    serde_json::Value::Array(taken)\n}"
+  },
+  "properties": [
+    {
+      "kind": "Range",
+      "field": "input.n",
+      "min": 0
+    },
+    {
+      "kind": "FieldLengthMax",
+      "subject_field": "output",
+      "bound_field": "input.items"
+    },
+    {
+      "kind": "SubsetOf",
+      "subject_field": "output",
+      "super_field": "input.items"
+    }
+  ],
+  "examples": [
+    {
+      "input": { "items": [1, 2, 3, 4, 5], "n": 0 },
+      "output": []
+    },
+    {
+      "input": { "items": [1, 2, 3, 4, 5], "n": 3 },
+      "output": [1, 2, 3]
+    },
+    {
+      "input": { "items": ["a", "b", "c"], "n": 10 },
+      "output": ["a", "b", "c"]
+    },
+    {
+      "input": { "items": [], "n": 5 },
+      "output": []
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
     - Debug a failed graph: agents/debug-a-failed-graph.md
   - Guides:
     - Building Custom Stages: guides/custom-stages.md
+    - Sandbox & Isolation: guides/sandbox-isolation.md
+    - Filesystem-scoped Effects: guides/filesystem-effects.md
     - Composition Graphs: guides/composition-graphs.md
     - LLM-Powered Compose: guides/llm-compose.md
     - Semantic Search: guides/semantic-search.md
@@ -86,6 +88,7 @@ nav:
     - Type System: architecture/type-system.md
     - Stage Identity: architecture/stage-identity.md
     - Composition Engine: architecture/composition-engine.md
+    - Optimizer: architecture/optimizer.md
     - Nix Execution: architecture/nix-execution.md
   - Reference:
     - CLI Commands: cli/commands.md


### PR DESCRIPTION
## Summary

README, mkdocs, and the tutorial had drifted behind the last four shipped deliverables. This pass closes the gap — no code changes.

## What lands

### New pages

- **`docs/architecture/optimizer.md`** — pipeline position, per-pass semantics with before/after, `OptimizerPass` trait contract, `NOETHER_NO_OPTIMIZE` / `NOETHER_NO_MEMOIZE` opt-outs, honest note that `fuse_pure_sequential` / `hoist_invariant` need planner-level work rather than AST passes.
- **`docs/guides/sandbox-isolation.md`** — `--isolate=` flag, bwrap guarantees + caveats (distro-nix, DNS, mount order), caller-managed filesystem trust, common failure modes, Phase 1 → Phase 2 roadmap (v0.8).
- **`docs/guides/filesystem-effects.md`** — `Effect::FsRead` / `FsWrite` wire form, `from_effects` bind derivation, mount ordering with narrower-RO-wins worked example, trust framing (caller-authored, not crate-validated).

### Updated pages

- **`README.md`** — "What's new in v0.7" section covering sandbox, `noether-isolation` / `noether-sandbox` crates, `rw_binds` + `FsRead` / `FsWrite`, optimizer, parametric-polymorphism foundation.
- **`docs/agents/debug-a-failed-graph.md`** — isolation section distinguishes Phase 1 (v0.7.x bwrap) from Phase 2 (v0.8 native namespaces, roadmapped) so agents don't mistake current-shipped for final-state.
- **`docs/tutorial/concepts.md`** — 3-sentence optimizer subsection pointing at the architecture page.
- **`docs/tutorial/when-things-go-wrong.md`** — Phase 1 / Phase 2 framing on the isolation failure section + forward-ref to the new sandbox guide.

### New example

- **`examples/property-annotated/`** — `take_first_n` stage declaring three properties (`Range`, `FieldLengthMax`, `SubsetOf`) with four examples that exercise each. Demonstrates value-level invariants the type system can't catch. `noether stage add` refuses the spec if any example violates any property.

### Nav

- `mkdocs.yml` — `Sandbox & Isolation` + `Filesystem-scoped Effects` under Guides; `Optimizer` under Concepts.

## Test plan

- [x] `mkdocs build` — clean on the new tree. Pre-existing `../../STABILITY.md` / `../../SECURITY.md` warnings are unchanged (they live in pages I didn't touch)
- [x] No Rust changes, no `cargo` gates applicable

## What this does NOT do

- **No rewrite of `docs/tutorial/index.md`** (the old citecheck walkthrough). The front-of-page warning from PR #41 still sends readers to the three v0.7 tutorial pages. A proper rewrite against the current CLI + Lagrange format is a bigger project worth its own PR.
- **No generic-stdlib-stage examples** (parametric polymorphism slice 3 hasn't landed — no `identity` / `head` / `tail` / `map` to show yet).
- **No mention of slice 2b** (unification binding propagation through `check_graph`) beyond the roadmap pointer; it's flagged as pending in the M3 row.

## Related

- #56, #57, #58 — M3 optimizer passes
- #59 — unification module
- #60 — `NType::Var` + `NType ↔ Ty` conversion
- #55 — M3.x `Effect::FsRead` / `FsWrite`
- #47 — `IsolationPolicy.rw_binds`
- #37 — `noether-isolation` extraction + `noether-sandbox` binary

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>