### PR TITLE
chore: v0.8.1 — repair v0.8.0 crates.io publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.8.1 — 2026-04-23
+
+Patch release. Two goals: repair a partial v0.8.0 crates.io publish, and ship the refinement-enforcement follow-up that merged to `main` post-tag.
+
+### Fixed — crates.io publish repair
+
+`noether-engine` and `noether-cli` did not publish at v0.8.0. The release workflow failed because `noether-engine/Cargo.toml` declared `llm-here-core` via `git = "..."` without a version constraint; crates.io rejects unversioned git deps on publish. Meanwhile `noether-core`, `noether-store`, and `noether-isolation` did publish, leaving crates.io with a mixed view of the workspace (cli still on 0.7.3).
+
+Fix: publish `llm-here-core` to crates.io and switch `noether-engine` to the crates.io coordinate.
+
+- `llm-here-core` 0.4.0 published to crates.io from `alpibrusl/llm-here`.
+- `noether-engine/Cargo.toml`: `llm-here-core = { version = "0.4.0", optional = true }` (dropped `git` + `tag`).
+
 ### Added — refinement runtime enforcement
 
 `ValidatingExecutor` wraps any `StageExecutor` and enforces declared refinements at every stage boundary. Inputs are checked before the stage runs; outputs are checked after. A violation aborts with `ExecutionError::StageFailed` carrying the refinement and the validator's reason.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/noether"

--- a/crates/noether-engine/Cargo.toml
+++ b/crates/noether-engine/Cargo.toml
@@ -37,9 +37,8 @@ arrow = { version = "58", optional = true, default-features = false, features = 
 base64 = { version = "0.22", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # CLI detection + dispatch delegated to llm-here (shared across caloron,
-# agentspec, and noether-grid — see docs/research/llm-here.md). Pinned to
-# a tag until llm-here lands on crates.io.
-llm-here-core = { git = "https://github.com/alpibrusl/llm-here", tag = "v0.4.0", optional = true }
+# agentspec, and noether-grid — see docs/research/llm-here.md).
+llm-here-core = { version = "0.4.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }


### PR DESCRIPTION
## Summary

Two fixes in one patch:

1. **crates.io publish repair.** The v0.8.0 Release workflow failed on \`noether-engine\`: \`llm-here-core\` was declared as an unversioned git dep, which crates.io rejects (\"all dependencies must have a version requirement specified when publishing\"). That cascaded to \`noether-cli\`, which is why the crates.io badge still shows 0.7.3.

    Upstream \`llm-here-core\` 0.4.0 is now published to crates.io from \`alpibrusl/llm-here\`. This PR switches \`noether-engine/Cargo.toml\` to the crates.io coordinate: \`llm-here-core = { version = \"0.4.0\", optional = true }\`.

2. **Ship refinement runtime enforcement** (\`ValidatingExecutor\`, merged in #67). Tagging it here bundles the fix with the post-v0.8.0 follow-up rather than cutting two tags.

## Verification

- [x] \`llm-here-core\` 0.4.0 visible on crates.io.
- [x] \`cargo update -p llm-here-core\` resolves from crates.io (not git).
- [x] \`cargo check --workspace\` clean.
- [x] \`cargo test --workspace\` green.

## After merge

Tag \`v0.8.1\` → release workflow republishes \`noether-engine\` and \`noether-cli\` at 0.8.1, closing the crates.io drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)