### PR TITLE
chore: v0.8.2 — publish noether-grid to crates.io + ship prebuilts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
           cargo build -p noether-cli --release --target ${{ matrix.target }}
           cargo build -p noether-scheduler --release --target ${{ matrix.target }}
           cargo build -p noether-sandbox --release --target ${{ matrix.target }}
+          cargo build -p noether-grid-broker --release --target ${{ matrix.target }}
+          cargo build -p noether-grid-worker --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
@@ -70,8 +72,14 @@ jobs:
           tar czf "$ARCHIVE" -C "$DIR" noether
           SCHED_ARCHIVE=noether-scheduler-${VERSION}-${{ matrix.target }}.tar.gz
           tar czf "$SCHED_ARCHIVE" -C "$DIR" noether-scheduler
+          BROKER_ARCHIVE=noether-grid-broker-${VERSION}-${{ matrix.target }}.tar.gz
+          tar czf "$BROKER_ARCHIVE" -C "$DIR" noether-grid-broker
+          WORKER_ARCHIVE=noether-grid-worker-${VERSION}-${{ matrix.target }}.tar.gz
+          tar czf "$WORKER_ARCHIVE" -C "$DIR" noether-grid-worker
           echo "ASSET_CLI=$ARCHIVE" >> $GITHUB_ENV
           echo "ASSET_SCHED=$SCHED_ARCHIVE" >> $GITHUB_ENV
+          echo "ASSET_BROKER=$BROKER_ARCHIVE" >> $GITHUB_ENV
+          echo "ASSET_WORKER=$WORKER_ARCHIVE" >> $GITHUB_ENV
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
@@ -83,8 +91,14 @@ jobs:
           Compress-Archive -Path "$dir/noether.exe" -DestinationPath $archive
           $sched = "noether-scheduler-${version}-${{ matrix.target }}.zip"
           Compress-Archive -Path "$dir/noether-scheduler.exe" -DestinationPath $sched
+          $broker = "noether-grid-broker-${version}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "$dir/noether-grid-broker.exe" -DestinationPath $broker
+          $worker = "noether-grid-worker-${version}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "$dir/noether-grid-worker.exe" -DestinationPath $worker
           echo "ASSET_CLI=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "ASSET_SCHED=$sched" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "ASSET_BROKER=$broker" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "ASSET_WORKER=$worker" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # noether-sandbox is only packaged for Linux targets: bubblewrap
       # is Linux-only, so shipping a sandbox tarball for macOS or Windows
@@ -113,6 +127,8 @@ jobs:
             ${{ env.ASSET_CLI }}
             ${{ env.ASSET_SCHED }}
             ${{ env.ASSET_SANDBOX }}
+            ${{ env.ASSET_BROKER }}
+            ${{ env.ASSET_WORKER }}
           generate_release_notes: true
 
   publish-crates:
@@ -126,29 +142,38 @@ jobs:
       # Dependency order (any publish that runs ahead of its deps will
       # fail with "no matching package" — this is what broke v0.7.1 and
       # v0.7.2 when noether-isolation was missing from the list):
-      #   core        — no internal deps
-      #   isolation   — depends on core
-      #   store       — depends on core
-      #   engine      — depends on core + store + isolation
-      #   cli         — depends on core + store + engine
-      #   scheduler   — depends on core + engine
-      #   sandbox     — depends on core + isolation
+      #   core           — no internal deps
+      #   grid-protocol  — no internal deps (only serde/serde_json/chrono)
+      #   isolation      — depends on core
+      #   store          — depends on core
+      #   engine         — depends on core + store + isolation
+      #   cli            — depends on core + store + engine
+      #   scheduler      — depends on core + engine
+      #   sandbox        — depends on core + isolation
+      #   grid-broker    — depends on grid-protocol + engine + store + core
+      #   grid-worker    — depends on grid-protocol + engine + store + core
       # `sleep 30` between each gives the crates.io index enough time
       # to index the previous publish before the next resolve.
       - name: Publish crates (in dependency order)
         run: |
-          cargo publish -p noether-core        --no-verify
+          cargo publish -p noether-core           --no-verify
           sleep 30
-          cargo publish -p noether-isolation   --no-verify
+          cargo publish -p noether-grid-protocol  --no-verify
           sleep 30
-          cargo publish -p noether-store       --no-verify
+          cargo publish -p noether-isolation      --no-verify
           sleep 30
-          cargo publish -p noether-engine      --no-verify
+          cargo publish -p noether-store          --no-verify
           sleep 30
-          cargo publish -p noether-cli         --no-verify
+          cargo publish -p noether-engine         --no-verify
           sleep 30
-          cargo publish -p noether-scheduler   --no-verify
+          cargo publish -p noether-cli            --no-verify
           sleep 30
