### PR TITLE
chore: v0.8.0 — M3 close-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.8.0 — 2026-04-21
+
+**M3: Optimizer + Richer Types — shipped.** Four tracks landed in one push: a real graph optimizer, parametric polymorphism end-to-end, row polymorphism on records, and refinement types with a runtime validator. The entries below recap what shipped since v0.7.3.
+
+### Headline additions
+
+- **Parametric polymorphism.** Stage signatures can carry `NType::Var("T")`; `check_graph` threads substitutions through every edge so `text_to_num >> identity` resolves its output to `Number`, not `<T>`. Stdlib gains `identity`, `head`, `tail`.
+- **Row polymorphism.** `NType::RecordWith { fields, rest }` captures unknown extra fields via a row variable; `Record ~ RecordWith` unification binds the tail, so `{ name, age } >> mark_done` resolves to `Record { name, age, done }` instead of silently dropping the extras.
+- **Refinement types.** `NType::Refined { base, refinement }` attaches runtime-checkable predicates — `Range`, `OneOf`, `NonEmpty`. Available as type-level constraints today; auto-enforcement at stage-execute boundaries is a v0.8.x follow-up.
+- **Graph optimizer.** Runs between type-check and plan: `canonical_structural` flattens nested wrappers, `dead_branch` folds `Branch(Const(bool), …)`, `memoize_pure` caches repeated Pure-stage invocations within a run. Opt-outs via `NOETHER_NO_OPTIMIZE=1` / `NOETHER_NO_MEMOIZE=1`.
+
+### Stdlib: 85 stages (was 80)
+
+Five new polymorphic / refined stages: `identity`, `head`, `tail`, `mark_done`, `clamp_percent`. Existing stages are unchanged — content-addressing means no migration needed.
+
+### Wire-format compatibility
+
+Every v0.7.x payload is a valid v0.8 payload. The three new `NType` variants (`Var`, `RecordWith`, `Refined`) are additive and placed at the end of the enum so discriminant ordering of existing stages stays bit-identical.
+
+### Deferred follow-ups (flagged honestly)
+
+- Refinement runtime auto-enforcement at stage-execute boundaries
+- Predicate implication for refinement subtyping (e.g., `Range(0..=10) <: Range(0..=100)`)
+- `RecordWith ↔ RecordWith` unification with shared-tail splitting
+- Higher-order stdlib generics (`map`, `filter` as true `<A> → <B>` stages) — need stage-as-value support
+- `fuse_pure_sequential` + `hoist_invariant` as planner-level passes
+
 ### Added — refinement types (M3 last slice)
 
 `NType::Refined { base, refinement }` attaches a runtime-checkable predicate to any base type. A refinement is one of:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/noether"

--- a/crates/noether-cli/Cargo.toml
+++ b/crates/noether-cli/Cargo.toml
@@ -14,9 +14,9 @@ name = "noether"
 path = "src/main.rs"
 
 [dependencies]
-noether-core = { path = "../noether-core", version = "0.7" }
-noether-store = { path = "../noether-store", version = "0.7" }
-noether-engine = { path = "../noether-engine", version = "0.7" }
+noether-core = { path = "../noether-core", version = "0.8" }
+noether-store = { path = "../noether-store", version = "0.8" }
+noether-engine = { path = "../noether-engine", version = "0.8" }
 acli = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/noether-engine/Cargo.toml
+++ b/crates/noether-engine/Cargo.toml
@@ -17,9 +17,9 @@ default = ["native"]
 native = ["dep:reqwest", "dep:rusqlite", "dep:arrow", "dep:base64", "dep:llm-here-core"]
 
 [dependencies]
