### PR TITLE
docs: new minimal mkdocs site, written against v0.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ crates/noether-engine/data.csv
 crates/noether-engine/empty.txt
 crates/noether-engine/log.txt
 crates/noether-engine/out.json
+site/

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,153 @@
+# Concepts
+
+The five ideas you need to hold in your head. Every other page assumes
+this one.
+
+## Stage
+
+A **stage** is an immutable unit of computation.
+
+```
+stage : { input: T } → { output: U }   # structural type signature
+      + EffectSet                       # declared side effects
+      + Option<Implementation>          # Rust fn, Python, JavaScript, Bash
+      + [Example…]                      # at least one input/output pair
+      + [Property…]                     # optional declarative checks
+```
+
+Two stages with the same hash are provably the same computation —
+across machines, across repositories, forever.
+
+```
+identity = SHA-256(canonical_json(signature + implementation_hash))
+```
+
+The identity hash is called the `StageId` (or `ImplementationId` — the
+two are type-aliases today). A second hash — the `SignatureId` —
+covers only `(name, input, output, effects)` and is stable across
+bug-fix reimplementations of the same stage.
+
+Stages live in a **store**: content-addressed, immutable, with a
+lifecycle (`Draft → Active → Deprecated → Tombstone`). Replacing a
+stage means publishing a new one with the same `SignatureId`; the
+store auto-deprecates the old implementation.
+
+## Type system
+
+Types are **structural**, not nominal. Two types are compatible if
+their structure matches — there's no registry of named types to
+coordinate on. Width and depth subtyping both apply:
+
+```
+Record { a: Text, b: Number, c: Bool }   <:   Record { a: Text, b: Number }
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^                ^^^^^^^^^^^^^^^^^^
+         subtype can carry extra fields            ...and fewer fields is OK
+```
+
+The `NType` enum covers:
+
+- **Primitives** — `Text`, `Number`, `Bool`, `Null`, `Bytes`, `VNode`, `Any`.
+- **Containers** — `List(T)`, `Map<K, V>`, `Record { f: T, … }`,
+  `Stream<T>`.
+- **Union** — flattened, deduped, sorted. `union()` is the only
+  normalising constructor.
+- **Parametric** (v0.8) — `Var("T")`. `identity: <T> → <T>`.
+- **Row-polymorphic record** (v0.8) — `RecordWith { fields, rest }`.
+  Captures known fields plus a row variable for the rest.
+- **Refined** (v0.8) — `Refined { base, refinement }`. A base type
+  with a runtime-checkable predicate: `Range { min, max }`,
+  `OneOf { options }`, `NonEmpty`.
+
+`Any` is a bidirectional escape hatch — `is_subtype_of(T, Any)` and
+`is_subtype_of(Any, T)` both hold. Use sparingly; it defeats the
+checker at that edge.
+
+**The checker verifies graph topology, not stage bodies.** A stage
+that declares `Text → Number` but returns a string fails at runtime,
+not check time. Refinement predicates are the exception: their
+runtime enforcement via `ValidatingExecutor` (on main, ships next
+tag) closes the loop for refined types.
+
+## Effects
+
+Every stage declares its effects in the signature:
+
+| Effect | Meaning |
+|---|---|
+| `Pure` | No side effects. Same input always produces the same output. |
+| `Fallible` | May return a typed error the caller must handle. |
+| `Network` | Makes outbound network calls (sandbox toggles `--share-net`). |
+| `Llm { model }` | Invokes an LLM. `model` is a hint; policy keys on `EffectKind::Llm`. |
+| `NonDeterministic` | Same input may produce different output. |
+| `Process` | Spawns, signals, or waits on OS processes. |
+| `Cost { cents }` | Declared monetary cost. Consumed by `--budget-cents`. |
+| `FsRead(path)` | Reads from a specific filesystem path. |
+| `FsWrite(path)` | Writes to a specific filesystem path. |
+| `Unknown` | Effect-inference couldn't classify. Treated conservatively. |
+
+Effects drive three separate pre-flight checks that run before the
+executor starts:
+
+- **Capability policy** (`--allow-capabilities`) — blocks stages that
+  need capabilities the caller hasn't granted.
+- **Effect policy** (`--allow-effects`) — blocks stages whose effect
+  kinds aren't in the allowed list.
+- **Budget check** (`--budget-cents`) — blocks when the sum of
+  `Cost { cents }` exceeds the ceiling.
+
+`FsRead(path)` and `FsWrite(path)` also feed `IsolationPolicy::from_effects`
+so the sandbox bind-mounts exactly the paths the stage declared.
+
+## Composition graph
+
+A composition is a tree of `CompositionNode` values. The operators:
+
+| Op | Meaning |
+|---|---|
+| `Stage { id, pinning }` | Invoke a stage. `pinning: "signature"` resolves to whichever impl is Active; `"both"` requires an exact implementation. |
+| `RemoteStage { url, id }` | Invoke a stage hosted on a remote registry. |
+| `Const { value }` | Inject a literal JSON value. |
+| `Sequential { stages }` | Run in order; output of N feeds input of N+1. |
+| `Parallel { branches }` | Run a record-keyed set of branches concurrently; output is a record. |
+| `Branch { predicate, if_true, if_false }` | Classic branch. |
+| `Fanout { source, targets }` | Feed one source output into many branches. |
+| `Merge { sources, target }` | Combine multiple sources into one target input. |
+| `Retry { stage, max_attempts, backoff_ms }` | Re-run on `Fallible` failure. |
+| `Let { bindings, body }` | Name intermediate results; reference them in `body`. |
+
+The graph is just JSON. Every operator has a stable `"op"` tag; the
+full schema lives in `crates/noether-engine/src/lagrange/ast.rs`.
+
+Two graphs that canonicalise to the same tree have the same
+**composition ID** (SHA-256 of the canonical form). That's how replay
+works: `noether trace <composition_id>` pulls up the previous run of
+the same-shape graph.
+
+## Content addressing
+
+Everything identity-bearing in Noether is a hash. Never a name,
+never a version string, never a pointer to a database row.
+
+| Hash | What it identifies |
+|---|---|
+| `SignatureId` | `(name, input, output, effects)` |
+| `ImplementationId` / `StageId` | `(signature + implementation_hash)` |
+| `CompositionId` | Canonical form of a composition graph |
+
+**Consequences:**
+
+- A graph JSON that produced result R yesterday produces the same R
+  today, regardless of whether the underlying stage implementations
+  rotated — as long as the graph references stages by `SignatureId`
+  and the Active implementation still exists.
+- Two projects that both write `to_upper` independently end up with
+  the same `SignatureId` if their signatures match. No naming
+  collision, no registry lock-in.
+- Modifying an implementation produces a new `StageId` with the same
+  `SignatureId`. Graphs pinned to `"signature"` pick up the fix
+  automatically; graphs pinned to `"both"` stay on the old
+  implementation until re-pinned.
+
+The [STABILITY.md](https://github.com/alpibrusl/noether/blob/main/STABILITY.md)
+contract is what makes this work in practice — it pins exactly which
+hashes stay stable across 1.x and which can drift.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,120 @@
+# Examples
+
+Three worked examples, each self-contained. Paste-runnable against
+v0.8.
+
+## 1. Run a stdlib stage directly
+
+The stdlib includes `to_text` (converts any value to its string form)
+and `text_length` (returns the number of characters). Chain them.
+
+```bash
+# 1. Find the stage ids you need.
+noether stage search "convert any value to its text"
+# → prints the id for `to_text`
+
+noether stage search "number of characters in a text"
+# → prints the id for `text_length`
+
+# For the example, grab the 8-char prefixes and drop them into a graph:
+cat > rows.json <<'EOF'
+{
+  "description": "count characters in stringified input",
+  "root": {
+    "op": "Sequential",
+    "stages": [
+      { "op": "Stage", "id": "<to_text-prefix>" },
+      { "op": "Stage", "id": "<text_length-prefix>" }
+    ]
+  }
+}
+EOF
+
+noether run --input '{"rows": [1, 2, 3]}' rows.json
+# → { "ok": true, "result": { "output": 22 } }
+```
+
+The `Sequential` operator pipes `to_text`'s output directly into
+`text_length`'s input. The type checker verified at dry-run time that
+`Text → Number` is a valid edge.
+
+## 2. Compose a graph from a problem description
+
+With an LLM provider configured, let the agent assemble the graph.
+
+```bash
+export MISTRAL_API_KEY=…        # or OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.
+
+noether compose "take a list of numbers, keep only the ones above 10, and return their sum"
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "composition_id": "3fa8…",
+    "graph": { "op": "Sequential", "stages": [ … ] },
+    "output": 42
+  }
+}
+```
+
+Use `--dry-run` to see the graph without executing, and `--verbose` to
+see which candidate stages the semantic index surfaced and what the
+LLM picked.
+
+## 3. Author a custom stage
+
+Define a stage as JSON, with a Python implementation.
+
+```json
+{
+  "name": "celsius_to_fahrenheit",
+  "description": "Convert a Celsius temperature to Fahrenheit",
+  "input":  { "Record": [["celsius", "Number"]] },
+  "output": { "Record": [["fahrenheit", "Number"]] },
+  "effects": ["Pure"],
+  "language": "python",
+  "implementation": "def execute(input):\n    return {'fahrenheit': input['celsius'] * 9 / 5 + 32}",
+  "examples": [
+    { "input": {"celsius": 0},   "output": {"fahrenheit": 32.0} },
+    { "input": {"celsius": 100}, "output": {"fahrenheit": 212.0} }
+  ]
+}
+```
+
+Register it:
+
+```bash
+noether stage add celsius_to_fahrenheit.json
+# → validates structure + examples, hashes signature, signs, promotes Active
+```
+
+Python stage contract:
+
+- Top-level `def execute(input): …` that takes the parsed input dict and
+  returns the output dict.
+- **Do not** read from `sys.stdin` or `print` the result. The Noether
+  runtime handles I/O — your `execute` is called with the parsed input
+  and its return value is JSON-serialised.
+- **Do not** add a top-level `if __name__ == "__main__":` block. The
+  runtime synthesises its own `__main__` wrapper.
+
+Now it's in your local store:
+
+```bash
+noether stage search "celsius"
+noether stage get <id-prefix>
+```
+
+Use it in a graph by dropping its id into a `Stage` node, same as any
+stdlib stage.
+
+## Worked example in the repo
+
+A fully annotated example with declared properties (runtime-checked
+invariants beyond the type signature) lives at
+[`examples/property-annotated/`](https://github.com/alpibrusl/noether/tree/main/examples/property-annotated)
+in the source repo.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+# Noether
+
+Typed, content-addressed composition for agent-built pipelines.
+
+A **stage** is an immutable unit of computation addressed by
+`SHA-256(signature + implementation)`. Stages compose into graphs
+that the type checker verifies before execution. Effects
+(`Pure`, `Network`, `Llm`, `Cost`, `Process`, `FsRead`, `FsWrite`, …)
+are declared in the signature and enforced pre-flight by policy.
+
+## Status
+
+One active maintainer, pre-1.0. Current tag: **v0.8.0** (tagged 2026-04-21).
+
+Breaking changes are possible between minor versions per
+[STABILITY.md](https://github.com/alpibrusl/noether/blob/main/STABILITY.md).
+See [`CHANGELOG.md`](https://github.com/alpibrusl/noether/blob/main/CHANGELOG.md)
+for release notes and [`roadmap.md`](roadmap.md) for what ships vs.
+what's planned.
+
+## What v0.8 shipped
+
+Closes **M3 — Optimizer + Richer Types**:
+
+- **Parametric polymorphism** — stage signatures can carry `NType::Var("T")`;
+  `check_graph` threads substitutions through every edge.
+- **Row polymorphism** — `NType::RecordWith { fields, rest }` captures
+  unknown extra fields; `{ name, age } >> mark_done` resolves the tail to
+  `Record { name, age, done }` instead of silently dropping extras.
+- **Refinement types** — `NType::Refined { base, refinement }` attaches
+  runtime-checkable predicates (`Range`, `OneOf`, `NonEmpty`).
+- **Graph optimizer** — three passes run between type-check and plan:
+  `canonical_structural` (flattens nested wrappers), `dead_branch`
+  (folds `Branch(Const(bool), …)`), `memoize_pure` (caches Pure-stage
+  invocations within a run).
+- **Stdlib grew to 85** — added `identity`, `head`, `tail`, `mark_done`,
+  `clamp_percent` for the new type machinery.
+- **Filesystem-scoped effects** — `Effect::FsRead(path)` /
+  `Effect::FsWrite(path)` drive `IsolationPolicy::from_effects`, so
+  path-scoped bind mounts fall out of the declared signature.
+
+**On main, ships in the next tag:** runtime enforcement of refinement
+predicates at stage boundaries via `ValidatingExecutor`.
+
+## Where to go next
+
+- [Install](install.md) — five minutes from zero to running.
+- [Concepts](concepts.md) — stages, types, effects, composition graphs,
+  content addressing. The reference you'll come back to.
+- [Usage](usage.md) — the CLI surface: `stage`, `compose`, `run`, `trace`.
+- [Examples](examples.md) — worked end-to-end runs.
+
+## Not the right tool for
+
+- **Request/response with SLAs, autoscaling, sticky sessions** — use a
+  regular service framework. Noether runs graphs and returns.
+- **Hardened sandbox for hostile multi-tenant code** — the bwrap layer
+  is sized for "LLM-generated stages I haven't audited", not
+  "adversaries targeting a shared kernel". See
+  [SECURITY.md](https://github.com/alpibrusl/noether/blob/main/SECURITY.md).
+- **Airflow / Prefect / Dagster territory** — those are mature for
+  scheduled DAGs with UI ops, lineage, alerting. Noether has none of
+  that surface.
+- **One-shot scripts** — content-addressing pays off on run N+1. If
+  there is no run 2, a plain script is simpler.
+- **Non-JSON data** — the type system is structural over JSON. Streaming
+  video, arbitrary binary, or live-network protocols are doable but
+  you'll fight the model.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,90 @@
+# Install
+
+## From crates.io
+
+```bash
+cargo install noether-cli
+```
+
+Optionally install the scheduler binary for scheduled compositions:
+
+```bash
+cargo install noether-scheduler
+```
+
+## Prebuilt binaries
+
+Download from [GitHub Releases](https://github.com/alpibrusl/noether/releases/latest)
+— Linux, macOS, and Windows artifacts are built per tag.
+
+## From source
+
+```bash
+git clone https://github.com/alpibrusl/noether
+cd noether
+cargo build --release -p noether-cli
+./target/release/noether version
+```
+
+## Optional runtime dependencies
+
+### Nix — for non-Rust stages
+
+Noether's stdlib stages are all Rust-native and run without Nix. You
+only need Nix if you author or execute stages written in Python,
+JavaScript, or Bash. Those stages run in a Nix-pinned hermetic runtime
+so the same source produces byte-identical results across machines.
+
+Install Nix: [nixos.org/download](https://nixos.org/download). No
+further Noether configuration needed — `noether run` detects Nix
+automatically when a graph references a non-Rust stage.
+
+### bubblewrap — the sandbox backend
+
+The v0.7+ isolation layer wraps every non-Rust stage subprocess with a
+`bwrap` call: fresh namespaces, UID-mapped to `nobody`, cap-drop ALL,
+sandbox-private tmpfs at `/work`.
+
+```bash
+# Debian / Ubuntu
+sudo apt install bubblewrap
+
+# Fedora
+sudo dnf install bubblewrap
+
+# macOS (via nix-darwin or Docker)
+# bwrap is Linux-only; use --isolate=none on macOS.
+```
+
+On Linux with bubblewrap present, `noether run --isolate=auto` (the
+default) sandboxes every subprocess. Without bubblewrap, `auto` falls
+back to unsandboxed with a warning. Pass `--require-isolation` (or set
+`NOETHER_REQUIRE_ISOLATION=1`) to turn that fallback into a hard error
+in CI.
+
+## Verify the install
+
+```bash
+noether version
+noether stage list | head
+```
+
+If `stage list` prints the 85-stage stdlib, you're set.
+
+## LLM providers (for `noether compose`)
+
+`noether compose` needs an LLM to translate problem descriptions into
+composition graphs. It picks the first available provider at runtime:
+
+| Provider | Env var | Notes |
+|---|---|---|
+| Mistral native | `MISTRAL_API_KEY` | EU-hosted. Preferred default. |
+| OpenAI | `OPENAI_API_KEY` | Override base with `OPENAI_API_BASE` for Ollama / Together / etc. |
+| Anthropic | `ANTHROPIC_API_KEY` | LLM only (no embeddings). |
+| Vertex AI | `VERTEX_AI_PROJECT` + creds | Supports Mistral, Gemini, Claude via Model Garden. |
+| Subscription CLI | `NOETHER_LLM_PROVIDER=claude-cli` (or `gemini-cli`, `cursor-cli`, `opencode`) | Uses your seat's auth; no API key. |
+| Mock | (fallback) | Deterministic, used in tests. |
+
+If none of these is configured, `noether compose` still runs — against
+the mock provider — but the results are not useful for real problems.
+`noether stage search` and `noether run` never need an LLM.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+pymdown-extensions>=10

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ Current implementation status and future directions for Noether.
 
 ## Milestones (post-phase 9)
 
-Noether shifted from sequential "phase" numbering to milestone tracking with the v0.5 release. Milestones correspond to the [Rock-Solid Plan](roadmap/2026-04-18-rock-solid-plan.md).
+Noether shifted from sequential "phase" numbering to milestone tracking with the v0.5 release. Milestones correspond to the [Rock-Solid Plan](https://github.com/alpibrusl/noether/blob/main/docs/roadmap/2026-04-18-rock-solid-plan.md).
 
 | Milestone | Name | Status | Shipped as | Key deliverables |
 |---|---|---|---|---|
@@ -59,10 +59,10 @@ These are not scheduled — they are design explorations:
 
 | Idea | Notes |
 |---|---|
-| **Grid — capability generalisation** | Lift grid routing beyond `Effect::Llm` to any capability kind (GPU time, DB connections, scraper rotation). See [research](research/grid-capabilities.md). |
-| **`llm-here`** | Unify caloron's `_llm.py`, agentspec's resolver, and grid's `cli_provider.rs` behind one shared tool. See [research](research/llm-here.md). |
-| **NoetherReact** | Content-addressed UI components as stages; `UI = f(stage_graph(state))`. See [research](research/noether-react.md). |
-| **WASM stdlib** | Compile Pure Rust stdlib stages to WASM for zero-latency in-browser execution. See [research](research/wasm-target.md). |
+| **Grid — capability generalisation** | Lift grid routing beyond `Effect::Llm` to any capability kind (GPU time, DB connections, scraper rotation). See [research](https://github.com/alpibrusl/noether/blob/main/docs/research/grid-capabilities.md). |
+| **`llm-here`** | Unify caloron's `_llm.py`, agentspec's resolver, and grid's `cli_provider.rs` behind one shared tool. See [research](https://github.com/alpibrusl/noether/blob/main/docs/research/llm-here.md). |
+| **NoetherReact** | Content-addressed UI components as stages; `UI = f(stage_graph(state))`. See [research](https://github.com/alpibrusl/noether/blob/main/docs/research/noether-react.md). |
+| **WASM stdlib** | Compile Pure Rust stdlib stages to WASM for zero-latency in-browser execution. See [research](https://github.com/alpibrusl/noether/blob/main/docs/research/wasm-target.md). |
 | **Multi-tenant stores** | Separate stage namespaces per agent / team |
 | **Pure-stage caching** | Automatic output memoisation for `Pure`-annotated stages |
 | **Remote gRPC executor** | High-throughput data routing via gRPC + Apache Arrow for stream stages |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,151 @@
+# Usage
+
+The CLI surface is four verbs — `stage`, `compose`, `run`, `trace` —
+plus a handful of helpers. Every command emits [ACLI](https://acli.dev)-
+shaped JSON (`{ ok: bool, command, result | error, meta }`) so downstream
+agents can parse results without brittle stdout scraping.
+
+## Browse the stdlib
+
+```bash
+noether stage list                    # all 85 stages
+noether stage list --tag text         # filter by tag
+noether stage get <id-or-prefix>      # 8-char prefix is enough for stdlib
+noether stage search "parse CSV"      # semantic search (three-index fusion)
+```
+
+`stage search` runs a hash-based mock embedding locally. Point at a
+real embedding provider (Mistral, OpenAI, Vertex) via env vars to get
+better-quality results — see [Install → LLM providers](install.md#llm-providers-for-noether-compose).
+
+## Compose a graph from a problem description
+
+```bash
+# Uses the first LLM provider configured in your env.
+noether compose "parse CSV data and count the rows"
+
+# Don't execute — just show the graph the agent produced.
+noether compose --dry-run "extract email domains from a list of addresses"
+
+# Bypass the composition cache to force a fresh LLM call.
+noether compose --force "…"
+
+# See the full reasoning — search candidates, LLM prompt, each attempt.
+noether compose --verbose "…"
+```
+
+Without an LLM key, `compose` runs against the mock provider and
+produces placeholder graphs — fine for smoke tests, not for real use.
+
+## Run a graph
+
+```bash
+noether run graph.json                      # execute end-to-end
+noether run --dry-run graph.json            # type-check + plan only
+noether run --input '{"x": 1}' graph.json   # pass runtime input
+```
+
+Policy flags:
+
+```bash
+# Block stages that declare effect kinds you didn't allow.
+noether run --allow-effects pure,fallible graph.json
+
+# Block stages that need capabilities you didn't grant.
+noether run --allow-capabilities network,fs-read graph.json
+
+# Reject graphs whose estimated cost exceeds N cents.
+noether run --budget-cents 50 graph.json
+
+# Isolation knobs (non-Rust stages only).
+noether run --isolate=auto graph.json              # bwrap if present, warn-fallback otherwise
+noether run --isolate=bwrap graph.json             # require bwrap; hard error if missing
+noether run --isolate=none graph.json              # disable sandbox (warns)
+noether run --require-isolation graph.json         # make `auto`'s fallback a hard error (CI)
+```
+
+Refinement-predicate enforcement runs automatically when the graph
+uses refined types (merged on main; ships in the next tag). Disable
+with `NOETHER_NO_REFINEMENT_CHECK=1` only for debugging.
+
+## Replay a past run
+
+Every run writes a `CompositionTrace` to the local trace store:
+
+```bash
+noether run graph.json
+# → { "ok": true, "result": { "composition_id": "abc123…", "output": … } }
+
+noether trace abc123
+# → full trace: per-stage inputs, outputs, timing, any errors
+```
+
+The `composition_id` is the SHA-256 of the **pre-resolution** canonical
+graph — so the same source graph produces the same id on every run,
+regardless of which concrete implementation each signature-pinned node
+resolved to. That's what makes replay useful across implementation
+rotations.
+
+## Remote registry
+
+Point at a noether-cloud registry to pull stages over HTTP:
+
+```bash
+export NOETHER_REGISTRY=https://registry.alpibru.com
+noether stage list            # now queries the remote
+noether stage search "…"      # semantic search over the remote index
+```
+
+Every stage / store command honours `NOETHER_REGISTRY`. `noether run`
+and `noether compose` snapshot what the remote reports and execute
+locally — there's no "remote execution" mode in the CLI.
+
+## Build a graph into a binary
+
+```bash
+noether build graph.json                          # native binary at ./noether-app
+noether build graph.json --target browser         # HTML + WASM bundle
+noether build graph.json --serve :8080            # native build + serve as HTTP API
+```
+
+The built binary accepts runtime input on stdin and prints ACLI JSON on
+stdout — same contract as `noether run`. The browser target produces a
+self-contained HTML page that runs the pure subset of the graph in the
+user's tab.
+
+## Introspect
+
+For agents wiring this up programmatically:
+
+```bash
+noether introspect           # full command tree as JSON (ACLI standard)
+noether agent-docs           # list of intent-keyed agent playbooks
+noether agent-docs compose-a-graph    # a specific playbook
+noether agent-docs --search sandbox   # search playbooks by keyword
+```
+
+## The scheduler
+
+The `noether-scheduler` binary runs a cron of Lagrange graphs and fires
+webhooks with the result. Configure via `scheduler.json`:
+
+```json
+{
+  "store_path": ".noether/registry.json",
+  "jobs": [
+    {
+      "name": "hourly-health-check",
+      "cron": "0 * * * *",
+      "graph": "graphs/health-check.json",
+      "webhook": "https://hooks.example.com/noether-health"
+    }
+  ]
+}
+```
+
+```bash
+noether-scheduler --config scheduler.json
+```
+
+Stateless per run — the graph's composition id + trace go to the
+webhook; restart-safety is your responsibility.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: Noether
+site_description: Typed, content-addressed composition for agent-built pipelines.
+site_url: https://alpibrusl.github.io/noether/
+repo_url: https://github.com/alpibrusl/noether
+repo_name: alpibrusl/noether
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+exclude_docs: |
+  agents/
+  research/
+  roadmap/
+  requirements.txt
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Install: install.md
+  - Concepts: concepts.md
+  - Usage: usage.md
+  - Examples: examples.md
+  - Roadmap: roadmap.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/alpibrusl/noether
+
+copyright: Copyright &copy; 2024-2026 alpibrusl — Licensed under EUPL-1.2


### PR DESCRIPTION
## Summary

Fresh mkdocs site replacing the patchwork tree that #69 removed. Six nav entries, each a single-responsibility page — updating what a topic says doesn't require editing multiple files.

## Pages

- \`index.md\` — what Noether is, status, v0.8 M3 highlights, "not right tool for" list.
- \`install.md\` — cargo / releases / source + optional Nix + bwrap + LLM providers.
- \`concepts.md\` — stage, type system, effects, composition graph, content addressing.
- \`usage.md\` — \`stage\` / \`compose\` / \`run\` / \`trace\` with real commands.
- \`examples.md\` — three paste-runnable examples.
- \`roadmap.md\` — existing page; \`roadmap/\` + \`research/\` links rewritten to absolute GitHub URLs so the site stays clean without pulling those trees in.

## Exclusions

\`agents/\`, \`research/\`, \`roadmap/\` are excluded from the built site via \`exclude_docs\`. They stay in-repo — \`agents/\` is CLI product input (\`include_str!\`), \`research/\` is raw thinking notes, \`roadmap/\` is milestone backing material. GitHub-renders them when someone follows a link from roadmap.md.

## Verification

- [x] \`mkdocs build --strict\` — 0 warnings, site builds clean locally.
- [x] Every link in the six published pages resolves within the site or to a GitHub URL.
- [x] Workflow shape matches the prior \`.github/workflows/docs.yml\` — builds with \`--strict\`, deploys via \`actions/deploy-pages@v5\` on pushes to main under \`docs/\` / \`mkdocs.yml\`.

## Stale site

The GitHub Pages deployment at \`alpibrusl.github.io/noether\` is still serving the pre-#69 mkdocs snapshot. Merging this will trigger a fresh deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)