### PR TITLE
feat(stdlib): generic identity / head / tail stages (M3 parametric polymorphism slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+### Added — three generic stdlib stages (M3 parametric polymorphism slice 3)
+
+First stdlib stages whose signatures carry `NType::Var`. Slice 2b (PR #62) made `check_graph` propagate bindings end-to-end; these three stages are what that propagation now visibly does.
+
+- **`identity: <T> → <T>`** — returns the input unchanged. Simplest possible polymorphic stage; the test probe for "does slice 2b's substitution threading actually reach the stdlib."
+- **`head: List<<T>> → <T>`** (Pure + Fallible) — first element of a list. Empty list surfaces as a typed `StageFailed` error, matching the Fallible effect.
+- **`tail: List<<T>> → List<<T>>`** — every element except the first. Total: empty input → empty output. Declares two properties: `FieldLengthMax` (output no longer than input) and `SubsetOf` (every output element came from the input).
+
+A polymorphic `list_length: List<<T>> → Number` was considered and skipped — the existing `list_length: List<Any> → Number` in `collections.rs` already resolves concrete upstreams via the Any-is-compatible rule, so a Var-shaped copy would be a name-clashing duplicate without new semantics.
+
+### Tests — end-to-end polymorphism verification
+
+New `crates/noether-engine/tests/generic_stdlib_polymorphism.rs`: five tests that pipe concrete upstream stages into the polymorphic stdlib stages and assert that `CheckResult.resolved.output` is the concrete type, not a `Var`. Before slice 2b these would have trivially passed via the permissive `is_subtype_of` short-circuit without proving anything; after slice 2b they are meaningful — a regression in the substitution-threading code would make them fail loudly.
+
+- `identity_resolves_to_concrete_output` — single-hop propagation
+- `chained_identity_propagates_through_multiple_hops` — `identity >> identity` stays bound
+- `head_of_concrete_list_resolves_to_element_type` — `List<Number>` piped into `head` yields `Number`
+- `tail_preserves_list_element_type` — `tail` preserves `List<Number>`
+- `head_then_identity_binds_both_vars_to_same_concrete` — two distinct Vars (T in `head`, T in `identity`) both bind to the same concrete type along the pipeline
+
+### What this does NOT do
+
+- **No `map` / `filter`.** They need higher-order type support (a stage passed as a value). That's a separate milestone, not slice 3.
+- **No rewrite of the existing `list_length`.** The Any version works; deprecating it to promote a Var version is a stdlib-curation decision for M4.
+- **No removal of the permissive `Var` short-circuit** in `is_subtype_of`. Tightening it comes after row polymorphism and refinement types — both still pending for M3.
+
 ### Changed — `check_graph` threads unification through every edge (M3 parametric polymorphism slice 2b)
 
 Slice 2 (PR #60) added `NType::Var` and made it permissively compatible in `is_subtype_of`. Slice 2b makes the propagation real: the checker carries a `Substitution` through the graph walk, and at every edge where either side contains a `Var` it invokes the unifier to extend the substitution and rewrite downstream types so later edges see the bound concrete form.

--- a/crates/noether-core/src/stdlib/generic.rs
+++ b/crates/noether-core/src/stdlib/generic.rs
@@ -1,0 +1,121 @@
+//! Generic (polymorphic) stdlib stages — M3 slice 3.
+//!
+//! These stages carry [`NType::Var`] in their signatures. The M3 slice 2b
+//! changes to [`crate::types::unification`] and the engine's `check_graph`
+//! mean that composing one of these with a concrete upstream (e.g.
+//! `text_to_number >> identity`) type-checks end-to-end with the
+//! concrete type flowing through — the resolved output is `Number`, not
+//! `<T>`.
+//!
+//! All four are `Pure`. `head` is additionally `Fallible` — an empty
+//! input list has no first element, so the runtime surfaces the error
+//! rather than returning a surprising default.
+//!
+//! None of these are higher-order — `map` / `filter` stay in
+//! `collections.rs` because they take a stage id as input; a generic
+//! version needs proper higher-order type support which is a later
+//! milestone.
+
+use crate::effects::{Effect, EffectSet};
+use crate::stage::property::Property;
+use crate::stage::{Stage, StageBuilder};
+use crate::types::NType;
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+
+pub fn stages(key: &SigningKey) -> Vec<Stage> {
+    vec![
+        // identity : <T> -> <T>
+        // Trivial polymorphic stage. Useful as a test probe for the
+        // type checker (does slice 2b's substitution threading actually
+        // bind <T> at the edge?) and as a no-op placeholder in graphs
+        // where a stage is expected but none is needed.
+        StageBuilder::new("identity")
+            .input(NType::var("T"))
+            .output(NType::var("T"))
+            .pure()
+            .description("Return the input unchanged. Polymorphic: <T> -> <T>.")
+            .example(json!("hello"), json!("hello"))
+            .example(json!(42), json!(42))
+            .example(json!(true), json!(true))
+            .example(json!([1, 2, 3]), json!([1, 2, 3]))
+            .example(json!({ "a": 1 }), json!({ "a": 1 }))
+            .tag("generic")
+            .tag("polymorphic")
+            .tag("pure")
+            .alias("id")
+            .alias("pass_through")
+            .alias("no_op")
+            .build_stdlib(key)
+            .unwrap(),
+        // head : List<<T>> -> <T>
+        // First element of a list. Empty list -> typed execution error;
+        // that's the Fallible effect.
+        StageBuilder::new("head")
+            .input(NType::List(Box::new(NType::var("T"))))
+            .output(NType::var("T"))
+            .effects(EffectSet::new([Effect::Pure, Effect::Fallible]))
+            .description("Return the first element of a list. Empty list is a Fallible error.")
+            .example(json!([1, 2, 3]), json!(1))
+            .example(json!(["a"]), json!("a"))
+            .example(json!([true, false]), json!(true))
+            .example(json!([[1, 2], [3, 4]]), json!([1, 2]))
+            .example(json!([null, 1]), json!(null))
+            .tag("generic")
+            .tag("polymorphic")
+            .tag("list")
+            .tag("fallible")
+            .tag("pure")
+            .alias("first")
+            .alias("car")
+            .alias("list_head")
+            .build_stdlib(key)
+            .unwrap(),
+        // tail : List<<T>> -> List<<T>>
+        // All but the first element. Total: empty list -> empty list.
+        StageBuilder::new("tail")
+            .input(NType::List(Box::new(NType::var("T"))))
+            .output(NType::List(Box::new(NType::var("T"))))
+            .pure()
+            .description(
+                "Return every element of a list except the first. Empty list -> empty list.",
+            )
+            // Output length is always (input length - 1), clamped at 0.
+            // `FieldLengthMax` pins "output no longer than input" — the
+            // weaker half of that invariant, but enough to rule out an
+            // implementation that invents elements.
+            .property(Property::FieldLengthMax {
+                subject_field: "output".into(),
+                bound_field: "input".into(),
+            })
+            // Every element of the output came from the input (it's a
+            // suffix of it). `SubsetOf` catches an implementation that
+            // rewrites elements.
+            .property(Property::SubsetOf {
+                subject_field: "output".into(),
+                super_field: "input".into(),
+            })
+            .example(json!([1, 2, 3]), json!([2, 3]))
+            .example(json!(["a", "b"]), json!(["b"]))
+            .example(json!([true]), json!([]))
+            .example(json!([]), json!([]))
+            .example(json!([1, 2, 3, 4, 5]), json!([2, 3, 4, 5]))
+            .tag("generic")
+            .tag("polymorphic")
+            .tag("list")
+            .tag("pure")
+            .alias("rest")
+            .alias("cdr")
+            .alias("list_tail")
+            .build_stdlib(key)
+            .unwrap(),
+        // (A separate polymorphic `list_length: List<<T>> -> Number` was
+        // considered here. Skipped: the existing `list_length` in
+        // `collections.rs` has signature `List<Any> -> Number`, which
+        // already resolves a concrete upstream via the Any-is-compatible
+        // rule, so an additional Var-shaped copy would be a name-clashing
+        // duplicate without buying new semantics. The point of slice 3
+        // is demonstrated by `identity` / `head` / `tail` — each of which
+        // declares a Var the existing stdlib does not.)
+    ]
+}

--- a/crates/noether-core/src/stdlib/mod.rs
+++ b/crates/noether-core/src/stdlib/mod.rs
@@ -1,6 +1,7 @@
 mod collections;
 mod control;
 mod data;
+mod generic;
 mod internal;
 mod io;
 mod kv;
@@ -38,6 +39,7 @@ pub fn load_stdlib() -> Vec<Stage> {
     stages.extend(validation::stages(&key));
     stages.extend(ui::stages(&key));
     stages.extend(process::stages(&key));
+    stages.extend(generic::stages(&key));
     stages
 }
 
@@ -46,9 +48,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn load_stdlib_returns_50_stages() {
+    fn load_stdlib_returns_expected_stage_count() {
         let stages = load_stdlib();
-        assert_eq!(stages.len(), 80); // 76 existing + 4 process stages
+        // 76 existing + 4 process + 3 generic (M3 slice 3: identity,
+        // head, tail — `list_length` is already covered by the Any
+        // variant in collections.rs)
+        assert_eq!(stages.len(), 83);
     }
 
     #[test]

--- a/crates/noether-engine/src/executor/stages/generic.rs
+++ b/crates/noether-engine/src/executor/stages/generic.rs
@@ -1,0 +1,99 @@
+//! Implementations for the polymorphic stdlib stages (M3 slice 3).
+//!
+//! Rust-native, no Nix. Each function operates on `&serde_json::Value`
+//! — at runtime `<T>` is just a JSON value of whatever concrete shape
+//! the upstream produced. The type checker ensures the shape is
+//! consistent before the graph executes.
+//!
+//! Mapping to stage descriptions (see `find_implementation` in this
+//! module's `mod.rs`):
+//!
+//! - "Return the input unchanged. Polymorphic: <T> -> <T>." → [`identity`]
+//! - "Return the first element of a list. Empty list is a Fallible error." → [`head`]
+//! - "Return every element of a list except the first. Empty list -> empty list." → [`tail`]
+
+use crate::executor::ExecutionError;
+use noether_core::stage::StageId;
+use serde_json::Value;
+
+/// `identity: <T> -> <T>` — pass through.
+pub fn identity(input: &Value) -> Result<Value, ExecutionError> {
+    Ok(input.clone())
+}
+
+/// `head: List<<T>> -> <T>` — first element, or a typed error on an
+/// empty list. Fallible-effect: callers wrap in `Retry` or surface
+/// the error through their composition.
+pub fn head(input: &Value) -> Result<Value, ExecutionError> {
+    let arr = input
+        .as_array()
+        .ok_or_else(|| ExecutionError::StageFailed {
+            stage_id: StageId("head".into()),
+            message: format!("expected list, got {input}"),
+        })?;
+    arr.first()
+        .cloned()
+        .ok_or_else(|| ExecutionError::StageFailed {
+            stage_id: StageId("head".into()),
+            message: "cannot take head of empty list".into(),
+        })
+}
+
+/// `tail: List<<T>> -> List<<T>>` — every element except the first.
+/// Total: empty input yields empty output, matching the declared example.
+pub fn tail(input: &Value) -> Result<Value, ExecutionError> {
+    let arr = input
+        .as_array()
+        .ok_or_else(|| ExecutionError::StageFailed {
+            stage_id: StageId("tail".into()),
+            message: format!("expected list, got {input}"),
+        })?;
+    let out: Vec<Value> = arr.iter().skip(1).cloned().collect();
+    Ok(Value::Array(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn identity_passes_through_any_json_shape() {
+        assert_eq!(identity(&json!(42)).unwrap(), json!(42));
+        assert_eq!(identity(&json!("hello")).unwrap(), json!("hello"));
+        assert_eq!(identity(&json!([1, 2, 3])).unwrap(), json!([1, 2, 3]));
+        assert_eq!(identity(&json!({"a": 1})).unwrap(), json!({"a": 1}));
+        assert_eq!(identity(&json!(null)).unwrap(), json!(null));
+    }
+
+    #[test]
+    fn head_of_non_empty_list() {
+        assert_eq!(head(&json!([1, 2, 3])).unwrap(), json!(1));
+        assert_eq!(head(&json!(["a", "b"])).unwrap(), json!("a"));
+        assert_eq!(head(&json!([null])).unwrap(), json!(null));
+    }
+
+    #[test]
+    fn head_of_empty_list_is_stage_failed() {
+        let err = head(&json!([])).unwrap_err();
+        assert!(matches!(err, ExecutionError::StageFailed { .. }));
+    }
+
+    #[test]
+    fn head_of_non_list_is_stage_failed() {
+        let err = head(&json!(42)).unwrap_err();
+        assert!(matches!(err, ExecutionError::StageFailed { .. }));
+    }
+
+    #[test]
+    fn tail_of_non_empty_list() {
+        assert_eq!(tail(&json!([1, 2, 3])).unwrap(), json!([2, 3]));
+        assert_eq!(tail(&json!(["a", "b"])).unwrap(), json!(["b"]));
+        assert_eq!(tail(&json!([true])).unwrap(), json!([]));
+    }
+
+    #[test]
+    fn tail_of_empty_list_is_empty_list() {
+        assert_eq!(tail(&json!([])).unwrap(), json!([]));
+    }
+}

--- a/crates/noether-engine/src/executor/stages/mod.rs
+++ b/crates/noether-engine/src/executor/stages/mod.rs
@@ -3,6 +3,7 @@ pub mod arrow;
 pub mod collections;
 pub mod control;
 pub mod data;
+pub mod generic;
 #[cfg(feature = "native")]
 pub mod io;
 #[cfg(feature = "native")]
@@ -25,6 +26,13 @@ pub type StageFn = fn(&Value) -> Result<Value, ExecutionError>;
 /// Returns None for stages without real implementations (LLM, Arrow, internal).
 pub fn find_implementation(description: &str) -> Option<StageFn> {
     match description {
+        // Generic (polymorphic — M3 slice 3)
+        "Return the input unchanged. Polymorphic: <T> -> <T>." => Some(generic::identity),
+        "Return the first element of a list. Empty list is a Fallible error." => Some(generic::head),
+        "Return every element of a list except the first. Empty list -> empty list." => {
+            Some(generic::tail)
+        }
+
         // Scalar
         "Convert any value to its text representation" => Some(scalar::to_text),
         "Parse a value as a number; fails on non-numeric text" => Some(scalar::to_number),

--- a/crates/noether-engine/tests/generic_stdlib_polymorphism.rs
+++ b/crates/noether-engine/tests/generic_stdlib_polymorphism.rs
@@ -1,0 +1,200 @@
+//! End-to-end tests for the generic stdlib stages landed in M3 slice 3.
+//!
+//! Each test builds a pipeline that pipes a concrete upstream into a
+//! polymorphic stdlib stage and asserts that `check_graph` resolves
+//! to the concrete type — proving slice 2b's substitution threading
+//! actually reaches the stdlib.
+//!
+//! Before slice 2b, the resolved type would have been `<T>` rather
+//! than `Number` / `Text` / `Bool`; the `is_subtype_of` permissive
+//! Var short-circuit still passed the check, but the resolved output
+//! carried no useful type information. These tests pin the post-2b
+//! behaviour so a regression in substitution threading would make
+//! them fail loudly.
+
+use noether_core::stage::{CostEstimate, Stage, StageId, StageLifecycle, StageSignature};
+use noether_core::stdlib::load_stdlib;
+use noether_core::types::NType;
+use noether_engine::checker::check_graph;
+use noether_engine::lagrange::{CompositionNode, Pinning};
+use noether_store::{MemoryStore, StageStore};
+use std::collections::BTreeSet;
+
+/// Build a store seeded with the full stdlib plus a handful of
+/// hand-rolled stages that give us concrete types to feed into the
+/// polymorphic ones.
+fn init_store() -> MemoryStore {
+    let mut store = MemoryStore::new();
+    for stage in load_stdlib() {
+        store.put(stage).unwrap();
+    }
+    // Probe stages: provide concrete upstream / downstream shapes.
+    store
+        .put(make_stage("text_to_num", NType::Text, NType::Number))
+        .unwrap();
+    store
+        .put(make_stage(
+            "num_to_list",
+            NType::Number,
+            NType::List(Box::new(NType::Number)),
+        ))
+        .unwrap();
+    store
+        .put(make_stage(
+            "text_to_bool_list",
+            NType::Text,
+            NType::List(Box::new(NType::Bool)),
+        ))
+        .unwrap();
+    store
+}
+
+fn make_stage(id: &str, input: NType, output: NType) -> Stage {
+    Stage {
+        id: StageId(id.into()),
+        signature_id: None,
+        signature: StageSignature {
+            input,
+            output,
+            effects: noether_core::effects::EffectSet::pure(),
+            implementation_hash: format!("impl_{id}"),
+        },
+        capabilities: BTreeSet::new(),
+        cost: CostEstimate {
+            time_ms_p50: Some(1),
+            tokens_est: None,
+            memory_mb: None,
+        },
+        description: format!("probe stage {id}"),
+        examples: vec![],
+        lifecycle: StageLifecycle::Active,
+        ed25519_signature: None,
+        signer_public_key: None,
+        implementation_code: None,
+        implementation_language: None,
+        ui_style: None,
+        tags: vec![],
+        aliases: vec![],
+        name: None,
+        properties: Vec::new(),
+    }
+}
+
+/// Find the first active stdlib stage whose `name` matches. Panics
+/// if not found; the stage set is loaded directly from `load_stdlib`
+/// so a mismatch means the generic stages didn't register.
+fn find_stdlib(store: &MemoryStore, name: &str) -> StageId {
+    store
+        .list(None)
+        .into_iter()
+        .find(|s| s.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("stdlib stage '{name}' not found"))
+        .id
+        .clone()
+}
+
+fn stage_ref(id: StageId) -> CompositionNode {
+    CompositionNode::Stage {
+        id,
+        pinning: Pinning::Signature,
+        config: None,
+    }
+}
+
+fn probe(name: &str) -> CompositionNode {
+    CompositionNode::Stage {
+        id: StageId(name.into()),
+        pinning: Pinning::Both,
+        config: None,
+    }
+}
+
+#[test]
+fn identity_resolves_to_concrete_output() {
+    // text_to_num (Text -> Number) >> identity (<T> -> <T>)
+    // Resolved output must be Number — slice 2b's substitution threading
+    // binds <T> to Number at the edge.
+    let store = init_store();
+    let id = find_stdlib(&store, "identity");
+    let graph = CompositionNode::Sequential {
+        stages: vec![probe("text_to_num"), stage_ref(id)],
+    };
+    let check = check_graph(&graph, &store).expect("identity composition must type-check");
+    assert_eq!(check.resolved.input, NType::Text);
+    assert_eq!(
+        check.resolved.output,
+        NType::Number,
+        "identity's <T> must be bound to Number after unification — \
+         if the resolved output is a Var, slice 2b regressed"
+    );
+}
+
+#[test]
+fn chained_identity_propagates_through_multiple_hops() {
+    // text_to_num >> identity >> identity
+    // Two hops; substitution must survive across both.
+    let store = init_store();
+    let id = find_stdlib(&store, "identity");
+    let graph = CompositionNode::Sequential {
+        stages: vec![probe("text_to_num"), stage_ref(id.clone()), stage_ref(id)],
+    };
+    let check = check_graph(&graph, &store).expect("chained identity must type-check");
+    assert_eq!(check.resolved.output, NType::Number);
+}
+
+#[test]
+fn head_of_concrete_list_resolves_to_element_type() {
+    // num_to_list (Number -> List<Number>) >> head (List<<T>> -> <T>)
+    // head's output is Number, not <T>.
+    let store = init_store();
+    let head_id = find_stdlib(&store, "head");
+    let graph = CompositionNode::Sequential {
+        stages: vec![probe("num_to_list"), stage_ref(head_id)],
+    };
+    let check = check_graph(&graph, &store).expect("head composition must type-check");
+    assert_eq!(
+        check.resolved.output,
+        NType::Number,
+        "head's <T> must be bound to Number"
+    );
+}
+
+#[test]
+fn tail_preserves_list_element_type() {
+    // num_to_list >> tail
+    // tail's output is List<Number>, not List<<T>>.
+    let store = init_store();
+    let tail_id = find_stdlib(&store, "tail");
+    let graph = CompositionNode::Sequential {
+        stages: vec![probe("num_to_list"), stage_ref(tail_id)],
+    };
+    let check = check_graph(&graph, &store).expect("tail composition must type-check");
+    assert_eq!(
+        check.resolved.output,
+        NType::List(Box::new(NType::Number)),
+        "tail's List<<T>> must be bound to List<Number>"
+    );
+}
+
+#[test]
+fn head_then_identity_binds_both_vars_to_same_concrete() {
+    // num_to_list >> head >> identity
+    // head binds its <T> to Number. identity's independent <T> must
+    // then bind to Number too (different variable name, same concrete).
+    let store = init_store();
+    let head_id = find_stdlib(&store, "head");
+    let identity_id = find_stdlib(&store, "identity");
+    let graph = CompositionNode::Sequential {
+        stages: vec![
+            probe("num_to_list"),
+            stage_ref(head_id),
+            stage_ref(identity_id),
+        ],
+    };
+    let check = check_graph(&graph, &store).expect("chain must type-check");
+    assert_eq!(
+        check.resolved.output,
+        NType::Number,
+        "identity after head must carry Number through, not a fresh Var"
+    );
+}

--- a/crates/noether-engine/tests/index_integration.rs
+++ b/crates/noether-engine/tests/index_integration.rs
@@ -25,7 +25,7 @@ fn build_index(store: &MemoryStore) -> SemanticIndex {
 fn index_all_stdlib_stages() {
     let store = init_store();
     let index = build_index(&store);
-    assert_eq!(index.len(), 80); // 76 existing + 4 process stages
+    assert_eq!(index.len(), 83); // 76 existing + 4 process + 3 generic (M3 slice 3)
 }
 
 #[test]

--- a/crates/noether-store/tests/stdlib_store.rs
+++ b/crates/noether-store/tests/stdlib_store.rs
@@ -9,7 +9,7 @@ fn load_all_stdlib_into_store() {
     for stage in stages {
         store.put(stage).unwrap();
     }
-    assert_eq!(store.len(), 80); // 70 + 5 validation stages + 1 UI (vnode_render)
+    assert_eq!(store.len(), 83); // + 3 generic (M3 slice 3)
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn all_stdlib_stages_are_active_in_store() {
         store.put(stage).unwrap();
     }
     let active = store.list(Some(&StageLifecycle::Active));
-    assert_eq!(active.len(), 80); // 70 + 5 validation stages + 1 UI (vnode_render)
+    assert_eq!(active.len(), 83); // + 3 generic (M3 slice 3)
 }
 
 #[test]
@@ -29,8 +29,8 @@ fn store_stats_after_stdlib_load() {
         store.put(stage).unwrap();
     }
     let stats = store.stats();
-    assert_eq!(stats.total, 80); // 70 + 5 validation stages + 1 UI (vnode_render)
-    assert_eq!(stats.by_lifecycle.get("active"), Some(&80));
+    assert_eq!(stats.total, 83); // + 3 generic (M3 slice 3)
+    assert_eq!(stats.by_lifecycle.get("active"), Some(&83));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

First stdlib stages carrying `NType::Var`. Slice 2b (#62) made `check_graph` propagate bindings end-to-end; these three stages are what that propagation now visibly does in real compositions.

## The stages

| Stage | Signature | Effects | Notes |
|---|---|---|---|
| `identity` | `<T> → <T>` | Pure | Trivial polymorphic; clean probe for slice 2b. |
| `head` | `List<<T>> → <T>` | Pure + Fallible | Empty list → typed `StageFailed`. |
| `tail` | `List<<T>> → List<<T>>` | Pure | Total. Two properties: `FieldLengthMax` (output no longer than input), `SubsetOf` (every output element came from the input). |

## What's NOT in this PR

- **No `map` / `filter`.** Higher-order type support (stage-as-value) is a separate milestone.
- **No polymorphic `list_length`.** The existing `list_length: List<Any> → Number` already resolves concrete upstreams via the Any-is-compatible rule; a Var-shaped copy would be a name-clashing duplicate. Flagged inline in `generic.rs`.
- **No deprecation of existing stages.** Curation is M4.

## Files

- `crates/noether-core/src/stdlib/generic.rs` — new module, stage specs.
- `crates/noether-engine/src/executor/stages/generic.rs` — Rust implementations with unit tests (empty / non-array / non-empty branches).
- `find_implementation` dispatch updated in `crates/noether-engine/src/executor/stages/mod.rs`.

## Tests (+5 end-to-end + 6 implementation unit tests)

`crates/noether-engine/tests/generic_stdlib_polymorphism.rs` — each test pipes a concrete upstream into one of the generic stages and asserts `CheckResult.resolved.output` is concrete, not `Var`:

- `identity_resolves_to_concrete_output`
- `chained_identity_propagates_through_multiple_hops`
- `head_of_concrete_list_resolves_to_element_type`
- `tail_preserves_list_element_type`
- `head_then_identity_binds_both_vars_to_same_concrete`

Before slice 2b these would have passed trivially (resolved output was `Var`, assertion never meaningful). After slice 2b they're load-bearing — any regression in substitution threading makes them fail.

Six unit tests inside `executor/stages/generic.rs` cover the implementations themselves (pass-through, head of empty / non-array, tail of empty / non-empty).

## Stage count bumped

`load_stdlib` returns 83 stages (was 80). Three hardcoded count assertions updated across noether-core / noether-engine / noether-store tests.

## Test plan

- [x] `cargo test --workspace` green. `stdlib_verifies` now runs the new examples through the registered implementations and passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Related

- #62 — slice 2b (unification through `check_graph`), prerequisite
- #60 — slice 2 (`NType::Var` + conversion)
- #59 — slice 1 (unification module)

## M3 status after this merges

- ✅ Optimizer framework + 3/4 passes landed (fuse_pure_sequential, hoist_invariant flagged as planner work)
- ✅ Parametric polymorphism: slices 1, 2, 2b, 3 all landed
- ⏳ Row polymorphism — not started
- ⏳ Refinement types — not started

Two tracks to go for M3 full close-out.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>