-          cargo publish -p noether-sandbox     --no-verify
+          cargo publish -p noether-scheduler      --no-verify
+          sleep 30
+          cargo publish -p noether-sandbox        --no-verify
+          sleep 30
+          cargo publish -p noether-grid-broker    --no-verify
+          sleep 30
+          cargo publish -p noether-grid-worker    --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Notable changes to Noether. Follows [Keep a Changelog](https://keepachangelog.co
 
 ## Unreleased
 
+## 0.8.2 — 2026-04-24
+
+### Added — `noether-grid` publishes to crates.io and ships prebuilt binaries
+
+Dropped `publish = false` from `noether-grid-protocol`, `noether-grid-broker`, and `noether-grid-worker`. They publish alongside the other crates in the dependency chain now:
+
+```bash
+cargo install noether-grid-broker
+cargo install noether-grid-worker
+```
+
+The release workflow also builds and uploads prebuilt broker + worker archives alongside the CLI / scheduler / sandbox tarballs, for every Linux / macOS / Windows target — operators running a worker on a developer laptop no longer need a Rust toolchain.
+
+Descriptions keep the `"RESEARCH —"` prefix. The operator surface is supported but still evolving release-to-release; pin to exact versions in production.
+
+Also bumped `acli` 0.4 → 0.5 (noether doesn't touch the breaking `skill`-subcommand surface; drop-in).
+
 ## 0.8.1 — 2026-04-23
 
 Patch release. Two goals: repair a partial v0.8.0 crates.io publish, and ship the refinement-enforcement follow-up that merged to `main` post-tag.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/noether"

--- a/crates/noether-grid-broker/Cargo.toml
+++ b/crates/noether-grid-broker/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "RESEARCH — noether-grid broker: pools worker LLM capacity, dispatches jobs"
-publish = false
 
 [[bin]]
 name = "noether-grid-broker"

--- a/crates/noether-grid-protocol/Cargo.toml
+++ b/crates/noether-grid-protocol/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "RESEARCH — shared serde types for noether-grid (intra-company LLM pooling)"
-publish = false
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/noether-grid-worker/Cargo.toml
+++ b/crates/noether-grid-worker/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "RESEARCH — noether-grid worker: advertises LLM capacity, runs graphs on request"
-publish = false
 
 [[bin]]
 name = "noether-grid-worker"

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,6 +62,27 @@ back to unsandboxed with a warning. Pass `--require-isolation` (or set
 `NOETHER_REQUIRE_ISOLATION=1`) to turn that fallback into a hard error
 in CI.
 
+## Grid (broker + worker)
+
+`noether-grid` pools LLM capacity across a company — see the
+[broker README](https://github.com/alpibrusl/noether/tree/main/crates/noether-grid-broker)
+for the full pitch and deployment guide.
+
+Install from crates.io (v0.8.2+):
+
+```bash
+cargo install noether-grid-broker
+cargo install noether-grid-worker
+```
+
+Or download prebuilt binaries from
+[GitHub Releases](https://github.com/alpibrusl/noether/releases/latest)
+— Linux / macOS / Windows artifacts published per tag, same as the CLI.
+
+Both crates carry a `"RESEARCH —"` prefix in their crates.io descriptions:
+shipped and supported, but the operator surface is still evolving
+release-to-release. Pin to exact versions in production.
+
 ## Verify the install
 
 ```bash


### PR DESCRIPTION
## Summary

Three bundled changes, all targeting grid install ergonomics:

1. **Drop \`publish = false\`** from \`noether-grid-protocol\`, \`noether-grid-broker\`, \`noether-grid-worker\`. They publish to crates.io alongside the rest of the workspace. Descriptions keep the \`\"RESEARCH —\"\` prefix — honest signal at the listing that the operator surface is supported but still evolving.
2. **Prebuilt binaries** — \`release.yml\` builds + packages + uploads broker and worker archives for every target (Linux / macOS / Windows), same shape as the CLI / scheduler / sandbox artefacts. Publish job gains three new entries in the dep-ordered sequence: \`grid-protocol\` after \`core\`, \`grid-broker\` and \`grid-worker\` at the end.
3. **Docs** — \`docs/install.md\` gains a \"Grid (broker + worker)\" section pointing at both \`cargo install noether-grid-{broker,worker}\` and the GitHub Releases tarballs.

Workspace version \`0.8.1\` → \`0.8.2\`. \`cargo test --workspace\` green. \`cargo publish -p noether-grid-protocol --dry-run --allow-dirty\` clean; broker/worker dry-runs fail only because protocol isn't yet on the index — the release workflow publishes protocol first, so the 30s index-settle between steps handles it.

## After merge

Tag \`v0.8.2\` → release workflow publishes the three grid crates and uploads prebuilt broker/worker archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)