-noether-core = { path = "../noether-core", version = "0.7" }
-noether-store = { path = "../noether-store", version = "0.7" }
-noether-isolation = { path = "../noether-isolation", version = "0.7" }
+noether-core = { path = "../noether-core", version = "0.8" }
+noether-store = { path = "../noether-store", version = "0.8" }
+noether-isolation = { path = "../noether-isolation", version = "0.8" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_jcs = "0.2"

--- a/crates/noether-grid-broker/Cargo.toml
+++ b/crates/noether-grid-broker/Cargo.toml
@@ -15,10 +15,10 @@ name = "noether-grid-broker"
 path = "src/main.rs"
 
 [dependencies]
-noether-grid-protocol = { path = "../noether-grid-protocol", version = "0.7" }
-noether-engine = { path = "../noether-engine", version = "0.7" }
-noether-store = { path = "../noether-store", version = "0.7" }
-noether-core = { path = "../noether-core", version = "0.7" }
+noether-grid-protocol = { path = "../noether-grid-protocol", version = "0.8" }
+noether-engine = { path = "../noether-engine", version = "0.8" }
+noether-store = { path = "../noether-store", version = "0.8" }
+noether-core = { path = "../noether-core", version = "0.8" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/noether-grid-worker/Cargo.toml
+++ b/crates/noether-grid-worker/Cargo.toml
@@ -15,10 +15,10 @@ name = "noether-grid-worker"
 path = "src/main.rs"
 
 [dependencies]
-noether-grid-protocol = { path = "../noether-grid-protocol", version = "0.7" }
-noether-core = { path = "../noether-core", version = "0.7" }
-noether-store = { path = "../noether-store", version = "0.7" }
-noether-engine = { path = "../noether-engine", version = "0.7" }
+noether-grid-protocol = { path = "../noether-grid-protocol", version = "0.8" }
+noether-core = { path = "../noether-core", version = "0.8" }
+noether-store = { path = "../noether-store", version = "0.8" }
+noether-engine = { path = "../noether-engine", version = "0.8" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/noether-isolation/Cargo.toml
+++ b/crates/noether-isolation/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 description = "Stage-execution sandbox policy + bubblewrap command builder. Extracted from noether-engine for consumers that want isolation without the full composition engine."
 
 [dependencies]
-noether-core = { path = "../noether-core", version = "0.7" }
+noether-core = { path = "../noether-core", version = "0.8" }
 serde        = { workspace = true }
 thiserror    = { workspace = true }
 tracing      = "0.1"

--- a/crates/noether-sandbox/Cargo.toml
+++ b/crates/noether-sandbox/Cargo.toml
@@ -14,6 +14,6 @@ name = "noether-sandbox"
 path = "src/main.rs"
 
 [dependencies]
-noether-core      = { path = "../noether-core", version = "0.7" }
-noether-isolation = { path = "../noether-isolation", version = "0.7" }
+noether-core      = { path = "../noether-core", version = "0.8" }
+noether-isolation = { path = "../noether-isolation", version = "0.8" }
 serde_json        = { workspace = true }

--- a/crates/noether-scheduler/Cargo.toml
+++ b/crates/noether-scheduler/Cargo.toml
@@ -14,9 +14,9 @@ name = "noether-scheduler"
 path = "src/main.rs"
 
 [dependencies]
-noether-core = { path = "../noether-core", version = "0.7" }
-noether-store = { path = "../noether-store", version = "0.7" }
-noether-engine = { path = "../noether-engine", version = "0.7" }
+noether-core = { path = "../noether-core", version = "0.8" }
+noether-store = { path = "../noether-store", version = "0.8" }
+noether-engine = { path = "../noether-engine", version = "0.8" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/noether-store/Cargo.toml
+++ b/crates/noether-store/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 description = "Noether stage store: immutable content-addressed registry of stages with lifecycle management"
 
 [dependencies]
-noether-core = { path = "../noether-core", version = "0.7" }
+noether-core = { path = "../noether-core", version = "0.8" }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 thiserror    = { workspace = true }


### PR DESCRIPTION
## Summary

No source changes. Version bump + CHANGELOG top entry summarising M3.

## What lands in v0.8.0

- **Parametric polymorphism end-to-end** (#59 / #60 / #62 / #63) — unification module, `NType::Var`, `check_graph` substitution threading, generic stdlib stages (`identity`, `head`, `tail`).
- **Row polymorphism** (#64) — `NType::RecordWith`, Record↔RecordWith unification, `mark_done` stdlib stage.
- **Refinement types** (#65) — `NType::Refined`, `Refinement` DSL (`Range` / `OneOf` / `NonEmpty`), runtime `validate_refinement`, integration with `validate_stage`, `clamp_percent` stdlib stage.
- **Graph optimizer** (#56 / #57 / #58) — framework + `dead_branch` + `canonical_structural` + `memoize_pure`.

5 new stdlib stages; total 85 (was 80).

## Deferred follow-ups (honest, in CHANGELOG)

- Refinement runtime auto-enforcement at stage-execute boundaries
- Predicate implication in refinement subtyping (`Range(0..=10) <: Range(0..=100)`)
- `RecordWith ↔ RecordWith` unification with shared-tail splitting
- Higher-order stdlib generics (`map`, `filter` as `<A> → <B>`)
- `fuse_pure_sequential` / `hoist_invariant` as planner passes

## Wire-format stability

v0.7.x payloads are valid v0.8 payloads. The three new `NType` variants are additive and placed at the enum's end so discriminant ordering for existing stages stays bit-identical.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI to confirm; then tag v0.8.0; release workflow publishes all 7 crates + tarballs

## Post-merge

1. Tag v0.8.0 — release workflow (fixed in #52) publishes everything
2. Small PR: wire `validate_refinement` into `run_composition` (closes the one honest deferred promise)
3. Rebuild noether-cloud so `registry.alpibru.com` surfaces the 5 new stdlib stages

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>