### PR TITLE
chore: bump acli 0.4 → 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.8"
 hex = "0.4"
 thiserror = "2"
 proptest = "1"
-acli = "0.4"
+acli = "0.5"
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.13", features = ["blocking", "json", "form", "rustls"], default-features = false }
 regex = "1"


### PR DESCRIPTION
acli 0.5's breaking changes are all in the `skill` subcommand / `ACLIApp` constructor — noether uses none of that surface. Only touches `CommandInfo`, `CommandTree`, `ExitCode`, `CacheMeta`, `success_envelope`, `error_envelope` — all unchanged between 0.4 and 0.5.

Drop-in bump; no call-site edits needed. `cargo test --workspace` and `cargo clippy --all-targets -- -D warnings` both green locally.